### PR TITLE
Repozycjonowanie strony pod Digital Product Designer

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Karol Wyszyński – UX/UI Designer |Intuicyjne rozwiązania i łatwa obłsuga</title>
-    <meta name="description" content="Pomagam firmom zwiększać sprzedaż przez przemyślany UX/UI design. Projektuję strony internetowe i aplikacje, które przekonują użytkowników do zakupu.">
+    <title>Karol Wyszyński – Digital Product Designer | Produkty cyfrowe, automatyzacje, usprawnienia procesów</title>
+    <meta name="description" content="Projektuję i wdrażam produkty cyfrowe, automatyzacje i usprawnienia procesów biznesowych. Aplikacje, strony i integracje, które oszczędzają godziny pracy i ograniczają błędy.">
 
     <!-- Canonical -->
     <link rel="canonical" href="https://kwyszynski.pl/" />
@@ -12,16 +12,16 @@
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://kwyszynski.pl/" />
-    <meta property="og:title" content="Karol Wyszyński – Intuicyjne rozwiązania i łatwa obłsuga" />
-    <meta property="og:description" content="Pomagam firmom zwiększać sprzedaż przez przemyślany UX/UI design. Projektuję strony internetowe i aplikacje, które przekonują użytkowników do zakupu." />
+    <meta property="og:title" content="Karol Wyszyński – Digital Product Designer | Produkty cyfrowe, automatyzacje, procesy" />
+    <meta property="og:description" content="Projektuję i wdrażam produkty cyfrowe, automatyzacje i usprawnienia procesów biznesowych. Aplikacje, strony i integracje, które oszczędzają godziny pracy i ograniczają błędy." />
     <meta property="og:image" content="https://kwyszynski.pl/assets/images/android-chrome-512x512.png" />
     <meta property="og:locale" content="pl_PL" />
-    <meta property="og:site_name" content="Karol Wyszyński – UX/UI Designer" />
+    <meta property="og:site_name" content="Karol Wyszyński – Digital Product Designer" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Karol Wyszyński – UX/UI Designer | Intuicyjne rozwiązania i łatwa obłsuga" />
-    <meta name="twitter:description" content="Pomagam firmom zwiększać sprzedaż przez przemyślany UX/UI design. Projektuję strony internetowe i aplikacje, które przekonują użytkowników do zakupu." />
+    <meta name="twitter:title" content="Karol Wyszyński – Digital Product Designer | Produkty cyfrowe, automatyzacje, procesy" />
+    <meta name="twitter:description" content="Projektuję i wdrażam produkty cyfrowe, automatyzacje i usprawnienia procesów biznesowych. Aplikacje, strony i integracje, które oszczędzają godziny pracy i ograniczają błędy." />
     <meta name="twitter:image" content="https://kwyszynski.pl/assets/images/android-chrome-512x512.png" />
 
     <!-- JSON-LD -->
@@ -30,16 +30,11 @@
       "@context": "https://schema.org",
       "@type": "Person",
       "name": "Karol Wyszyński",
-      "jobTitle": "Project Manager",
+      "jobTitle": "Digital Product Designer",
       "url": "https://kwyszynski.pl",
       "email": "wyszynski.k@onet.pl",
-      "description": "Pomagam firmom zwiększać sprzedaż przez przemyślany UX/UI design. Projektuję strony internetowe i aplikacje, które przekonują użytkowników do zakupu.",
-      "knowsAbout": ["Project Management", "UX Design", "UI Design", "Agile", "Scrum", "Branding", "WordPress", "WooCommerce"],
-      "offers": [
-        {"@type": "Offer", "name": "CORE", "price": "2500", "priceCurrency": "PLN"},
-        {"@type": "Offer", "name": "GROW", "price": "4500", "priceCurrency": "PLN"},
-        {"@type": "Offer", "name": "MASTER", "price": "7500", "priceCurrency": "PLN"}
-      ]
+      "description": "Projektuję i wdrażam produkty cyfrowe, automatyzacje i usprawnienia procesów biznesowych. Łączę projektowanie, technologię i rozumienie procesów w działający produkt.",
+      "knowsAbout": ["Product Design", "UX Design", "UI Design", "Automatyzacja procesów", "Google Apps Script", "WordPress", "WooCommerce", "Projektowanie aplikacji"]
     }
     </script>
 
@@ -112,17 +107,19 @@
 
         <div class="container hero-section-content">
             <div class="hero-main-title">
-                <p class="hero-eyebrow">Twój system zasługuje na to</p>
+                <p class="hero-eyebrow">Digital Product Designer · Automatyzacje · Procesy</p>
                 <h1 class="hero-title">
-                    Intuicyjne rozwiązania<span class="highlight-digits-tyt"> i łatwa obłsuga</span>
+                    Projektuję i wdrażam produkty cyfrowe,<span class="highlight-digits-tyt"> które porządkują procesy w firmie.</span>
                 </h1>
             </div>
 
             <div class="hero-main-content">
                 <div class="hero-info-icons">
-                
                     <div class="info-icon">
-                        <span class="text"><span class="highlight-digits">8+</span> lat doświadczenia w projektowaniu</span>
+                        <span class="text"><span class="highlight-digits">−90%</span> czasu wyceny — z godziny do ok. 5 minut</span>
+                    </div>
+                    <div class="info-icon">
+                        <span class="text"><span class="highlight-digits">10+</span> zautomatyzowanych procesów w realnych firmach</span>
                     </div>
                     <div class="info-icon">
                         <span id="availability-dot" class="dot green"></span>
@@ -131,13 +128,13 @@
                 </div>
                 <div class="hero-image">
                     <div class="hero-image-container">
-                        <img src="assets/images/ja-skupiony2.webp" alt="Karol Wyszyński - UX/UI Designer" />
+                        <img src="assets/images/ja-skupiony2.webp" alt="Karol Wyszyński - Digital Product Designer" />
                         <div class="gradient-overlay"></div>
                         <div class="hero-floating-badge">
                             <span class="badge-icon">✨</span>
                             <div class="badge-text">
-                                <span class="badge-title">Project Manager</span>
-                                <span class="badge-sub">UX/UI Designer</span>
+                                <span class="badge-title">Digital Product</span>
+                                <span class="badge-sub">Designer</span>
                             </div>
                         </div>
                     </div>
@@ -146,11 +143,11 @@
 
             <div class="hero-bottom-content">
                 <p class="hero-subtitle">
-                  Pomagam znaleźć problem w procesie, usunąć tarcie i odzyskać płynność działania.
+                    Pomagam firmom zamienić ręczne, powtarzalne procesy w aplikacje, strony i automatyzacje. Pracuję od analizy problemu po działający produkt — sam projektuję i sam wdrażam.
                 </p>
                 <div class="cta-group">
-                    <a href="portfolio.html" class="btn btn-primary">Case studies →</a>
-                    <a href="#contact" class="btn btn-secondary smooth">Porozmawiajmy o roli</a>
+                    <a href="portfolio.html" class="btn btn-primary">Zobacz projekty →</a>
+                    <a href="#contact" class="btn btn-secondary smooth">Porozmawiajmy o procesie</a>
                     <a href="assets/CV_KarolWyszynski.pdf" class="btn btn-secondary" target="_blank" rel="noopener" download>Pobierz CV PDF</a>
                 </div>
             </div>
@@ -265,84 +262,99 @@
     <section id="process" class="process-section">
     <div class="container">
         <h2 class="section-title">
-            <span class="highlight">Jak prowadzę projekty?</span>
+            <span class="highlight">Jak pracuję</span>
         </h2>
         <p class="section-subtitle">
-            <span class="highlight">Sprawdzony proces PM</span>, który prowadzi od kick-offu do <span class="highlight">wymiernych rezultatów</span>
+            Od <span class="highlight">analizy procesu</span> do <span class="highlight">działającego rozwiązania</span> — sześć kroków, które prowadzą projekt od początku do końca
         </p>
 
         <div class="process-timeline-compact">
-            <!-- Step 1 -->
+            <!-- Krok 1 -->
             <div class="timeline-step">
                 <div class="step-marker">
                     <span class="step-num">01</span>
                 </div>
                 <div class="step-content">
                     <h3 class="step-title">
-                        <span class="highlight">Discovery & Scope</span>
+                        <span class="highlight">Zrozumienie problemu</span>
                     </h3>
                     <p class="step-desc">
-                        Definiuję wymagania ze stakeholderami i uzgadniam zakres. Kick-off z interesariuszami, ustalenie <strong>RACI</strong>, analiza ryzyk i priorytetów. Wychodzimy ze spotkania ze zdefiniowanym scope i jasnym podziałem odpowiedzialności.
+                        Zaczynam od rozmowy o procesie, ludziach i celach. Zanim cokolwiek zaprojektuję, muszę wiedzieć, <strong>co naprawdę boli</strong> i co ma się zmienić po wdrożeniu.
                     </p>
                 </div>
             </div>
 
-            <!-- Step 2 -->
+            <!-- Krok 2 -->
             <div class="timeline-step">
                 <div class="step-marker">
                     <span class="step-num">02</span>
                 </div>
                 <div class="step-content">
                     <h3 class="step-title">
-                        <span class="highlight">Planning & Architektura</span>
+                        <span class="highlight">Analiza</span>
                     </h3>
                     <p class="step-desc">
-                        Buduję <strong>WBS</strong> i backlog z milestones. Projektuję architekturę informacji i plan deliverables. Każde zadanie ma właściciela, termin i kryteria akceptacji — bez domysłów.
+                        Szukam miejsc, które można <strong>uprościć, przyspieszyć albo zautomatyzować</strong>. Na tym etapie najczęściej okazuje się, że problem leży gdzie indziej niż wszyscy myśleli.
                     </p>
                 </div>
             </div>
 
-            <!-- Step 3 -->
+            <!-- Krok 3 -->
             <div class="timeline-step">
                 <div class="step-marker">
                     <span class="step-num">03</span>
                 </div>
                 <div class="step-content">
                     <h3 class="step-title">
-                        <span class="highlight">Wykonanie & Iteracja</span>
+                        <span class="highlight">Projekt rozwiązania</span>
                     </h3>
                     <p class="step-desc">
-                        Prowadzę <strong>sprinty</strong> i koordynuję dostarczanie w iteracjach. Regularne <strong>stakeholder review</strong> — widoczność postępu i realny wpływ na kierunek. Blokerów nie czekam; eskaluję i replanifikuję na bieżąco.
+                        Tworzę strukturę strony, aplikacji albo nowego przebiegu procesu. To etap, na którym <strong>zapadają decyzje przesądzające o całej reszcie</strong>.
                     </p>
                 </div>
             </div>
 
-            <!-- Step 4 -->
+            <!-- Krok 4 -->
             <div class="timeline-step">
                 <div class="step-marker">
                     <span class="step-num">04</span>
                 </div>
                 <div class="step-content">
                     <h3 class="step-title">
-                        <span class="highlight">Testowanie & Walidacja</span>
+                        <span class="highlight">Budowa</span>
                     </h3>
                     <p class="step-desc">
-                        <strong>UAT</strong> z interesariuszami wg uzgodnionych kryteriów akceptacji. Walidacja funkcjonalna, wydajnościowa i dostępnościowa. Żaden defekt blokujący nie przechodzi do wdrożenia.
+                        Składam rozwiązanie: interfejs, logikę, integracje. Pracuję samodzielnie, więc <strong>nic nie ginie między rolami</strong> i nie trzeba tłumaczyć projektu drugiej osobie.
                     </p>
                 </div>
             </div>
 
-            <!-- Step 5 -->
+            <!-- Krok 5 -->
             <div class="timeline-step">
                 <div class="step-marker">
                     <span class="step-num">05</span>
                 </div>
                 <div class="step-content">
                     <h3 class="step-title">
-                        <span class="highlight">Wdrożenie & Optymalizacja</span>
+                        <span class="highlight">Testowanie</span>
                     </h3>
                     <p class="step-desc">
-                        Zarządzam deployment planem i rollback planem. Po wdrożeniu — <strong>retrospective</strong> z zespołem i stakeholderami. Monitoruję KPIs i wdrażam optymalizacje bazując na danych, nie intuicji.
+                        Sprawdzam wszystko ręcznie, w realnych scenariuszach. <strong>Szukam tego, co się zepsuje, zanim zrobi to użytkownik</strong>.
+                    </p>
+                </div>
+            </div>
+
+            <!-- Krok 6 -->
+            <div class="timeline-step">
+                <div class="step-marker">
+                    <span class="step-num">06</span>
+                </div>
+                <div class="step-content">
+                    <h3 class="step-title">
+                        <span class="highlight">Wdrożenie</span>
+                    </h3>
+                    <p class="step-desc">
+                        Uruchamiam gotowe rozwiązanie i zostaję na tyle blisko, żeby <strong>wesprzeć pierwsze tygodnie użycia</strong> i dopracować to, co widać dopiero w praktyce.
                     </p>
                 </div>
             </div>
@@ -351,7 +363,7 @@
 
     <div class="process-cta">
         <a href="#contact" class="btn btn-primary smooth">
-            <span class="highlight">Porozmawiajmy o projekcie</span>
+            <span class="highlight">Porozmawiajmy o Twoim procesie</span>
         </a>
     </div>
 </section>
@@ -480,73 +492,73 @@
 
     <div class="container">
         
-        <h2 class="section-title">Usługi</h2>
-        <p class="section-subtitle">Proponowane usługi to sprawdzone rozwiązania. Jeśli interesuje Cię inny rodzaj współpracy - skontaktuj się przez formularz.</p>
+        <h2 class="section-title">Co robię</h2>
+        <p class="section-subtitle">Trzy obszary, w których realnie pomagam firmom. Nie pakiety z półki — projekty wyceniane pod konkretny zakres i proces.</p>
 
         <div class="services-grid">
-            
-            <!-- PAKIET 1: CORE -->
+
+            <!-- OBSZAR 1: Produkty cyfrowe -->
             <div class="service-card">
                 <div class="service-icon">
-                    <img src="assets/images/KW_rocket_STARTCOMPANY.svg" alt="Ikona cel" width="56" height="56">
+                    <img src="assets/images/KW_laptop.svg" alt="Ikona produkty cyfrowe" width="56" height="56">
                 </div>
-                <h3>CORE</h3>
-                <p class="service-description">Logo + identyfikacja wizualna</p>
+                <h3>Produkty cyfrowe</h3>
+                <p class="service-description">Aplikacje biznesowe i strony internetowe</p>
                 <ul class="service-features">
-                    <li><strong>Logo</strong> (3 propozycje + poprawki)</li>
-                    <li><strong>Kolorystyka i typografia</strong> marki</li>
-                    <li><strong>Materiały firmowe</strong> (wizytówki, papiery)</li>
-                    <li>Mini brand book (księga znaku)</li>
-                    <li>30 dni wsparcia po zakończeniu</li>
+                    <li><strong>Aplikacje webowe</strong> projektowane pod konkretny proces</li>
+                    <li><strong>Strony internetowe</strong> — od prezentacyjnych po z integracjami</li>
+                    <li><strong>Sklepy</strong> i systemy zamówień (WordPress, WooCommerce)</li>
+                    <li>Architektura informacji, projekt interfejsu i wdrożenie</li>
+                    <li>Wsparcie po starcie i dopracowanie w praktyce</li>
                 </ul>
                 <div class="service-meta">
-                    <p class="service-time">Czas: 3-5 tygodni</p>
-                    <p class="service-price">od 2500 zł</p>
+                    <p class="service-time">Czas większych projektów: 4–5 miesięcy</p>
+                    <p class="service-price">współpraca od 8 000 zł</p>
                 </div>
                 <a href="uslugi.html" class="service-btn">Więcej informacji</a>
             </div>
 
-            <!-- PAKIET 2: GROW (Najpopularniejszy) -->
+            <!-- OBSZAR 2: Automatyzacje procesów -->
             <div class="service-card featured">
-                <div class="popular-badge">Najpopularniejsze</div>
+                <div class="popular-badge">Najczęściej wybierane</div>
                 <div class="service-icon">
-                    <img src="assets/images/KW_laptop.svg" alt="Ikona laptop" width="56" height="56">
+                    <img src="assets/images/KW_PRO.svg" alt="Ikona automatyzacje" width="56" height="56">
                 </div>
-                <h3>GROW</h3>
-                <p class="service-description">Marka + strona internetowa</p>
+                <h3>Automatyzacje procesów</h3>
+                <p class="service-description">Zamieniam ręczne czynności w działające automaty</p>
                 <ul class="service-features">
-                    <li><strong>Wszystko z pakietu CORE +</strong></li>
-                    <li><strong>Strona WWW</strong> (do 5 podstron, responsywna)</li>
-                    <li><strong>Optymalizacja konwersji i SEO</strong></li>
-                    <li><strong>Integracja z mediami społecznościowymi</strong></li>
-                    <li>90 dni wsparcia technicznego</li>
+                    <li><strong>Automatyzacje</strong> w Google Apps Script i arkuszach</li>
+                    <li><strong>Integracje</strong> między systemami, bazami danych i plikami</li>
+                    <li><strong>Kalkulatory i konfiguratory</strong> oparte na realnej logice biznesowej</li>
+                    <li>Skrócenie powtarzalnych zadań nawet o ponad 90%</li>
+                    <li>Testowanie i wdrożenie w realnym środowisku pracy</li>
                 </ul>
                 <div class="service-meta">
-                    <p class="service-time">Czas: 6-8 tygodni</p>
-                    <p class="service-price">od 4500 zł</p>
+                    <p class="service-time">Realny efekt: z godziny do kilku minut</p>
+                    <p class="service-price">współpraca od 8 000 zł</p>
                 </div>
-                <a href="uslugi.html" class="service-btn">Wybieram ten pakiet</a>
+                <a href="uslugi.html" class="service-btn">Więcej informacji</a>
             </div>
 
-            <!-- PAKIET 3: MASTER -->
+            <!-- OBSZAR 3: Usprawnienia procesów -->
             <div class="service-card">
                 <div class="service-icon">
-                    <img src="assets/images/KW_PRO.svg" alt="Ikona rakieta" width="56" height="56">
+                    <img src="assets/images/KW_rocket_STARTCOMPANY.svg" alt="Ikona usprawnienia" width="56" height="56">
                 </div>
-                <h3>MASTER</h3>
-                <p class="service-description">Kompletny pakiet z automatyzacjami</p>
+                <h3>Usprawnienia procesów</h3>
+                <p class="service-description">Analiza i porządkowanie tego, co dziś działa „jakoś"</p>
                 <ul class="service-features">
-                    <li><strong>Wszystko z pakietu GROW +</strong></li>
-                    <li><strong>Sklep WooCommerce</strong> lub system rezerwacji online</li>
-                    <li><strong>Automatyzacje marketingowe</strong> (newsletter, sekwencje mailowe)</li>
-                    <li><strong>Google Analytics 4</strong> z celami konwersji</li>
-                    <li>6 miesięcy wsparcia i konsultacji</li>
+                    <li><strong>Analiza procesu</strong> i wskazanie wąskich gardeł</li>
+                    <li><strong>Projekt nowego przebiegu</strong> pracy lub narzędzia</li>
+                    <li>Decyzja: aplikacja, automat, skrypt czy zmiana w sposobie pracy</li>
+                    <li>Wdrożenie zmian razem z zespołem</li>
+                    <li>Mniej błędów, większa przewidywalność, mniej „ratowania"</li>
                 </ul>
                 <div class="service-meta">
-                    <p class="service-time">Czas: 8-12 tygodni</p>
-                    <p class="service-price">od 7500 zł</p>
+                    <p class="service-time">Zakres ustalany po analizie</p>
+                    <p class="service-price">współpraca od 8 000 zł</p>
                 </div>
-                <a href="uslugi.html" class="service-btn">Zaczynam biznes</a>
+                <a href="uslugi.html" class="service-btn">Więcej informacji</a>
             </div>
 
         </div>
@@ -558,55 +570,55 @@
    <!-- PM Competencies -->
     <section id="social-proof" class="social-proof-section">
         <div class="container">
-            <h2 class="section-title">Kompetencje PM</h2>
-            <p class="section-subtitle">Co wnoszę do projektu poza tytułem</p>
+            <h2 class="section-title">Co wnoszę do projektu</h2>
+            <p class="section-subtitle">Dlaczego współpraca ze mną wygląda inaczej niż z agencją albo freelancerem od jednej rzeczy</p>
             <div class="benefits-grid">
+                <div class="benefit-card">
+                    <div class="benefit-icon">
+                        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+                    </div>
+                    <h3>Analiza przed projektem</h3>
+                    <p>Zaczynam od pytań o proces, nie od otwierania Figmy. Dzięki temu rozwiązanie odpowiada na realny problem, a nie na ten, który wydaje się oczywisty.</p>
+                </div>
+
+                <div class="benefit-card">
+                    <div class="benefit-icon">
+                        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3h18v18H3z"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>
+                    </div>
+                    <h3>Projekt pod realne ograniczenia</h3>
+                    <p>Uwzględniam ograniczenia produkcyjne, technologiczne i ludzkie. Projekt, który dobrze wygląda, ale nie da się go wdrożyć, jest dla mnie półproduktem.</p>
+                </div>
+
                 <div class="benefit-card">
                     <div class="benefit-icon">
                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
                     </div>
-                    <h3>Delivery Focus</h3>
-                    <p>Dostarczam w terminie i w scope. Zarządzam ryzykiem i zmianami przez cały cykl — sprint po sprincie.</p>
-                </div>
-
-                <div class="benefit-card">
-                    <div class="benefit-icon">
-                        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
-                    </div>
-                    <h3>Stakeholder Management</h3>
-                    <p>Jasna komunikacja z każdym interesariuszem: status, ryzyka, decyzje — zawsze na czas i bez niespodzianek.</p>
-                </div>
-
-                <div class="benefit-card">
-                    <div class="benefit-icon">
-                        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
-                    </div>
-                    <h3>Data-Driven Decisions</h3>
-                    <p>Priorytety i decyzje opieram na danych. Google Analytics, metryki konwersji, KPIs — nie opinie.</p>
+                    <h3>Wdrożenie, nie tylko projekt</h3>
+                    <p>Kończę pracę dopiero, gdy rozwiązanie działa w realnym środowisku. Bez przekazywania półproduktu komuś innemu „do dokończenia".</p>
                 </div>
 
                 <div class="benefit-card">
                     <div class="benefit-icon">
                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>
                     </div>
-                    <h3>Cross-Functional Leadership</h3>
-                    <p>Koordynuję design, dev i business bez silosów. Rozumiem każdą stronę od środka — bo sam to robię.</p>
+                    <h3>Automatyzacja w środku designu</h3>
+                    <p>Interfejs i logika powstają razem. Dzięki temu produkt nie jest tylko ładny — realnie skraca czas pracy i ogranicza błędy.</p>
                 </div>
 
                 <div class="benefit-card">
                     <div class="benefit-icon">
-                        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+                        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12l2 2 4-4"/><circle cx="12" cy="12" r="10"/></svg>
                     </div>
-                    <h3>Risk Management</h3>
-                    <p>Identyfikuję ryzyka wcześnie i mam plan B. Scope creep, dependencies, tech debt — pod kontrolą od dnia 1.</p>
+                    <h3>Dokładność i odpowiedzialność</h3>
+                    <p>Sam testuję to, co zbudowałem. Skrupulatność wyniosłem z poligrafii — w druku nie ma „naprawimy to w następnej wersji".</p>
                 </div>
 
                 <div class="benefit-card">
                     <div class="benefit-icon">
                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
                     </div>
-                    <h3>UX jako Przewaga</h3>
-                    <p>Rozumiem produkt od strony użytkownika. UX thinking na każdym etapie decyzji — przewaga nad PM bez background designerskiego.</p>
+                    <h3>Doświadczenie z dwóch światów</h3>
+                    <p>Poligrafia nauczyła mnie myślenia procesowego i dokładności. Webdesign — projektowania pod użytkownika. Razem to przewaga, której nie da się zdobyć w jednej branży.</p>
                 </div>
             </div>
         </div>
@@ -616,40 +628,47 @@
     <!-- FAQ -->
     <section id="faq" class="faq-section">
         <div class="container">
-            <h2 class="section-title">FAQ dla rekruterów PM</h2>
+            <h2 class="section-title">Najczęstsze pytania</h2>
             <div class="faq-container">
                 <div class="faq-item">
-                    <button class="faq-question">Jakie metodyki PM stosujesz? <span class="faq-icon">+</span></button>
+                    <button class="faq-question">Od jakiego budżetu zaczynamy rozmowę? <span class="faq-icon">+</span></button>
                     <div class="faq-answer">
-                        <p>Stosuję Agile (Scrum + Kanban) jako podstawę, z elementami waterfall przy projektach z twardymi deadline'ami. Sprinty dwutygodniowe przy ciągłym development, Kanban przy maintenance i support. Zawsze retrospective po każdym etapie — nawet w projektach solo.</p>
+                        <p>Minimum to <strong>8 000 zł</strong>. Przy tym poziomie ma sens zrobić projekt dobrze — z analizą procesu, projektem, wdrożeniem i testami. Mniejsze, jednorazowe zlecenia po prostu nie są moją specjalizacją i nie dam tam wartości, której się ode mnie oczekuje.</p>
                     </div>
                 </div>
 
                 <div class="faq-item">
-                    <button class="faq-question">Jakich narzędzi PM używasz? <span class="faq-icon">+</span></button>
+                    <button class="faq-question">Ile trwa typowy projekt? <span class="faq-icon">+</span></button>
                     <div class="faq-answer">
-                        <p>Do zarządzania projektami: <strong>Jira</strong> (backlog, sprinty, raporty), <strong>Notion</strong> (dokumentacja, OKRs, bazy wiedzy), <strong>GitHub</strong> (repozytoria, PR review, issues). Do analityki: <strong>Google Analytics 4</strong>, Search Console. Do designu: Figma, Adobe CC. Do automatyzacji: Google Apps Script.</p>
+                        <p>Większe projekty — aplikacja, strona z integracjami, automatyzacja kilku procesów — zajmują zwykle <strong>4–5 miesięcy</strong>. Mniejsze usprawnienia kilka tygodni. Dokładny termin ustalam po analizie, na podstawie realnego zakresu, a nie szacunku „na oko".</p>
                     </div>
                 </div>
 
                 <div class="faq-item">
-                    <button class="faq-question">Jak zarządzasz zmianą scope'u? <span class="faq-icon">+</span></button>
+                    <button class="faq-question">Z jakimi firmami współpracuje się najlepiej? <span class="faq-icon">+</span></button>
                     <div class="faq-answer">
-                        <p>Każda zmiana scope'u przechodzi przez formalny change request: ocena wpływu na timeline, budżet i jakość, a następnie stakeholder review i decyzja. <strong>RACI</strong> określa kto ma prawo zatwierdzać zmiany. Nie blokuję zmian — zarządzam nimi transparentnie. Zmiana scope = renegocjacja albo odkładamy na następną iterację.</p>
+                        <p>Z firmami, które <strong>mają już działające procesy</strong> i chcą je uporządkować, uprościć albo zautomatyzować. Tam widać największą różnicę. Najgorzej działa to tam, gdzie nie wiadomo, co właściwie firma robi i jak — wtedy najpierw trzeba zrobić porządek, a dopiero potem brać się za technologię.</p>
                     </div>
                 </div>
 
                 <div class="faq-item">
-                    <button class="faq-question">Jak mierzysz sukces projektu? <span class="faq-icon">+</span></button>
+                    <button class="faq-question">Projektujesz, czy też wdrażasz? <span class="faq-icon">+</span></button>
                     <div class="faq-answer">
-                        <p>Definiuję KPIs przed startem razem ze stakeholderami — nie po fakcie. Przykłady: czas wykonania task (Raz Dwa Druk: −90%), wskaźnik konwersji, PageSpeed, czas do rynku, liczba defektów post-launch. Po wdrożeniu monitoruję przez minimum 30 dni i porównuję z baseline.</p>
+                        <p><strong>Robię obie rzeczy.</strong> Od analizy procesu, przez projekt, po działające rozwiązanie, które trafia do użytkowników. Dzięki temu nic nie ginie w przekazywaniu pracy między rolami, a estymacje są precyzyjne — wiem, co jest trudne, bo sam to składam.</p>
                     </div>
                 </div>
 
                 <div class="faq-item">
-                    <button class="faq-question">Czym różnisz się od PM bez background technicznego? <span class="faq-icon">+</span></button>
+                    <button class="faq-question">Pracujesz samodzielnie? <span class="faq-icon">+</span></button>
                     <div class="faq-answer">
-                        <p>Projektuję i implementuję sam, więc estymacje są precyzyjne — wiem co jest trudne technicznie i co designowo. Nie potrzebuję tłumacza między biznesem a devami. Mogę przejąć zadanie wykonawcze gdy pojawi się bloker. To skraca cykl decyzyjny i eliminuje całą kategorię ryzyk typowych dla PM bez background technicznego.</p>
+                        <p>Tak. Prowadzę projekty od początku do końca samodzielnie, korzystając z narzędzi wspomagających — w tym narzędzi AI tam, gdzie realnie skracają pracę bez utraty jakości. Tam, gdzie potrzebny jest dodatkowy specjalista, dobieram zaufaną osobę pod konkretny zakres.</p>
+                    </div>
+                </div>
+
+                <div class="faq-item">
+                    <button class="faq-question">Czego nie robię? <span class="faq-icon">+</span></button>
+                    <div class="faq-answer">
+                        <p>Nie biorę się za projekty bez realnego problemu do rozwiązania, jednorazowe zlecenia graficzne ani prace „na wczoraj" bez analizy. Nie jestem agencją od wszystkiego — pracuję z firmami, które chcą zrobić coś <strong>dobrze raz</strong>, a nie tanio trzy razy.</p>
                     </div>
                 </div>
             </div>
@@ -662,9 +681,9 @@
     <section id="contact" class="contact-section">
         <div class="container">
             <div class="contact-content">
-                <h2 class="contact-title">Potrzebujesz projektu? Porozmawiajmy!</h2>
+                <h2 class="contact-title">Masz proces, który zjada za dużo czasu? Porozmawiajmy.</h2>
                 <p class="contact-subtitle">
-                    Sprawdź, jak mogę pomóc Twojej firmie zwiększyć sprzedaż przez lepszy design
+                    Odpowiadam w ciągu 24 godzin. Pierwsza rozmowa nic nie kosztuje — sprawdzimy, czy w ogóle warto się brać.
                 </p>
                 <div class="contact-form-container">
                     <form id="contactForm" class="contact-form">
@@ -684,14 +703,14 @@
                                 <input type="tel" id="phone" name="phone" placeholder="123 456 789" />
                             </div>
                             <div class="form-group">
-                                <label for="projectType">Rodzaj projektu</label>
+                                <label for="projectType">Czego potrzebujesz</label>
                                 <select id="projectType" name="projectType">
                                     <option value="">-- wybierz --</option>
-                                    <option value="logo">Logo i branding</option>
-                                    <option value="website">Strona internetowa</option>
-                                    <option value="ecommerce">Sklep internetowy</option>
-                                    <option value="full">Kompleksowy projekt</option>
-                                    <option value="other">Inne</option>
+                                    <option value="aplikacja">Aplikacja biznesowa</option>
+                                    <option value="strona">Strona internetowa</option>
+                                    <option value="automatyzacja">Automatyzacja procesu</option>
+                                    <option value="usprawnienie">Analiza i usprawnienie procesu</option>
+                                    <option value="nie-wiem">Nie wiem — pomóż mi to nazwać</option>
                                 </select>
                             </div>
                         </div>
@@ -699,21 +718,21 @@
                             <label for="budget">Budżet (opcjonalnie)</label>
                             <select id="budget" name="budget">
                                 <option value="">-- wybierz --</option>
-                                <option value="2000-5000">2 000 - 5 000 zł</option>
-                                <option value="5000-10000">5 000 - 10 000 zł</option>
-                                <option value="10000+">10 000+ zł</option>
+                                <option value="8000-15000">8 000 – 15 000 zł</option>
+                                <option value="15000-30000">15 000 – 30 000 zł</option>
+                                <option value="30000+">30 000 zł +</option>
                                 <option value="do-ustalenia">Do ustalenia</option>
                             </select>
                         </div>
                         <div class="form-group">
-                            <label for="message">Opis projektu*</label>
-                            <textarea id="message" name="message" rows="5" placeholder="Opowiedz mi o swoim projekcie, celach i oczekiwaniach..." required></textarea>
+                            <label for="message">Opis problemu lub procesu*</label>
+                            <textarea id="message" name="message" rows="5" placeholder="Opisz, co dziś nie działa, zajmuje za dużo czasu albo generuje błędy. Im konkretniej, tym lepiej." required></textarea>
                         </div>
                         <button type="submit" class="submit-btn">
                             <span class="btn-text">Wyślij zapytanie</span>
                             <span class="btn-loader" style="display: none;">Wysyłam...</span>
                         </button>
-                        <p class="form-note">Odezwę się w ciągu 24h z konkretną propozycją współpracy</p>
+                        <p class="form-note">Odezwę się w ciągu 24 godzin z pierwszą oceną i propozycją kolejnego kroku.</p>
                     </form>
                 </div>
             </div>
@@ -725,7 +744,7 @@
         <div class="container footer-inner">
             <div class="footer-info">
                 <h3>Karol Wyszyński</h3>
-                <p>Project Manager · UX/UI Designer</p>
+                <p>Digital Product Designer · Automatyzacje · Procesy</p>
                 <a href="mailto:wyszynski.k@onet.pl" class="footer-email">wyszynski.k@onet.pl</a>
                 <div class="footer-social">
                     <a href="https://www.linkedin.com/in/karol-wyszynski/" target="_blank" rel="noopener" aria-label="LinkedIn">

--- a/kontakt.html
+++ b/kontakt.html
@@ -3,17 +3,17 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Kontakt – Karol Wyszyński | UX/UI Designer</title>
-    <meta name="description" content="Skontaktuj się ze mną w sprawie projektu UX/UI, strony internetowej lub brandingu. Odpowiadam w ciągu 24h. Bezpłatna konsultacja." />
+    <title>Kontakt – Karol Wyszyński | Digital Product Designer</title>
+    <meta name="description" content="Napisz w sprawie projektu cyfrowego, automatyzacji procesu lub usprawnienia procesu biznesowego. Odpowiadam w ciągu 24 godzin. Współpraca od 8 000 zł." />
 
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="assets/images/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="assets/images/favicon-32x32.png">
-    
+
     <!-- Apple Touch Icon -->
     <link rel="apple-touch-icon" sizes="180x180" href="assets/images/apple-touch-icon.png">
-    
+
     <!-- Android Chrome Icons -->
     <link rel="icon" type="image/png" sizes="192x192" href="assets/images/android-chrome-192x192.png">
     <link rel="icon" type="image/png" sizes="512x512" href="assets/images/android-chrome-512x512.png">
@@ -22,7 +22,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet" />
-    
+
     <!-- Main CSS -->
     <link rel="stylesheet" href="assets/css/style.css" />
 </head>
@@ -44,43 +44,63 @@
     <!-- Hero section for contact page -->
     <section class="hero" style="background-image: url('assets/images/automation.png');">
         <div class="hero-overlay">
-            <h1>Skontaktuj się ze mną</h1>
-            <p>Masz pytania lub chcesz rozpocząć współpracę? Napisz – odpowiem w ciągu 24h.</p>
+            <h1>Porozmawiajmy o Twoim procesie</h1>
+            <p>Masz proces, który zjada za dużo czasu, albo pomysł na produkt cyfrowy? Napisz — odpowiadam w ciągu 24 godzin.</p>
         </div>
     </section>
 
     <section class="contact">
         <div class="contact-info">
             <h2>Dane kontaktowe</h2>
-            <p><strong>Email:</strong> <a href="mailto:kontakt@kwyszynski.pl">kontakt@kwyszynski.pl</a></p>
-            <p><strong>Telefon:</strong> <a href="tel:+48123456789">+48 123 456 789</a></p>
-            <p>Odpowiadam na wiadomości w ciągu 24 godzin (dni robocze).</p>
+            <p><strong>Email:</strong> <a href="mailto:wyszynski.k@onet.pl">wyszynski.k@onet.pl</a></p>
+            <p><strong>LinkedIn:</strong> <a href="https://www.linkedin.com/in/karol-wyszynski/" target="_blank" rel="noopener">linkedin.com/in/karol-wyszynski</a></p>
+            <p>Odpowiadam na wiadomości w ciągu 24 godzin w dni robocze.</p>
+
+            <h3>Zanim napiszesz</h3>
+            <ul>
+                <li>Współpracę zaczynam od <strong>8 000 zł</strong>.</li>
+                <li>Większe projekty trwają zwykle <strong>4–5 miesięcy</strong>.</li>
+                <li>Najlepiej działam z firmami, które mają już działające procesy i chcą je uporządkować, uprościć albo zautomatyzować.</li>
+                <li>Pierwsza rozmowa nic nie kosztuje — sprawdzimy, czy w ogóle warto się brać.</li>
+            </ul>
         </div>
 
         <div class="contact-form">
             <h2>Formularz kontaktowy</h2>
-            <form id="contactForm" method="POST" action="mailto:kontakt@kwyszynski.pl" enctype="text/plain">
+            <form id="contactForm" method="POST" action="mailto:wyszynski.k@onet.pl" enctype="text/plain">
                 <label for="name">Imię i nazwisko*</label>
                 <input type="text" id="name" name="name" required placeholder="Jan Kowalski" />
 
                 <label for="email">Adres e-mail*</label>
                 <input type="email" id="email" name="email" required placeholder="jan@firma.pl" />
 
-                <label for="phone">Telefon</label>
-                <input type="tel" id="phone" name="phone" placeholder="+48 123 456 789" />
+                <label for="company">Firma</label>
+                <input type="text" id="company" name="company" placeholder="Nazwa firmy" />
 
-                <label for="subject">Temat</label>
+                <label for="phone">Telefon</label>
+                <input type="tel" id="phone" name="phone" placeholder="opcjonalnie" />
+
+                <label for="subject">Czego potrzebujesz</label>
                 <select id="subject" name="subject">
                     <option value="">-- wybierz --</option>
-                    <option value="projekt-strony">Projekt strony internetowej</option>
-                    <option value="branding">Logo i branding</option>
-                    <option value="sklep">Sklep internetowy</option>
-                    <option value="wspolpraca">Współpraca długoterminowa</option>
-                    <option value="inne">Inne</option>
+                    <option value="aplikacja">Aplikacja biznesowa</option>
+                    <option value="strona">Strona internetowa</option>
+                    <option value="automatyzacja">Automatyzacja procesu</option>
+                    <option value="usprawnienie">Analiza i usprawnienie procesu</option>
+                    <option value="nie-wiem">Nie wiem — pomóż mi to nazwać</option>
                 </select>
 
-                <label for="message">Wiadomość*</label>
-                <textarea id="message" name="message" required rows="6" placeholder="Opisz swój projekt lub pytanie..."></textarea>
+                <label for="budget">Budżet (opcjonalnie)</label>
+                <select id="budget" name="budget">
+                    <option value="">-- wybierz --</option>
+                    <option value="8000-15000">8 000 – 15 000 zł</option>
+                    <option value="15000-30000">15 000 – 30 000 zł</option>
+                    <option value="30000+">30 000 zł +</option>
+                    <option value="do-ustalenia">Do ustalenia</option>
+                </select>
+
+                <label for="message">Opis problemu lub procesu*</label>
+                <textarea id="message" name="message" required rows="6" placeholder="Opisz, co dziś nie działa, zajmuje za dużo czasu albo generuje błędy. Im konkretniej, tym lepiej."></textarea>
 
                 <button type="submit">Wyślij wiadomość</button>
             </form>
@@ -88,7 +108,7 @@
     </section>
 
     <footer>
-        <p>&copy; 2025&nbsp;Karol&nbsp;Wyszyński&nbsp;&ndash; kontakt: <a href="mailto:kontakt@kwyszynski.pl">kontakt@kwyszynski.pl</a></p>
+        <p>&copy; 2026&nbsp;Karol&nbsp;Wyszyński&nbsp;&ndash; kontakt: <a href="mailto:wyszynski.k@onet.pl">wyszynski.k@onet.pl</a></p>
     </footer>
 
     <script src="assets/js/scripts.js"></script>

--- a/omnie.html
+++ b/omnie.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>O&nbsp;mnie – Karol Wyszyński | UX/UI Designer</title>
-    <meta name="description" content="Poznaj Karola Wyszyńskiego – UX/UI Designera z ponad 10-letnim doświadczeniem. Tworzę strony i identyfikacje wizualne, które łączą estetykę z funkcją." />
+    <title>O&nbsp;mnie – Karol Wyszyński | Digital Product Designer</title>
+    <meta name="description" content="Karol Wyszyński – Digital Product Designer. Projektuję i wdrażam produkty cyfrowe, automatyzacje i usprawnienia procesów biznesowych. ~10 lat doświadczenia, droga od poligrafii przez webdesign do aplikacji." />
 
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
@@ -42,27 +42,54 @@
     >
       <div class="hero-overlay">
         <h1>O&nbsp;mnie</h1>
-        <p>Poznaj mnie lepiej i dowiedz się, jak pracuję.</p>
+        <p>Droga od poligrafii przez webdesign do produktów cyfrowych i automatyzacji.</p>
       </div>
     </section>
 
     <section class="about">
-      <h2>Project Manager · UX/UI Designer</h2>
+      <h2>Digital Product Designer</h2>
+
       <p>
-        Nazywam się Karol Wyszyński. Jestem Project Managerem i UX/UI Designerem z 8+ letnim doświadczeniem w prowadzeniu projektów cyfrowych end-to-end — od discovery i definiowania wymagań, przez architekturę i design, aż po wdrożenie produkcyjne i retrospective.
+        Jestem Karol Wyszyński. Od ~8 lat projektuję produkty cyfrowe, a od kilku lat łączę projektowanie z automatyzacjami i rozwijaniem aplikacji biznesowych. Pomagam firmom, które mają już działające procesy, ale chcą je uprościć, przyspieszyć albo przenieść do jednego, dobrze zaprojektowanego narzędzia.
       </p>
+
       <p>
-        Zarządzam scope'em, timeline'em i jakością deliverables. Ponieważ sam projektuję i implementuję, rozumiem każdy etap od strony technicznej i biznesowej — bez potrzeby tłumacza między designem, devem a biznesem. Pracowałem w branżach: druk B2B, e-commerce, wellness/coaching i design services.
+        Pracę zaczynałem w poligrafii — tam nauczyłem się dokładności, myślenia procesowego i pracy pod realne ograniczenia produkcyjne. Z czasem przeszedłem do projektowania stron i aplikacji, a kiedy zobaczyłem, ile czasu firmy tracą na powtarzalne czynności, dołączyłem do tego automatyzacje. W sumie ~10 lat pracy zawodowej w dwóch światach: poligrafii i webdesignie.
       </p>
+
       <p>
-        Stosuję Agile/Scrum i Kanban, decyzje opieram na danych, a UX traktuję jako przewagę konkurencyjną, nie dekorację. Jeśli szukasz PM-a, który rozumie produkt od środka — zapraszam do kontaktu.
+        Dzisiaj projektuję i wdrażam rozwiązania cyfrowe od początku do końca: zaczynam od rozmowy o procesie, znajduję wąskie gardła, projektuję rozwiązanie, buduję je i testuję w praktyce. Mam za sobą 5 stron internetowych, ponad 10 zautomatyzowanych procesów i aplikację biznesową dla drukarni, która skróciła proces wyceny z około godziny do około 5 minut.
+      </p>
+
+      <p>
+        Najmocniej działam wtedy, gdy firma ma realny problem, budżet na jego rozwiązanie i gotowość, żeby uporządkować to, co dziś działa „jakoś". Nie jestem agencją od wszystkiego — pracuję z firmami, które chcą zrobić coś dobrze raz, a nie tanio trzy razy. Próg współpracy zaczynam od 8 000 zł, większe projekty trwają zwykle 4–5 miesięcy.
+      </p>
+
+      <p>
+        Równolegle rozwijam się w stronę product i project managementu — kierunek, który naturalnie wynika z tego, jak prowadzę projekty: od analizy problemu, przez decyzje projektowe, po wdrożenie i pierwsze tygodnie użycia.
+      </p>
+
+      <h3>Co wyróżnia moją pracę</h3>
+      <ul>
+        <li><strong>Analiza przed projektem.</strong> Zaczynam od pytań o proces, a nie od otwierania Figmy.</li>
+        <li><strong>Projektowanie i wdrożenie w jednym ręku.</strong> Nic nie ginie w przekazywaniu pracy między rolami.</li>
+        <li><strong>Dokładność i odpowiedzialność za efekt.</strong> Testuję ręcznie to, co zbudowałem.</li>
+        <li><strong>Doświadczenie z dwóch światów.</strong> Poligrafia nauczyła mnie myślenia procesowego, web — projektowania pod użytkownika.</li>
+      </ul>
+
+      <h3>Narzędzia, na których pracuję</h3>
+      <p>
+        Zaawansowanie: Photoshop, Illustrator, InDesign, Acrobat, WordPress, Google Apps Script.<br />
+        Średnio i pomocniczo: Blender, Miro, Figma.<br />
+        Wcześniej: PackEdge, ArtPro, Substance 3D Painter.<br />
+        Codziennie wspieram się narzędziami AI (Claude, ChatGPT, Perplexity) tam, gdzie realnie skracają pracę bez utraty jakości.
       </p>
     </section>
 
     <footer>
       <p>
-        &copy; 2025&nbsp;Karol&nbsp;Wyszyński&nbsp;&ndash; kontakt:
-        <a href="mailto:kontakt@kwyszynski.pl">kontakt@kwyszynski.pl</a>
+        &copy; 2026&nbsp;Karol&nbsp;Wyszyński&nbsp;&ndash; kontakt:
+        <a href="mailto:wyszynski.k@onet.pl">wyszynski.k@onet.pl</a>
       </p>
     </footer>
 

--- a/portfolio.html
+++ b/portfolio.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Portfolio Projektów UX/UI – Karol Wyszyński | Strony WWW, Branding</title>
-    <meta name="description" content="Zobacz moje projekty UX/UI: strony internetowe, sklepy e-commerce, brandingowe identyfikacje wizualne i automatyzacje. Portfolio z case studies i realizacjami." />
+    <title>Portfolio – Karol Wyszyński | Produkty cyfrowe, aplikacje, automatyzacje</title>
+    <meta name="description" content="Wybrane projekty: aplikacja dla drukarni (Raz Dwa Druk), strony internetowe, sklepy i automatyzacje. Realizacje zaprojektowane i wdrożone od początku do końca." />
 
     <!-- Canonical -->
     <link rel="canonical" href="https://kwyszynski.pl/portfolio.html" />
@@ -12,16 +12,16 @@
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://kwyszynski.pl/portfolio.html" />
-    <meta property="og:title" content="Portfolio Projektów UX/UI – Karol Wyszyński | Strony WWW, Branding" />
-    <meta property="og:description" content="Zobacz moje projekty UX/UI: strony internetowe, sklepy e-commerce, brandingowe identyfikacje wizualne i automatyzacje. Portfolio z case studies i realizacjami." />
+    <meta property="og:title" content="Portfolio – Karol Wyszyński | Produkty cyfrowe, aplikacje, automatyzacje" />
+    <meta property="og:description" content="Wybrane projekty: aplikacja dla drukarni (Raz Dwa Druk), strony internetowe, sklepy i automatyzacje. Realizacje zaprojektowane i wdrożone od początku do końca." />
     <meta property="og:image" content="https://kwyszynski.pl/assets/images/android-chrome-512x512.png" />
     <meta property="og:locale" content="pl_PL" />
-    <meta property="og:site_name" content="Karol Wyszyński – UX/UI Designer" />
+    <meta property="og:site_name" content="Karol Wyszyński – Digital Product Designer" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Portfolio Projektów UX/UI – Karol Wyszyński | Strony WWW, Branding" />
-    <meta name="twitter:description" content="Zobacz moje projekty UX/UI: strony internetowe, sklepy e-commerce, brandingowe identyfikacje wizualne i automatyzacje. Portfolio z case studies i realizacjami." />
+    <meta name="twitter:title" content="Portfolio – Karol Wyszyński | Produkty cyfrowe, aplikacje, automatyzacje" />
+    <meta name="twitter:description" content="Wybrane projekty: aplikacja dla drukarni (Raz Dwa Druk), strony internetowe, sklepy i automatyzacje. Realizacje zaprojektowane i wdrożone od początku do końca." />
     <meta name="twitter:image" content="https://kwyszynski.pl/assets/images/android-chrome-512x512.png" />
 
     <!-- JSON-LD -->
@@ -30,7 +30,7 @@
       "@context": "https://schema.org",
       "@type": "CollectionPage",
       "name": "Portfolio – Karol Wyszyński",
-      "description": "Portfolio projektów UX/UI: strony internetowe, sklepy e-commerce, identyfikacje wizualne i automatyzacje.",
+      "description": "Portfolio realizacji: aplikacja biznesowa dla drukarni, strony internetowe, sklepy i automatyzacje procesów.",
       "url": "https://kwyszynski.pl/portfolio.html",
       "author": {
         "@type": "Person",
@@ -89,77 +89,77 @@
         <div class="container about-me-grid">
             <!-- TEXT -->
             <div class="about-me-text">
-                <p class="about-me-eyebrow">Project Manager · UX/UI Designer</p>
+                <p class="about-me-eyebrow">Digital Product Designer · Automatyzacje · Procesy</p>
                 <h1>Cześć, jestem Karol</h1>
-                <p class="subtitle">8+ lat end-to-end delivery — od discovery po wdrożenie produkcyjne</p>
-                <p>Project Manager i UX/UI Designer z 8+ letnim doświadczeniem w prowadzeniu projektów cyfrowych od analizy wymagań do wdrożenia produkcyjnego. Zarządzam scope'em, timeline'em i jakością — a ponieważ sam projektuję i implementuję, rozumiem każdy etap od strony technicznej i biznesowej. Dostarczałem rozwiązania dla e-commerce B2B, branży wellness, usług druku i agencji designu.</p>
+                <p class="subtitle">Projektuję i wdrażam produkty cyfrowe, automatyzacje i usprawnienia procesów biznesowych</p>
+                <p>Od ~8 lat projektuję produkty cyfrowe, a od kilku lat łączę projektowanie z automatyzacjami i rozwijaniem aplikacji biznesowych. Pracuję od analizy procesu, przez projekt, po działające rozwiązanie wdrożone u klienta. Mam za sobą 5 stron internetowych, ponad 10 zautomatyzowanych procesów i aplikację dla drukarni, która skróciła wycenę z około godziny do około 5 minut.</p>
 
-                <!-- Career Timeline -->
+                <!-- Droga zawodowa -->
                 <div class="career-timeline-pm">
-                    <h6>Doświadczenie zawodowe</h6>
+                    <h6>Droga zawodowa</h6>
                     <div class="ctp-item">
-                        <span class="ctp-year">2022 – teraz</span>
+                        <span class="ctp-year">Dziś</span>
                         <div class="ctp-content">
-                            <strong>Project Manager · UX/UI Designer</strong>
-                            <span>Freelance — End-to-end delivery: discovery, architektura, design, implementacja, launch</span>
+                            <strong>Digital Product Designer</strong>
+                            <span>Projektuję i wdrażam produkty cyfrowe, automatyzacje i usprawnienia procesów. Pracuję samodzielnie, od analizy po wdrożenie.</span>
                         </div>
                     </div>
                     <div class="ctp-item">
-                        <span class="ctp-year">2018 – 2022</span>
+                        <span class="ctp-year">Webdesign</span>
                         <div class="ctp-content">
-                            <strong>UX/UI Designer & Product Owner</strong>
-                            <span>Freelance — Projekty e-commerce, branding, automatyzacje, platformy WordPress</span>
+                            <strong>Strony, aplikacje i pierwsze automatyzacje</strong>
+                            <span>Przejście od projektowania graficznego do projektowania stron i aplikacji. Z czasem dołączyły automatyzacje procesów biznesowych.</span>
                         </div>
                     </div>
                     <div class="ctp-item">
-                        <span class="ctp-year">2016 – 2018</span>
+                        <span class="ctp-year">Poligrafia</span>
                         <div class="ctp-content">
-                            <strong>Graphic Designer & Web Developer</strong>
-                            <span>Projektowanie graficzne, identyfikacje wizualne, layouty stron</span>
+                            <strong>Start w produkcji</strong>
+                            <span>Tu nauczyłem się dokładności, myślenia procesowego i pracy pod realne ograniczenia produkcyjne. To wciąż wpływa na to, jak projektuję.</span>
                         </div>
                     </div>
                 </div>
 
-                <!-- Meta grid: branże, certyfikaty, metodyki -->
+                <!-- Meta grid: branże, doświadczenie -->
                 <div class="about-details-grid">
                     <div class="adg-item">
                         <span class="adg-label">Branże</span>
-                        <p>Druk B2B · E-commerce · Wellness/Coaching · Design Services</p>
+                        <p>Poligrafia · Webdesign</p>
                     </div>
                     <div class="adg-item">
-                        <span class="adg-label">Metodyki</span>
-                        <p>Agile · Scrum · Kanban · Design Thinking · Lean UX</p>
+                        <span class="adg-label">Doświadczenie</span>
+                        <p>~10 lat pracy zawodowej · ~8 lat w designie</p>
                     </div>
                     <div class="adg-item">
-                        <span class="adg-label">Certyfikaty</span>
-                        <p>Google Analytics 4 · UX Research · Agile PM (w trakcie)</p>
+                        <span class="adg-label">Zrealizowane</span>
+                        <p>5 stron · 1 aplikacja biznesowa · 10+ automatyzacji</p>
                     </div>
                     <div class="adg-item">
-                        <span class="adg-label">Wykształcenie</span>
-                        <p>Design / Multimedia — 8+ lat praktyki zawodowej</p>
+                        <span class="adg-label">Sposób pracy</span>
+                        <p>Analiza → projekt → budowa → testy → wdrożenie</p>
                     </div>
                 </div>
 
-                <!-- PM Tools — kategoryzowane -->
+                <!-- Narzędzia -->
                 <div class="pm-tools-section">
                     <h6>Narzędzia</h6>
                     <div class="pm-tools-cats">
                         <div class="ptc-row">
-                            <span class="ptc-label">PM</span>
+                            <span class="ptc-label">Projektowanie</span>
                             <div class="ptc-tags">
-                                <span>Jira</span><span>Notion</span><span>GitHub</span><span>Google Analytics</span>
+                                <span>Illustrator</span><span>Photoshop</span><span>InDesign</span><span>Acrobat</span><span>Figma</span>
                             </div>
                         </div>
                         <div class="ptc-row">
-                            <span class="ptc-label">Design</span>
+                            <span class="ptc-label">Budowa i web</span>
                             <div class="ptc-tags">
-                                <span>Figma</span><span>Illustrator</span><span>Photoshop</span>
+                                <span>WordPress</span><span>WooCommerce</span><span>HTML / CSS / JS</span>
                             </div>
                         </div>
                         <div class="ptc-row">
-                            <span class="ptc-label">Dev</span>
+                            <span class="ptc-label">Automatyzacje i praca</span>
                             <div class="ptc-tags">
-                                <span>WordPress</span><span>WooCommerce</span><span>HTML CSS JS</span>
+                                <span>Google Apps Script</span><span>Google Sheets</span><span>Miro</span><span>Obsidian</span>
                             </div>
                         </div>
                     </div>
@@ -186,9 +186,9 @@
             <!-- VISUALS -->
             <div class="about-me-visuals">
                 <div class="about-me-image">
-                    <img src="assets/images/presentation HERO.webp" alt="Karol Wyszyński - Project Manager UX/UI Designer">
+                    <img src="assets/images/presentation HERO.webp" alt="Karol Wyszyński - Digital Product Designer">
                 </div>
-                <a href="#portfolio-section" class="btn btn-primary cta-portfolio smooth">Zobacz case studies</a>
+                <a href="#portfolio-section" class="btn btn-primary cta-portfolio smooth">Zobacz wybrane projekty</a>
             </div>
         </div>
     </section>
@@ -197,7 +197,7 @@
     <section id="portfolio-section" class="portfolio-section">
         <div class="container">
             <h2 class="section-title">Wybrane projekty</h2>
-            <p class="section-subtitle">Każdy projekt to unikalna historia współpracy i rozwiązanie dostosowane do potrzeb klienta</p>
+            <p class="section-subtitle">Realizacje od analizy problemu po wdrożenie — strony, aplikacje i automatyzacje zaprojektowane pod konkretny proces</p>
             
             <!-- GRID 3 KOLUMNY -->
             <div class="portfolio-new-grid">
@@ -272,29 +272,29 @@
                 </div>
 
                 
- <!-- KARTA : automatyzacja  -->
-         <div class="portfolio-new-card" data-project="cyfradruk">
+ <!-- KARTA: CyfraDruk -->
+                <div class="portfolio-new-card" data-project="cyfradruk">
                     <div class="card-image-wrapper">
                         <img src="assets/images/Automatyzacja_liniekolory.webp"
-                             alt="Automatyzacja Illustrator"
+                             alt="CyfraDruk – wtyczka CEP do Adobe Illustrator wykrywająca błędy pre-press"
                              loading="lazy" />
                     </div>
                     <div class="card-content">
-                        <span class="card-category">Automatyzacja Illustrator</span>
-                        <h4 class="card-title">Automatyzacja Illustrator</h4>
-                        <p class="card-description">Detektor kolorów i zbyt cienkich linii</p>
+                        <span class="card-category">AUTOMATYZACJA · PRE-PRESS</span>
+                        <h4 class="card-title">CyfraDruk</h4>
+                        <p class="card-description">Wtyczka CEP do Adobe Illustrator wykrywająca błędy kolorów i zbyt cienkich linii przed drukiem.</p>
                         <div class="card-features">
                             <span class="feature-item">
                                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
                                     <path d="M13.5 3.5L6 11L2.5 7.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                 </svg>
-                                Illustrator, JS 
+                                Adobe Illustrator + ExtendScript
                             </span>
                             <span class="feature-item">
                                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
                                     <path d="M13.5 3.5L6 11L2.5 7.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                 </svg>
-                                Automatyzacja 
+                                Skaner kolorów i obiektów w jednym panelu
                             </span>
                         </div>
                         <div class="card-cta">
@@ -304,7 +304,7 @@
                             </svg>
                         </div>
                     </div>
-                </div>        
+                </div>
 
                
 
@@ -439,7 +439,7 @@
         <div class="container footer-inner">
             <div class="footer-info">
                 <h3>Karol Wyszyński</h3>
-                <p>Project Manager · UX/UI Designer</p>
+                <p>Digital Product Designer · Automatyzacje · Procesy</p>
                 <p>Email: <a href="mailto:wyszynski.k@onet.pl">wyszynski.k@onet.pl</a></p>
             </div>
             <div class="footer-links">

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -5,16 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <title>Case Study: Raz Dwa Druk — System Cyfrowy | Karol Wyszyński</title>
-  <meta name="description" content="Kompleksowy system cyfrowy dla drukarni Raz Dwa: kalkulator wycen B2B, UX/UI wielokolumnowy, architektura aplikacji TypeScript, Google Sheets, pdf-lib, PWA.">
-  <meta name="keywords" content="case study, kalkulator drukarni, Raz Dwa, aplikacja B2B, PWA, TypeScript, druk CAD, UX design, Google Sheets, pdf-lib">
+  <title>Raz Dwa Druk — aplikacja, która skróciła wycenę z godziny do ok. 5 minut | Karol Wyszyński</title>
+  <meta name="description" content="Aplikacja biznesowa dla drukarni Raz Dwa: kalkulator wycen, koszyk, eksport PDF i integracja z Google Sheets. Zastąpiła ręczne liczenie i papierowe cenniki — proces skrócony z godziny do około 5 minut.">
+  <meta name="keywords" content="aplikacja dla drukarni, kalkulator wycen, automatyzacja procesu, Google Apps Script, PWA, druk CAD, projekt produktu cyfrowego">
   <meta name="author" content="Karol Wyszyński">
   <meta name="robots" content="index, follow">
 
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://kwyszynskidesign.github.io/KWdesignnew/projects/razdwa-pelne.html">
-  <meta property="og:title" content="Case Study: Raz Dwa Druk — System Cyfrowy | Karol Wyszyński">
-  <meta property="og:description" content="Kompleksowy system cyfrowy dla drukarni: kalkulator B2B, PWA offline, Google Sheets, pdf-lib — 21 kategorii, 178 testów automatycznych, pełny proces UX/UI.">
+  <meta property="og:title" content="Raz Dwa Druk — aplikacja, która skróciła wycenę z godziny do ok. 5 minut">
+  <meta property="og:description" content="Aplikacja zastąpiła ręczne liczenie cen i papierowe cenniki: kalkulator druku, koszyk, eksport PDF i automatyczne zamówienia w Google Sheets.">
   <meta property="og:image" content="https://kwyszynskidesign.github.io/KWdesignnew/assets/images/kalkulator-cad-hero.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
   <meta property="og:site_name" content="Karol Wyszyński Portfolio">
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Case Study: Raz Dwa Druk — System Cyfrowy | Karol Wyszyński">
+  <meta name="twitter:title" content="Raz Dwa Druk — aplikacja, która skróciła wycenę z godziny do ok. 5 minut">
   <meta name="twitter:image" content="https://kwyszynskidesign.github.io/KWdesignnew/assets/images/kalkulator-cad-hero.png">
 
   <link rel="icon" type="image/png" sizes="32x32" href="/KWdesignnew/assets/images/favicon-32x32.png">
@@ -341,19 +341,19 @@
           <div class="hero-buttons-vertical">
             <div class="kwcs-chip chip-zakres">
               <strong>Zakres</strong><br>
-              Aplikacja B2B, UX/UI, Architektura TypeScript, testy
+              Aplikacja biznesowa, projekt UX/UI, architektura, testy ręczne i automatyczne
             </div>
             <div class="kwcs-chip chip-stack">
-              <strong>Stack</strong><br>
-              TypeScript, esbuild, Vitest, PWA, pdf-lib, Google Sheets
+              <strong>Technologie</strong><br>
+              TypeScript, esbuild, Vitest, PWA, pdf-lib, Google Apps Script, Google Sheets
             </div>
             <div class="kwcs-chip chip-automatyzacje">
-              <strong>Kategoria</strong><br>
-              System wewnętrzny B2B · Drukarnia wielkoformatowa
+              <strong>Branża</strong><br>
+              Drukarnia wielkoformatowa · proces B2B
             </div>
             <div class="kwcs-chip chip-dostarczone">
-              <strong>Dostarczone</strong><br>
-              21 kategorii, Koszyk UI, PDF + GSheets
+              <strong>Co dostarczyłem</strong><br>
+              Kalkulator, koszyk, eksport PDF, integracja z Google Sheets
             </div>
           </div>
 
@@ -385,25 +385,25 @@
 
         <div class="context-intro">
           <p>
-            <strong>Drukarnia Raz Dwa</strong> obsługuje klientów B2B zamawiających wydruki wielkoformatowe — projekty CAD, plakaty A0–A1, banery i folie. Przed wdrożeniem systemu każda wycena wymagała ręcznego sprawdzenia tabeli w Excelu, przeliczenia metrów bieżących i zsumowania dopłat.
+            <strong>Drukarnia Raz Dwa</strong> obsługuje klientów biznesowych zamawiających wydruki wielkoformatowe — projekty CAD, plakaty A0–A1, banery i folie. Przed wdrożeniem aplikacji każda wycena wymagała ręcznego sprawdzenia tabeli w Excelu, przeliczenia metrów bieżących i zsumowania dopłat. Cały proces zajmował <strong>około godziny</strong>.
           </p>
           <p>
-            Projekt objął stworzenie od zera kompleksowego systemu cyfrowego: <strong>interfejsu z koszykiem</strong>, specjalistycznego <strong>kalkulatora druku CAD</strong> oraz solidnej <strong>architektury PWA</strong> (TypeScript, testy automatyczne, integracje z Google Sheets i pdf-lib) bez użycia backendu.
+            Zaprojektowałem i zbudowałem od zera całe rozwiązanie: <strong>interfejs z koszykiem</strong>, dedykowany <strong>kalkulator druku CAD</strong> oraz architekturę aplikacji PWA z testami i integracjami (Google Apps Script + Google Sheets, eksport PDF). Bez serwera własnego po stronie drukarni.
           </p>
         </div>
 
         <div class="razdwa-stats">
           <div class="razdwa-stat">
+            <div class="razdwa-stat-num">~5 min</div>
+            <div class="razdwa-stat-label">czas wyceny (wcześniej ok. godziny)</div>
+          </div>
+          <div class="razdwa-stat">
             <div class="razdwa-stat-num">21</div>
             <div class="razdwa-stat-label">kategorii cennikowych</div>
           </div>
           <div class="razdwa-stat">
-            <div class="razdwa-stat-num">45 s</div>
-            <div class="razdwa-stat-label">czas wyceny (vs 8 min)</div>
-          </div>
-          <div class="razdwa-stat">
             <div class="razdwa-stat-num">0 IT</div>
-            <div class="razdwa-stat-label">wymagane do utrzymania (PWA)</div>
+            <div class="razdwa-stat-label">obsługa po stronie drukarni (PWA)</div>
           </div>
         </div>
       </div>
@@ -541,18 +541,18 @@
           </div>
           <div class="ux-decision-box">
             <div class="ux-label">Problem → Rozwiązanie</div>
-            <h4>Immediate price feedback</h4>
-            <p>Cena aktualizuje się natychmiast przy zmianie jakiegokolwiek parametru — bez zbędnego klikania przycisku "Przelicz".</p>
+            <h4>Cena na żywo</h4>
+            <p>Cena aktualizuje się natychmiast przy zmianie dowolnego parametru — bez zbędnego klikania przycisku „Przelicz".</p>
           </div>
           <div class="ux-decision-box">
             <div class="ux-label">Problem → Rozwiązanie</div>
-            <h4>Toasty zamiast modali</h4>
-            <p>Pop-upy i modale blokowały flow pracy. Zastąpiono je subtelnymi toastami informacyjnymi w rogu ekranu.</p>
+            <h4>Powiadomienia zamiast okien</h4>
+            <p>Wyskakujące okna i modale przerywały pracę. Zastąpiłem je subtelnymi powiadomieniami w rogu ekranu.</p>
           </div>
           <div class="ux-decision-box">
             <div class="ux-label">Problem → Rozwiązanie</div>
-            <h4>PWA offline ready</h4>
-            <p>Brak serwera? Żaden problem. Drukarnia instaluje aplikację przez Chrome jako osobną ikonę na pulpit, gotową do pracy offline.</p>
+            <h4>Działa offline jako PWA</h4>
+            <p>Brak serwera, brak problemu z internetem. Drukarnia instaluje aplikację z poziomu przeglądarki jako osobną ikonę na pulpicie i pracuje na niej także bez sieci.</p>
           </div>
         </div>
       </div>

--- a/uslugi.html
+++ b/uslugi.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Marka + Strona, które sprzedają. Od logo po pełnofunkcjonalną stronę internetową z automatyzacjami. Wybierz pakiet dostosowany do Twoich potrzeb. Przejrzysty cennik, bezpłatna konsultacja.">
+  <meta name="description" content="Usługi Karola Wyszyńskiego — Digital Product Designer. Projektowanie i wdrażanie produktów cyfrowych, automatyzacje procesów biznesowych, analiza i usprawnienia procesów. Współpraca od 8 000 zł.">
   <meta name="theme-color" content="#06b6d4">
-  <title>Usługi – Karol Wyszyński | Pakiety UX/UI Design & Branding</title>
+  <title>Usługi – Karol Wyszyński | Produkty cyfrowe, automatyzacje, procesy</title>
 
   <!-- Canonical -->
   <link rel="canonical" href="https://kwyszynski.pl/uslugi.html" />
@@ -13,16 +13,16 @@
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://kwyszynski.pl/uslugi.html" />
-  <meta property="og:title" content="Usługi – Karol Wyszyński | Pakiety UX/UI Design & Branding" />
-  <meta property="og:description" content="Marka + Strona, które sprzedają. Od logo po pełnofunkcjonalną stronę internetową z automatyzacjami. Przejrzysty cennik, bezpłatna konsultacja." />
+  <meta property="og:title" content="Usługi – Karol Wyszyński | Produkty cyfrowe, automatyzacje, procesy" />
+  <meta property="og:description" content="Projektowanie i wdrażanie produktów cyfrowych, automatyzacje procesów biznesowych, analiza i usprawnienia procesów. Współpraca od 8 000 zł." />
   <meta property="og:image" content="https://kwyszynski.pl/assets/images/android-chrome-512x512.png" />
   <meta property="og:locale" content="pl_PL" />
-  <meta property="og:site_name" content="Karol Wyszyński – UX/UI Designer" />
+  <meta property="og:site_name" content="Karol Wyszyński – Digital Product Designer" />
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Usługi – Karol Wyszyński | Pakiety UX/UI Design & Branding" />
-  <meta name="twitter:description" content="Marka + Strona, które sprzedają. Od logo po pełnofunkcjonalną stronę internetową z automatyzacjami. Przejrzysty cennik, bezpłatna konsultacja." />
+  <meta name="twitter:title" content="Usługi – Karol Wyszyński | Produkty cyfrowe, automatyzacje, procesy" />
+  <meta name="twitter:description" content="Projektowanie i wdrażanie produktów cyfrowych, automatyzacje procesów biznesowych, analiza i usprawnienia procesów. Współpraca od 8 000 zł." />
   <meta name="twitter:image" content="https://kwyszynski.pl/assets/images/android-chrome-512x512.png" />
 
   <!-- JSON-LD -->
@@ -30,20 +30,21 @@
   {
     "@context": "https://schema.org",
     "@type": "Service",
-    "name": "Usługi UX/UI Design i Branding",
+    "name": "Projektowanie i wdrażanie produktów cyfrowych, automatyzacji i usprawnień procesów",
     "provider": {
       "@type": "Person",
       "name": "Karol Wyszyński",
       "url": "https://kwyszynski.pl"
     },
+    "areaServed": "PL",
     "offers": [
-      {"@type": "Offer", "name": "CORE – Logo + identyfikacja wizualna", "price": "2500", "priceCurrency": "PLN"},
-      {"@type": "Offer", "name": "GROW – Marka + strona internetowa", "price": "4500", "priceCurrency": "PLN"},
-      {"@type": "Offer", "name": "MASTER – Kompletny pakiet z automatyzacjami", "price": "7500", "priceCurrency": "PLN"}
+      {"@type": "Offer", "name": "Produkty cyfrowe — aplikacje i strony", "priceCurrency": "PLN", "price": "8000", "priceSpecification": {"@type": "PriceSpecification", "minPrice": "8000", "priceCurrency": "PLN"}},
+      {"@type": "Offer", "name": "Automatyzacje procesów", "priceCurrency": "PLN", "price": "8000", "priceSpecification": {"@type": "PriceSpecification", "minPrice": "8000", "priceCurrency": "PLN"}},
+      {"@type": "Offer", "name": "Analiza i usprawnienia procesów", "priceCurrency": "PLN", "price": "8000", "priceSpecification": {"@type": "PriceSpecification", "minPrice": "8000", "priceCurrency": "PLN"}}
     ]
   }
   </script>
-  
+
   <!-- Favicon Setup -->
   <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
   <link rel="icon" type="image/png" sizes="16x16" href="assets/images/favicon-16x16.png">
@@ -51,12 +52,12 @@
   <link rel="apple-touch-icon" sizes="180x180" href="assets/images/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="192x192" href="assets/images/android-chrome-192x192.png">
   <link rel="icon" type="image/png" sizes="512x512" href="assets/images/android-chrome-512x512.png">
-  
+
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet" />
-  
+
   <!-- Main CSS -->
   <link rel="stylesheet" href="assets/css/index-styles.css" />
   <link rel="stylesheet" href="assets/css/services-page.css" />
@@ -91,300 +92,241 @@
     <div class="container">
       <div class="hero-content">
         <span class="hero-badge">Usługi</span>
-        <h1 class="hero-title">Marka + Strona, które sprzedają</h1>
+        <h1 class="hero-title">Projektuję i wdrażam rozwiązania cyfrowe, które porządkują pracę w firmie</h1>
         <p class="hero-subtitle">
-          Od logo po pełnofunkcjonalną stronę internetową z automatyzacjami. 
-          Wybierz pakiet dostosowany do Twoich potrzeb i etapu biznesu.
+          Aplikacje, strony i automatyzacje — od analizy procesu po działający produkt.
+          Nie pakiety z półki, tylko projekty wyceniane pod konkretny zakres.
         </p>
-        
-        <!-- Trust Signals in Hero -->
+
+        <!-- Sygnały zaufania -->
         <div class="hero-benefits" role="list">
           <span role="listitem">
             <svg width="18" height="18" viewBox="0 0 20 20" fill="none" aria-hidden="true">
               <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            Przejrzysty cennik
+            Współpraca od 8 000 zł
           </span>
           <span role="listitem">
             <svg width="18" height="18" viewBox="0 0 20 20" fill="none" aria-hidden="true">
               <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            Bezpłatna konsultacja
+            Projekt + wdrożenie w jednym ręku
           </span>
           <span role="listitem">
             <svg width="18" height="18" viewBox="0 0 20 20" fill="none" aria-hidden="true">
               <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            Support w toku projektu
+            Wsparcie po starcie
           </span>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- ========== PACKAGE GUIDE (NEW) ========== -->
-  <section class="package-guide" aria-labelledby="guide-title">
+  <!-- ========== TRZY OBSZARY ========== -->
+  <section class="services-pricing" aria-labelledby="areas-title">
     <div class="container">
-      <h2 class="section-title" id="guide-title">Nie wiesz, od czego zacząć?</h2>
-      <p class="section-subtitle">Odpowiedz sobie na 3 proste pytania i znajdź idealny pakiet</p>
-      
-      <div class="guide-cards">
-        <!-- Question 1 -->
-        <div class="guide-card">
-          <div class="guide-number">1</div>
-          <h3>Czy masz już stronę?</h3>
-          <div class="guide-options">
-            <div class="guide-option">
-              <span class="option-label">Nie</span>
-              <p class="option-answer">→ Zacznij od <strong>CORE</strong></p>
-            </div>
-            <div class="guide-option">
-              <span class="option-label">Tak, ale słaba</span>
-              <p class="option-answer">→ Potrzebujesz <strong>MASTER</strong></p>
-            </div>
-          </div>
-        </div>
-        
-        <!-- Question 2 -->
-        <div class="guide-card">
-          <div class="guide-number">2</div>
-          <h3>Chcesz sprzedawać online?</h3>
-          <div class="guide-options">
-            <div class="guide-option">
-              <span class="option-label">Tak</span>
-              <p class="option-answer">→ <strong>MASTER</strong> z WooCommerce</p>
-            </div>
-            <div class="guide-option">
-              <span class="option-label">Nie</span>
-              <p class="option-answer">→ <strong>CORE</strong> wystarczy</p>
-            </div>
-          </div>
-        </div>
-        
-        <!-- Question 3 -->
-        <div class="guide-card">
-          <div class="guide-number">3</div>
-          <h3>Masz już logo/markę?</h3>
-          <div class="guide-options">
-            <div class="guide-option">
-              <span class="option-label">Tak</span>
-              <p class="option-answer">→ Zaoszczędzisz 1000 zł 💰</p>
-            </div>
-            <div class="guide-option">
-              <span class="option-label">Nie</span>
-              <p class="option-answer">→ Wliczamy w pakiet</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
+      <h2 class="section-title" id="areas-title">Trzy obszary, w których pomagam</h2>
+      <p class="section-subtitle">Każdy projekt zaczyna się od rozmowy o procesie i kończy działającym rozwiązaniem</p>
 
-  <!-- ========== PRICING SECTION ========== -->
-  <section class="services-pricing" aria-labelledby="pricing-title">
-    <div class="container">
-      <h2 class="section-title" id="pricing-title">Twój plan inwestycji</h2>
-      <p class="section-subtitle">Transparentne ceny bez ukrytych kosztów</p>
-      
       <div class="pricing-grid">
-        
-        <!-- Package 1: Brand Start -->
-        <div class="pricing-card" id="brand-start-card">
-          <div class="card-header">
-            <div class="card-icon" aria-hidden="true">🎯</div>
-            <h3 class="card-title">CORE</h3>
-            <p class="card-subtitle">Logo + identyfikacja wizualna</p>
-          </div>
-          
-          <div class="card-pricing">
-            <span class="price-label">od</span>
-            <span class="price-amount">2500 <span class="currency">zł</span></span>
-          </div>
-          
-          <div class="card-features">
-            <ul aria-label="Charakterystyka pakietu CORE">
-              <li>
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Projekt unikalnego logo (3 propozycje)
-              </li>
-              <li>
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Definicja kolorystyki i typografii marki
-              </li>
-              <li>
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Projekt wizytówki i materiałów firmowych
-              </li>
-              <li>
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Mini brand book (księga znaku)
-              </li>
-              <li>
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                30-dniowe wsparcie po zakończeniu
-              </li>
-            </ul>
-          </div>
-          
-          <div class="card-meta">
-            <span class="meta-item">
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/>
-                <path d="M8 4v4l2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-              </svg>
-              <time datetime="P3W">3-5 tygodni</time>
-            </span>
-          </div>
-          
-          <a href="#brand-start" class="card-btn btn-secondary" data-package="brand-start">
-            Szczegóły pakietu
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-              <path d="M6 2L12 8L6 14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </a>
-        </div>
 
-        <!-- Package 2: CORE (POPULAR) -->
-        <div class="pricing-card featured" id="digital-boost-card">
-          <div class="popular-badge">
-            Najpopularniejsze
-            <span class="badge-meta">215+ projektów</span>
-          </div>
-          
+        <!-- Obszar 1: Produkty cyfrowe -->
+        <div class="pricing-card" id="produkty-cyfrowe-card">
           <div class="card-header">
             <div class="card-icon" aria-hidden="true">💻</div>
-            <h3 class="card-title">GROW</h3>
-            <p class="card-subtitle">Marka + strona internetowa</p>
+            <h3 class="card-title">Produkty cyfrowe</h3>
+            <p class="card-subtitle">Aplikacje i strony projektowane pod proces</p>
           </div>
-          
+
           <div class="card-pricing">
             <span class="price-label">od</span>
-            <span class="price-amount">4500 <span class="currency">zł</span></span>
+            <span class="price-amount">8 000 <span class="currency">zł</span></span>
           </div>
-          
+
           <div class="card-features">
-            <ul aria-label="Charakterystyka pakietu GROW">
+            <ul aria-label="Co obejmuje obszar Produkty cyfrowe">
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                <strong>Wszystko z pakietu CORE</strong>
+                Aplikacje webowe pod konkretny proces
               </li>
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                Projekt i wdrożenie strony WWW (do 5 podstron)
+                Strony internetowe — od prezentacyjnych po z integracjami
               </li>
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                Optymalizacja konwersji i SEO
+                Sklepy i systemy zamówień (WordPress, WooCommerce)
               </li>
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                Integracja z mediami społecznościowymi
+                Architektura informacji, projekt interfejsu, wdrożenie
               </li>
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                90-dniowe wsparcie techniczne
+                Wsparcie po starcie i dopracowanie w praktyce
               </li>
             </ul>
           </div>
-          
+
           <div class="card-meta">
             <span class="meta-item">
               <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
                 <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/>
                 <path d="M8 4v4l2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
               </svg>
-              <time datetime="P6W">6-8 tygodni</time>
+              <time datetime="P4M">Większe projekty: 4–5 miesięcy</time>
             </span>
           </div>
-          
-          <a href="index.html#contact" class="card-btn btn-primary" data-package="digital-boost">
-            Zarezerwuj konsultację
+
+          <a href="#produkty-cyfrowe" class="card-btn btn-secondary" data-area="produkty">
+            Szczegóły obszaru
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
               <path d="M6 2L12 8L6 14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
           </a>
         </div>
 
-        <!-- Package 3: MASTER -->
-        <div class="pricing-card" id="business-pro-card">
-          <div class="card-header">
-            <div class="card-icon" aria-hidden="true">🚀</div>
-            <h3 class="card-title">MASTER</h3>
-            <p class="card-subtitle">Kompletny pakiet z automatyzacjami</p>
+        <!-- Obszar 2: Automatyzacje (najczęściej wybierane) -->
+        <div class="pricing-card featured" id="automatyzacje-card">
+          <div class="popular-badge">
+            Najczęściej wybierane
           </div>
-          
+
+          <div class="card-header">
+            <div class="card-icon" aria-hidden="true">⚙️</div>
+            <h3 class="card-title">Automatyzacje procesów</h3>
+            <p class="card-subtitle">Z ręcznej roboty do działającego automatu</p>
+          </div>
+
           <div class="card-pricing">
             <span class="price-label">od</span>
-            <span class="price-amount">7500 <span class="currency">zł</span></span>
+            <span class="price-amount">8 000 <span class="currency">zł</span></span>
           </div>
-          
+
           <div class="card-features">
-            <ul aria-label="Charakterystyka pakietu MASTER">
+            <ul aria-label="Co obejmuje obszar Automatyzacje procesów">
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                <strong>Wszystko z pakietu GROW</strong>
+                Automatyzacje w Google Apps Script i arkuszach
               </li>
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                Sklep WooCommerce lub system rezerwacji online
+                Integracje między systemami, bazami i plikami
               </li>
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                Automatyzacje marketingowe (newsletter, sekwencje mailowe)
+                Kalkulatory i konfiguratory na realnej logice biznesowej
               </li>
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                Google Analytics 4 z celami konwersji
+                Skrócenie powtarzalnych zadań nawet o ponad 90%
               </li>
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                6-miesięczne wsparcie i konsultacje
+                Testowanie i wdrożenie w realnym środowisku pracy
               </li>
             </ul>
           </div>
-          
+
           <div class="card-meta">
             <span class="meta-item">
               <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
                 <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/>
                 <path d="M8 4v4l2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
               </svg>
-              <time datetime="P12W">8-12 tygodni</time>
+              <time>Realny efekt: z godziny do kilku minut</time>
             </span>
           </div>
-          
-          <a href="index.html#contact" class="card-btn btn-secondary" data-package="business-pro">
-            Zarezerwuj konsultację
+
+          <a href="#automatyzacje" class="card-btn btn-primary" data-area="automatyzacje">
+            Szczegóły obszaru
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M6 2L12 8L6 14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </a>
+        </div>
+
+        <!-- Obszar 3: Usprawnienia procesów -->
+        <div class="pricing-card" id="usprawnienia-card">
+          <div class="card-header">
+            <div class="card-icon" aria-hidden="true">🎯</div>
+            <h3 class="card-title">Usprawnienia procesów</h3>
+            <p class="card-subtitle">Analiza i porządkowanie tego, co dziś działa „jakoś"</p>
+          </div>
+
+          <div class="card-pricing">
+            <span class="price-label">od</span>
+            <span class="price-amount">8 000 <span class="currency">zł</span></span>
+          </div>
+
+          <div class="card-features">
+            <ul aria-label="Co obejmuje obszar Usprawnienia procesów">
+              <li>
+                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                Analiza procesu i wskazanie wąskich gardeł
+              </li>
+              <li>
+                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                Projekt nowego przebiegu pracy lub narzędzia
+              </li>
+              <li>
+                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                Decyzja: aplikacja, automat, skrypt czy zmiana sposobu pracy
+              </li>
+              <li>
+                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                Wdrożenie zmian razem z zespołem
+              </li>
+              <li>
+                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                Mniej błędów, większa przewidywalność, mniej „ratowania"
+              </li>
+            </ul>
+          </div>
+
+          <div class="card-meta">
+            <span class="meta-item">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/>
+                <path d="M8 4v4l2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+              </svg>
+              <time>Zakres ustalany po analizie</time>
+            </span>
+          </div>
+
+          <a href="#usprawnienia" class="card-btn btn-secondary" data-area="usprawnienia">
+            Szczegóły obszaru
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
               <path d="M6 2L12 8L6 14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
@@ -394,96 +336,96 @@
     </div>
   </section>
 
-  <!-- ========== DETAILED PACKAGE DESCRIPTIONS ========== -->
+  <!-- ========== SZCZEGÓŁY OBSZARÓW ========== -->
   <section class="package-details" aria-labelledby="details-title">
     <div class="container">
-      <h2 class="section-title" id="details-title">Poznaj szczegóły każdego pakietu</h2>
-      
-      <div class="details-grid">
-        <!-- Package 1: Brand Start -->
-        <div class="detail-card" id="brand-start">
-          <div class="detail-header">
-            <div class="detail-icon" aria-hidden="true">🎯</div>
-            <h3>CORE</h3>
-            <p class="detail-tagline">Logo + identyfikacja wizualna</p>
-          </div>
-          
-          <div class="detail-section">
-            <h4>Dla kogo jest ten pakiet?</h4>
-            <p>To idealne rozwiązanie dla startujących firm, marek osobistych i każdego, kto potrzebuje profesjonalnego wizerunku na start. Jeśli zaczynasz i chcesz od razu wyglądać wiarygodnie, to pakiet dla Ciebie.</p>
-          </div>
-          
-          <div class="detail-section">
-            <h4>Co dokładnie otrzymujesz?</h4>
-            <p>W ramach tego pakietu przeprowadzam z Tobą warsztat strategiczny, na bazie którego projektuję 3 propozycje logo. Po wybraniu finalnej wersji, tworzę kompletną mini-księgę znaku: definiuję paletę kolorów, dobieram fonty i projektuję materiały firmowe. Masz solidny fundament do dalszych działań.</p>
-          </div>
-          
-          <div class="detail-benefits">
-            <h4>Główne korzyści:</h4>
-            <ul>
-              <li>Spójny wizerunek od pierwszego dnia</li>
-              <li>Wiarygodność i profesjonalizm</li>
-              <li>Materiały gotowe do użytku</li>
-              <li>Elastyczne rozwinięcie w przyszłości</li>
-            </ul>
-          </div>
-        </div>
+      <h2 class="section-title" id="details-title">Co konkretnie robię w każdym obszarze</h2>
 
-        <!-- Package 2: CORE -->
-        <div class="detail-card featured" id="digital-boost">
-          <div class="popular-badge-detail">Najczęściej wybierany</div>
+      <div class="details-grid">
+        <!-- Obszar 1 -->
+        <div class="detail-card" id="produkty-cyfrowe">
           <div class="detail-header">
             <div class="detail-icon" aria-hidden="true">💻</div>
-            <h3>GROW</h3>
-            <p class="detail-tagline">Marka + strona internetowa</p>
+            <h3>Produkty cyfrowe</h3>
+            <p class="detail-tagline">Aplikacje i strony projektowane pod proces</p>
           </div>
-          
+
           <div class="detail-section">
-            <h4>Dla kogo jest ten pakiet?</h4>
-            <p>Dla firm, które chcą mocno zaistnieć w internecie lub których obecna strona internetowa nie przynosi klientów. Jeśli Twoja marka jest gotowa, ale potrzebujesz cyfrowego 'silnika', który będzie generował zapytania – to jest to.</p>
+            <h4>Dla kogo</h4>
+            <p>Dla firm, które potrzebują narzędzia dopasowanego do tego, jak realnie pracują — nie kolejnego szablonu. Najczęściej są to firmy, które dziś używają arkuszy, plików i kilku oderwanych systemów, a chcą mieć jedno, spójne rozwiązanie.</p>
           </div>
-          
+
           <div class="detail-section">
-            <h4>Co dokładnie otrzymujesz?</h4>
-            <p>Otrzymujesz wszystko z pakietu CORE ORAZ w pełni funkcjonalną, responsywną stronę internetową na WordPress. Projektuję ją w oparciu o strategię UX, aby prowadziła użytkownika prosto do celu (konwersji). Wdrażam podstawową analitykę, optymalizuję stronę pod SEO i zapewniam wsparcie techniczne.</p>
+            <h4>Co dokładnie robię</h4>
+            <p>Zaczynam od rozmowy o procesie i ludziach, którzy z niego korzystają. Projektuję strukturę produktu, interfejs i logikę działania. Buduję rozwiązanie, integruję je z tym, co już macie, i testuję ręcznie w realnych scenariuszach. Zostaję na tyle blisko, żeby wesprzeć pierwsze tygodnie użycia.</p>
           </div>
-          
+
           <div class="detail-benefits">
-            <h4>Główne korzyści:</h4>
+            <h4>Co zyskujesz</h4>
             <ul>
-              <li>Strona, która generuje zapytania</li>
-              <li>Pojawianie się w wynikach Google</li>
-              <li>Profesjonalna strona na mobilach</li>
-              <li>Wsparcie przez 90 dni</li>
+              <li>Narzędzie dopasowane do realnego procesu, nie odwrotnie</li>
+              <li>Spójność: jeden produkt zamiast pięciu oderwanych plików</li>
+              <li>Wdrożenie do końca, bez „dokończymy potem"</li>
+              <li>Wsparcie w pierwszych tygodniach użycia</li>
             </ul>
           </div>
         </div>
 
-        <!-- Package 3: MASTER -->
-        <div class="detail-card" id="business-pro">
+        <!-- Obszar 2 -->
+        <div class="detail-card featured" id="automatyzacje">
+          <div class="popular-badge-detail">Największa różnica w czasie pracy</div>
           <div class="detail-header">
-            <div class="detail-icon" aria-hidden="true">🚀</div>
-            <h3>MASTER</h3>
-            <p class="detail-tagline">Kompletny pakiet z automatyzacjami</p>
+            <div class="detail-icon" aria-hidden="true">⚙️</div>
+            <h3>Automatyzacje procesów</h3>
+            <p class="detail-tagline">Z ręcznej roboty do działającego automatu</p>
           </div>
-          
+
           <div class="detail-section">
-            <h4>Dla kogo jest ten pakiet?</h4>
-            <p>To kompletne rozwiązanie dla rozwiniętych biznesów, które chcą skalować sprzedaż, automatyzować procesy i podejmować decyzje w oparciu o twarde dane. Idealne dla sklepów e-commerce i firm usługowych gotowych na szybki wzrost.</p>
+            <h4>Dla kogo</h4>
+            <p>Dla firm, w których ten sam zestaw kroków powtarza się codziennie albo co tydzień: liczenie ofert, przygotowywanie plików, wprowadzanie danych, generowanie raportów. Tam, gdzie ktoś od miesięcy mówi „przydałby się skrypt".</p>
           </div>
-          
+
           <div class="detail-section">
-            <h4>Co dokładnie otrzymujesz?</h4>
-            <p>Otrzymujesz pełny pakiet GROW, rozbudowany o sklep WooCommerce lub system rezerwacji online. Konfiguruję automatyzacje marketingowe (np. odzyskiwanie porzuconych koszyków, newsletter), wdrażam zaawansowaną analitykę (Google Analytics 4 z celami) i zapewniam priorytetowe wsparcie.</p>
+            <h4>Co dokładnie robię</h4>
+            <p>Rozbieram proces na czynniki pierwsze, identyfikuję miejsca, które naprawdę można zautomatyzować, i piszę rozwiązanie (najczęściej w Google Apps Script, w połączeniu z arkuszami, bazami danych i plikami). Najmocniejszy zrealizowany przykład: aplikacja dla drukarni, która skróciła proces wyceny z około godziny do około 5 minut. Inny — przygotowanie dużej liczby plików z godziny do około 1,5 minuty.</p>
           </div>
-          
+
           <div class="detail-benefits">
-            <h4>Główne korzyści:</h4>
+            <h4>Co zyskujesz</h4>
             <ul>
-              <li>Automatyczna sprzedaż 24/7</li>
-              <li>Lejek marketingowy w pełni funkcjonalny</li>
-              <li>Decyzje oparte na danych</li>
-              <li>Wsparcie przez 6 miesięcy</li>
+              <li>Realne godziny pracy odzyskane co tydzień</li>
+              <li>Mniej błędów wynikających ze zmęczenia i ręcznego przepisywania</li>
+              <li>Przewidywalność: ten sam proces, ten sam wynik</li>
+              <li>Rozwiązanie wpisane w realne narzędzia, których już używacie</li>
+            </ul>
+          </div>
+        </div>
+
+        <!-- Obszar 3 -->
+        <div class="detail-card" id="usprawnienia">
+          <div class="detail-header">
+            <div class="detail-icon" aria-hidden="true">🎯</div>
+            <h3>Usprawnienia procesów</h3>
+            <p class="detail-tagline">Analiza i porządkowanie tego, co dziś działa „jakoś"</p>
+          </div>
+
+          <div class="detail-section">
+            <h4>Dla kogo</h4>
+            <p>Dla firm, które wiedzą, że coś nie działa, ale nie do końca wiedzą co. Najczęściej okazuje się, że odpowiedzią nie jest „kolejny system", tylko zmiana w samym przebiegu pracy — albo mały, dobrze zaprojektowany element, który porządkuje resztę.</p>
+          </div>
+
+          <div class="detail-section">
+            <h4>Co dokładnie robię</h4>
+            <p>Wchodzę głęboko w proces: rozmawiam z ludźmi, którzy go wykonują, sprawdzam realne narzędzia i dane. Pokazuję, gdzie tracony jest czas i pojawiają się błędy. Proponuję rozwiązanie — czasem to aplikacja, czasem prosty skrypt, czasem zmiana w sposobie pracy, której nie da się kupić w pudełku. I wdrażam to razem z zespołem.</p>
+          </div>
+
+          <div class="detail-benefits">
+            <h4>Co zyskujesz</h4>
+            <ul>
+              <li>Diagnoza, która pokazuje, gdzie naprawdę leży problem</li>
+              <li>Rozwiązanie dopasowane do tego, a nie do mody</li>
+              <li>Wdrożenie, a nie tylko raport na półkę</li>
+              <li>Spójniejszy, mniej awaryjny proces w codziennej pracy</li>
             </ul>
           </div>
         </div>
@@ -491,126 +433,101 @@
     </div>
   </section>
 
-  <!-- ========== SERVICE SCOPE ========== -->
+  <!-- ========== ZAKRES USŁUG ========== -->
   <section class="service-scope" aria-labelledby="scope-title">
     <div class="container">
-      <h2 class="section-title" id="scope-title">Szczegółowy zakres usług</h2>
-      <p class="section-subtitle">Co wchodzi w skład każdego pakietu</p>
-      
+      <h2 class="section-title" id="scope-title">Co dokładnie robię w projekcie</h2>
+      <p class="section-subtitle">Pełen zakres prac, z których składa się większość moich projektów</p>
+
       <div class="scope-grid">
         <div class="scope-column">
-          <div class="scope-icon" aria-hidden="true">🎨</div>
-          <h3>Branding i Identyfikacja Wizualna</h3>
+          <div class="scope-icon" aria-hidden="true">🔍</div>
+          <h3>Analiza i projekt</h3>
           <ul>
-            <li>Warsztat strategiczny i analiza rynku</li>
-            <li>Projektowanie logo (3 propozycje)</li>
-            <li>Dobór kolorystyki i typografii</li>
-            <li>Materiały firmowe (wizytówki, papiery)</li>
-            <li>Księga znaku (Brand Book)</li>
-            <li>Strategia komunikacji wizualnej</li>
+            <li>Rozmowa o procesie i celach biznesowych</li>
+            <li>Identyfikacja wąskich gardeł i ryzyk</li>
+            <li>Architektura informacji i przebieg użytkownika</li>
+            <li>Projekt interfejsu (UI) i doświadczenia (UX)</li>
+            <li>Decyzje o stosie technologicznym pod realny zakres</li>
+            <li>Plan wdrożenia rozpisany na etapy</li>
           </ul>
         </div>
-        
+
         <div class="scope-column">
-          <div class="scope-icon" aria-hidden="true">💻</div>
-          <h3>Strony Internetowe</h3>
+          <div class="scope-icon" aria-hidden="true">🛠️</div>
+          <h3>Budowa i integracje</h3>
           <ul>
-            <li>Badania użytkowników i wireframing</li>
-            <li>Projektowanie UX/UI (makiety, prototypy)</li>
-            <li>Responsywne strony na WordPress</li>
-            <li>Optymalizacja pod kątem SEO</li>
-            <li>Optymalizacja szybkości ładowania</li>
-            <li>Integracja z Google Analytics 4</li>
+            <li>Strony internetowe i sklepy na WordPress / WooCommerce</li>
+            <li>Aplikacje webowe pod konkretny proces</li>
+            <li>Automatyzacje w Google Apps Script</li>
+            <li>Integracje z arkuszami, bazami i plikami</li>
+            <li>Kalkulatory, konfiguratory i formularze biznesowe</li>
+            <li>Optymalizacja pod szybkość i podstawowe SEO</li>
           </ul>
         </div>
-        
+
         <div class="scope-column">
-          <div class="scope-icon" aria-hidden="true">⚙️</div>
-          <h3>Automatyzacje Biznesowe</h3>
+          <div class="scope-icon" aria-hidden="true">🚀</div>
+          <h3>Wdrożenie i wsparcie</h3>
           <ul>
-            <li>Wdrożenia e-commerce (WooCommerce)</li>
-            <li>Systemy rezerwacji online</li>
-            <li>Automatyzacja marketingu (Mailingi)</li>
-            <li>Integracje z systemami CRM</li>
-            <li>Lejek sprzedażowy i lead generation</li>
-            <li>Raporty i analiza danych</li>
+            <li>Testy ręczne w realnych scenariuszach</li>
+            <li>Uruchomienie produkcyjne i przekazanie</li>
+            <li>Szkolenie zespołu z obsługi nowego narzędzia</li>
+            <li>Dopracowanie na podstawie pierwszych tygodni użycia</li>
+            <li>Wsparcie po starcie i drobne zmiany</li>
+            <li>Dokumentacja kluczowych elementów rozwiązania</li>
           </ul>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- ========== COMPARISON TABLE ========== -->
-  <section class="services-comparison" aria-labelledby="comparison-title">
+  <!-- ========== JAK WYGLĄDA WSPÓŁPRACA ========== -->
+  <section class="services-comparison" aria-labelledby="how-title">
     <div class="container">
-      <h2 class="section-title" id="comparison-title">Porównanie pakietów</h2>
-      <p class="section-subtitle">Zobacz dokładnie, co zawiera każdy pakiet</p>
-      
+      <h2 class="section-title" id="how-title">Jak wygląda współpraca</h2>
+      <p class="section-subtitle">Od pierwszej rozmowy do działającego rozwiązania — w sześciu krokach</p>
+
       <div class="comparison-table-wrapper">
         <table class="comparison-table">
-          <caption>Porównanie cech i funkcjonalności pakietów usług</caption>
+          <caption>Etapy współpracy nad projektem</caption>
           <thead>
             <tr>
-              <th scope="col">Funkcjonalność</th>
-              <th scope="col">CORE</th>
-              <th scope="col" class="highlighted">GROW</th>
-              <th scope="col">MASTER</th>
+              <th scope="col">Etap</th>
+              <th scope="col">Co dzieje się na tym etapie</th>
+              <th scope="col">Po Twojej stronie</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td><strong>Projekt logo</strong></td>
-              <td><span class="check" aria-label="zawiera">✓</span></td>
-              <td class="highlighted"><span class="check" aria-label="zawiera">✓</span></td>
-              <td><span class="check" aria-label="zawiera">✓</span></td>
+              <td><strong>1. Rozmowa wstępna</strong></td>
+              <td>Sprawdzamy, czy projekt ma sens i czy się pasujemy. Bez zobowiązań.</td>
+              <td>30–60 minut rozmowy</td>
             </tr>
             <tr>
-              <td><strong>Identyfikacja wizualna</strong></td>
-              <td><span class="check" aria-label="zawiera">✓</span></td>
-              <td class="highlighted"><span class="check" aria-label="zawiera">✓</span></td>
-              <td><span class="check" aria-label="zawiera">✓</span></td>
+              <td><strong>2. Analiza procesu</strong></td>
+              <td>Wchodzę w proces, rozmawiam z osobami, które go wykonują, identyfikuję wąskie gardła.</td>
+              <td>Dostęp do procesu i osób, które go znają</td>
             </tr>
             <tr>
-              <td><strong>Strona internetowa (5 podstron)</strong></td>
-              <td><span class="cross" aria-label="nie zawiera">—</span></td>
-              <td class="highlighted"><span class="check" aria-label="zawiera">✓</span></td>
-              <td><span class="check" aria-label="zawiera">✓</span></td>
+              <td><strong>3. Projekt rozwiązania</strong></td>
+              <td>Projektuję strukturę, interfejs i logikę działania. Tu zapadają kluczowe decyzje.</td>
+              <td>Decyzje akceptujące kierunek</td>
             </tr>
             <tr>
-              <td><strong>E-commerce / Rezerwacja</strong></td>
-              <td><span class="cross" aria-label="nie zawiera">—</span></td>
-              <td class="highlighted"><span class="cross" aria-label="nie zawiera">—</span></td>
-              <td><span class="check" aria-label="zawiera">✓</span></td>
+              <td><strong>4. Budowa</strong></td>
+              <td>Buduję rozwiązanie wraz z integracjami. Pokazuję działający produkt w iteracjach.</td>
+              <td>Informacja zwrotna w trakcie</td>
             </tr>
             <tr>
-              <td><strong>Automatyzacje marketingowe</strong></td>
-              <td><span class="cross" aria-label="nie zawiera">—</span></td>
-              <td class="highlighted"><span class="cross" aria-label="nie zawiera">—</span></td>
-              <td><span class="check" aria-label="zawiera">✓</span></td>
+              <td><strong>5. Testy</strong></td>
+              <td>Testuję wszystko ręcznie, w realnych scenariuszach, przed startem produkcyjnym.</td>
+              <td>Wsparcie w sprawdzeniu skrajnych przypadków</td>
             </tr>
             <tr>
-              <td><strong>Zaawansowana analityka</strong></td>
-              <td><span class="cross" aria-label="nie zawiera">—</span></td>
-              <td class="highlighted"><span class="cross" aria-label="nie zawiera">—</span></td>
-              <td><span class="check" aria-label="zawiera">✓</span></td>
-            </tr>
-            <tr>
-              <td><strong>Wsparcie po wdrożeniu</strong></td>
-              <td>30 dni</td>
-              <td class="highlighted">90 dni</td>
-              <td><strong>6 miesięcy</strong></td>
-            </tr>
-            <tr>
-              <td><strong>Czas realizacji</strong></td>
-              <td>3-5 tygodni</td>
-              <td class="highlighted">6-8 tygodni</td>
-              <td>8-12 tygodni</td>
-            </tr>
-            <tr class="price-row">
-              <td><strong>Cena</strong></td>
-              <td><strong>od 2500 zł</strong></td>
-              <td class="highlighted"><strong>od 4500 zł</strong></td>
-              <td><strong>od 7500 zł</strong></td>
+              <td><strong>6. Wdrożenie i wsparcie</strong></td>
+              <td>Uruchamiam rozwiązanie i wspieram pierwsze tygodnie użycia.</td>
+              <td>Wdrożenie zmian w codziennej pracy</td>
             </tr>
           </tbody>
         </table>
@@ -618,102 +535,53 @@
     </div>
   </section>
 
-  <!-- ========== TESTIMONIALS (NEW) ========== -->
-  <section class="services-testimonials" aria-labelledby="testimonials-title">
-    <div class="container">
-      <h2 class="section-title" id="testimonials-title">Co mówią klienci</h2>
-      <p class="section-subtitle">Ponad 215 zadowolonych projektów</p>
-      
-      <div class="testimonials-grid">
-        <div class="testimonial">
-          <div class="testimonial-rating" aria-label="Ocena: 5 gwiazdek">
-            <span aria-hidden="true">★★★★★</span>
-          </div>
-          <blockquote>
-            <p>"Strona, którą Karol stworzył, zwiększyła moje zapytania o 40% w pierwszy miesiąc. Najlepsza inwestycja w biznes!"</p>
-            <footer>
-              <strong>Anna M.</strong>
-              <span class="testimonial-role">Salon urody</span>
-            </footer>
-          </blockquote>
-        </div>
-        
-        <div class="testimonial">
-          <div class="testimonial-rating" aria-label="Ocena: 5 gwiazdek">
-            <span aria-hidden="true">★★★★★</span>
-          </div>
-          <blockquote>
-            <p>"Profesjonalizm od pierwszego kontaktu. Karol nie tylko projektuje, ale myśli o naszym biznesie. Polecam!"</p>
-            <footer>
-              <strong>Tomasz K.</strong>
-              <span class="testimonial-role">Agencja nieruchomości</span>
-            </footer>
-          </blockquote>
-        </div>
-        
-        <div class="testimonial">
-          <div class="testimonial-rating" aria-label="Ocena: 5 gwiazdek">
-            <span aria-hidden="true">★★★★★</span>
-          </div>
-          <blockquote>
-            <p>"Wsparcie po wdrożeniu było kluczowe. Zawsze miał czas na nasze pytania. Dziękuję!"</p>
-            <footer>
-              <strong>Katarzyna W.</strong>
-              <span class="testimonial-role">E-shop z odzieżą</span>
-            </footer>
-          </blockquote>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- ========== FAQ (NEW) ========== -->
+  <!-- ========== FAQ ========== -->
   <section class="services-faq" aria-labelledby="faq-title">
     <div class="container">
-      <h2 class="section-title" id="faq-title">Często zadawane pytania</h2>
-      
+      <h2 class="section-title" id="faq-title">Najczęstsze pytania o usługi</h2>
+
       <div class="faq-items">
         <details class="faq-item">
-          <summary>Czy mogę zmienić pakiet po jego wyborze?</summary>
-          <p>Absolutnie! Możesz skalować pakiet w każdej chwili. Wycenimy dokładnie dodatkowe funkcjonalności i dopasujemy harmonogram prac. Elastyczność to nasz standard.</p>
+          <summary>Dlaczego nie ma gotowych pakietów cenowych?</summary>
+          <p>Bo nie wierzę w pakiety z półki przy projektach, które realnie zmieniają sposób pracy w firmie. Każdy proces wygląda inaczej, każda firma ma inną gotowość na zmianę, każde rozwiązanie ma inny zakres. Dlatego pierwsza rozmowa jest po to, żeby zrozumieć, czego potrzebujesz — a wycena jest wtedy precyzyjna, a nie szacowana „na oko".</p>
         </details>
-        
+
         <details class="faq-item">
-          <summary>Jaki jest proces płatności?</summary>
-          <p>Standardowy schemat to: 30% zaliczki, 50% w trakcie projektu, 20% po wdrożeniu. Możliwe są również raty na zgodę obu stron. Chętnie omówimy warianty dostosowane do Twojej sytuacji.</p>
+          <summary>Od jakiego budżetu zaczynamy?</summary>
+          <p>Współpracę zaczynam od <strong>8 000 zł</strong>. To poziom, przy którym ma sens zrobić projekt dobrze: z analizą procesu, projektem, wdrożeniem i testami. Mniejsze, jednorazowe zlecenia po prostu nie są moją specjalizacją.</p>
         </details>
-        
+
         <details class="faq-item">
-          <summary>Czy mogę mieć wiele rewizji projektu?</summary>
-          <p>Tak! Każdy pakiet zawiera ustaloną liczbę rewizji. Dodatkowe rewizje wyceniamy odrębnie. Naszym celem jest, abyś był w 100% zadowolony z efektu.</p>
+          <summary>Jak długo trwa projekt?</summary>
+          <p>Większe projekty — aplikacja, strona z integracjami, automatyzacja kilku procesów — to zwykle <strong>4–5 miesięcy</strong>. Mniejsze usprawnienia kilka tygodni. Termin ustalam po analizie, na podstawie realnego zakresu.</p>
         </details>
-        
+
         <details class="faq-item">
-          <summary>Na jakim hostingu będzie moja strona?</summary>
-          <p>Rekomendujemy sprawdzonych hostingodawców (np. SiteGround, Kinsta). Strona będzie całkowicie Twoja. Możesz przenieść ją w każdym momencie lub zostać z nami na wsparciu technicznym.</p>
+          <summary>Pracujesz samodzielnie czy z zespołem?</summary>
+          <p>Prowadzę projekty samodzielnie — od analizy po wdrożenie. Tam, gdzie potrzebny jest dodatkowy specjalista, dobieram zaufaną osobę pod konkretny zakres. Korzystam też z narzędzi AI tam, gdzie realnie skracają pracę bez utraty jakości.</p>
         </details>
-        
+
         <details class="faq-item">
-          <summary>Czy strona będzie responsywna (mobilna)?</summary>
-          <p>Wszystkie nasze strony są w 100% responsywne. Testujemy na urządzeniach iPhone, Android, tablet i desktop. Google preferuje strony mobilne – my to gwarantujemy.</p>
+          <summary>Czy zostaję sam po wdrożeniu?</summary>
+          <p>Nie. Po starcie zostaję na tyle blisko, żeby wesprzeć pierwsze tygodnie użycia i dopracować to, co widać dopiero w praktyce. Dłuższe wsparcie ustalamy osobno, jeśli ma sens.</p>
         </details>
-        
+
         <details class="faq-item">
-          <summary>Ile czasu trwa projekt od podpisania umowy?</summary>
-          <p>Zależy od pakietu: CORE 3-5 tygodni, GROW 6-8 tygodni, MASTER 8-12 tygodni. Harmonogram ustalamy indywidualnie w zależności od Twoich potrzeb.</p>
+          <summary>Co jeśli nie wiem, czego dokładnie potrzebuję?</summary>
+          <p>To częsta sytuacja. Wtedy najlepiej zacząć od obszaru „Usprawnienia procesów" — od analizy, która pokaże, gdzie naprawdę leży problem i jakie rozwiązanie ma sens. Często okazuje się, że to nie jest to, o czym wszyscy myśleli na początku.</p>
         </details>
       </div>
     </div>
   </section>
 
-  <!-- ========== CTA SECTION ========== -->
+  <!-- ========== CTA ========== -->
   <section class="services-cta" aria-labelledby="cta-title">
     <div class="container">
       <div class="cta-content">
-        <h2 id="cta-title">Nie jesteś pewny, który pakiet wybrać?</h2>
-        <p>Pakiety to tylko punkt wyjścia. Jeśli Twoje potrzeby są inne, z chęcią przygotuję dla Ciebie indywidualną wycenę. Porozmawiajmy o Twoim projekcie – <strong>bez zobowiązań</strong>.</p>
+        <h2 id="cta-title">Masz proces, który zjada za dużo czasu?</h2>
+        <p>Pierwsza rozmowa nic nie kosztuje — sprawdzimy, czy w ogóle warto się brać i jaki obszar będzie najlepszym punktem wyjścia. Odpowiadam w ciągu 24 godzin.</p>
         <a href="index.html#contact" class="btn btn-primary btn-large">
-          Zarezerwuj bezpłatną konsultację
+          Porozmawiajmy o Twoim procesie
           <svg width="18" height="18" viewBox="0 0 20 20" fill="none" aria-hidden="true">
             <path d="M9.5 3.5h7v7m-7-7l7.5 7.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
@@ -728,10 +596,10 @@
       <div class="footer-content">
         <div class="footer-info">
           <h3>Karol Wyszyński</h3>
-          <p>Project Manager · UX/UI Designer</p>
+          <p>Digital Product Designer · Automatyzacje · Procesy</p>
           <p>Email: <a href="mailto:wyszynski.k@onet.pl" aria-label="Wyślij wiadomość do Karola">wyszynski.k@onet.pl</a></p>
         </div>
-        
+
         <div class="footer-links">
           <h4>Szybkie linki</h4>
           <ul>
@@ -741,18 +609,18 @@
             <li><a href="index.html#contact">Kontakt</a></li>
           </ul>
         </div>
-        
+
         <div class="footer-trust">
-          <h4>Gwarancje</h4>
+          <h4>Współpraca</h4>
           <ul>
-            <li>🔒 Bezpieczne transakcje</li>
-            <li>📋 Umowa stanowiąca</li>
-            <li>✓ 30-dniowa gwarancja</li>
+            <li>Próg projektu: od 8 000 zł</li>
+            <li>Większe projekty: 4–5 miesięcy</li>
+            <li>Projekt + wdrożenie w jednym ręku</li>
           </ul>
         </div>
       </div>
     </div>
-    
+
     <div class="footer-bottom">
       <div class="container">
         <p>&copy; 2025–2026 Karol Wyszyński. Wszystkie prawa zastrzeżone.</p>


### PR DESCRIPTION
## Co zmieniam

Repozycjonowanie strony z **Project Manager / UX-UI Designer** na **Digital Product Designer** z naciskiem na produkty cyfrowe, automatyzacje i usprawnienia procesów biznesowych. Wymiana żargonu PM-owego (RACI, WBS, sprinty, scope, deliverables, stakeholder review, kick-off, end-to-end delivery) na polskojęzyczny język spójny z bazą wiedzy klienta.

## Dlaczego

Klient wprost odrzucił narrację „Project Manager" jako główne pozycjonowanie (była mocno obecna w hero, procesie, kompetencjach, FAQ i CV-podobnych sekcjach). Chce komunikować się jako osoba projektująca i wdrażająca rozwiązania cyfrowe dla biznesu, z progiem współpracy 8 000 zł.

## Podstrony objęte zmianą

- `index.html` — hero, proces 6-krokowy po polsku, oferta 3-obszarowa zamiast pakietów CORE/GROW/MASTER, kompetencje „Co wnoszę do projektu", FAQ dla klientów, formularz z budżetami 8–30k+
- `omnie.html` — krótkie i długie bio, droga zawodowa bez fabrykowanych dat
- `uslugi.html` — pełna przebudowa: 3 obszary usług, etapy współpracy, FAQ usług
- `portfolio.html` — sekcja „O mnie" oczyszczona z wymyślonych elementów, ujednolicenie karty CyfraDruk
- `kontakt.html` — usunięcie fikcyjnego emaila i telefonu, ujednolicenie formularza
- `projects/razdwa_aplikacja.html` — korekta liczb do zgodności z bazą wiedzy, polszczenie decyzji UX

## Usunięte fabrykowane dane

- Certyfikaty: „Google Analytics 4 · UX Research · Agile PM (w trakcie)" (niepotwierdzone)
- Metodyki: „Agile · Scrum · Kanban · Design Thinking · Lean UX" (nie w bazie wiedzy)
- Branże: „Druk B2B · E-commerce · Wellness/Coaching · Design Services" → poligrafia i webdesign (zgodnie z CSV)
- Daty stanowisk 2016/2018/2022 z konkretnymi tytułami (CSV mówi tylko ~10 lat doświadczenia)
- Testimoniale: Anna M., Tomasz K., Katarzyna W. + „215+ projektów" (zmyślone)
- „30-dniowa gwarancja", „Umowa stanowiąca" — nie potwierdzone
- Pakiety CORE / GROW / MASTER 2500/4500/7500 zł — pod progiem współpracy 8 000 zł
- Email `kontakt@kwyszynski.pl` → `wyszynski.k@onet.pl` (jeden prawdziwy)
- Telefon `+48 123 456 789` (placeholder) — usunięty, zastąpiony LinkedIn-em
- Liczby case study Raz Dwa Druk: „8 min → 45 s" → „godzina → ok. 5 min" (zgodnie z CSV)

## Co zostaje bez zmian

- Karty projektów w portfolio (Karoma, Power of Mind, Sir Roger, KW Design, Raz Dwa Druk, CyfraDruk) — rzeczywiste realizacje
- Struktura sekcji i klasy CSS — bez modyfikacji styli
- Sekcja testimoniali na `index.html` — już była `display:none`, zostawiona

## Konflikt podczas rebase

Na zdalnej gałęzi była równoległa edycja `index.html` (hero eyebrow „Twój system zasługuje na to" + nagłówek „Intuicyjne rozwiązania i łatwa obłsuga"). Konflikt rozwiązany na korzyść wersji z tej sesji (Digital Product Designer · Automatyzacje · Procesy) — równoległa zmiana zawierała literówkę („obłsuga") i odbiegała od głównego kierunku repozycjonowania. Jeśli te alternatywne treści były świadomym kierunkiem, można je przywrócić w osobnym commicie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)