### PR TITLE
Ujednolicenie hero case studies pod wzorzec Raz Dwa

### DIFF
--- a/projects/KW-Design.html
+++ b/projects/KW-Design.html
@@ -1,25 +1,46 @@
   <!-- Case Study Content -->
-  <section class="kwcs" id="case-logo-marka-d" aria-label="Case Study: Logo Marka D">
+  <section class="kwcs" id="case-kw-design" aria-label="Case Study: KW Design — logo i identyfikacja wizualna">
 
-    <!-- HERO BODY z chipsami w kolumnie + mockup -->
+    <!-- Hero Head -->
+    <div class="kwcs-hero-head">
+      <div class="wrap">
+        <p class="eyebrow">Case Study · Logo i identyfikacja wizualna</p>
+        <h1>KW Design<br>autorska marka projektanta produktów cyfrowych</h1>
+        <p class="sub">
+          Logo, księga znaku i kompletna paczka plików — projekt znaku przeprowadzony od analizy i koncepcji po pełną dokumentację marki.
+        </p>
+        <div class="pm-hero-meta">
+          <span><strong>Rola</strong> Digital Product Designer</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Typ</strong> Logo · Księga znaku</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Wynik</strong> Spójna identyfikacja gotowa do wdrożenia</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- HERO BODY: chipsy w kolumnie + mockup -->
     <div class="kwcs-hero-body">
       <div class="wrap inner">
 
-        <!-- LEWA STRONA: pionowe chipy -->
         <div class="hero-content-grid">
           <div class="hero-buttons-vertical">
-            <a href="#zakres" class="kwcs-chip chip-zakres">
-              <b>Zakres</b><br>
+            <div class="kwcs-chip chip-zakres">
+              <strong>Zakres</strong><br>
               Logo, księga znaku, makiety, wdrożenie na stronę
-            </a>
-            <a href="#stack" class="kwcs-chip chip-stack">
-              <b>Narzędzia</b><br>
-              Adobe Illustrator, Photoshop, Figma
-            </a>
-            <a href="#dostarczone" class="kwcs-chip chip-dostarczone">
-              <b>Efekt</b><br>
-              Logo, księga znaku, pliki wektorowe i rastrowe
-            </a>
+            </div>
+            <div class="kwcs-chip chip-stack">
+              <strong>Technologie</strong><br>
+              Adobe Illustrator · Photoshop · Figma
+            </div>
+            <div class="kwcs-chip chip-automatyzacje">
+              <strong>Co robiłem</strong><br>
+              Analiza · Koncepcja · Iteracje · Pliki produkcyjne
+            </div>
+            <div class="kwcs-chip chip-dostarczone">
+              <strong>Co dostarczyłem</strong><br>
+              Logo · Księga znaku · Pliki wektorowe i rastrowe
+            </div>
           </div>
 
           <!-- PRAWA STRONA: mockup -->
@@ -27,14 +48,22 @@
             <img
               class="cover"
               src="/KWdesignnew/assets/images/KWDESIGN_FRONT.png"
-              alt="Logo i identyfikacja wizualna marki kreatywnej"
+              alt="KW Design — logo i identyfikacja wizualna marki projektanta"
               loading="lazy"
               decoding="async"
               width="1200"
               height="630"
-              data-caption="Logo i identyfikacja wizualna marki kreatywnej">
+              data-caption="KW Design — logo i identyfikacja wizualna">
           </div>
         </div>
+
+        <!-- CTA pod gridem -->
+        <a class="hero-image-cta" href="/KWdesignnew/index.html#contact" rel="noopener noreferrer" aria-label="Zapytaj o podobny projekt brandingu">
+          Zapytaj o podobny projekt
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="9 18 15 12 9 6"></polyline>
+          </svg>
+        </a>
 
       </div>
     </div>

--- a/projects/cyfradruk.html
+++ b/projects/cyfradruk.html
@@ -48,7 +48,29 @@
   <section class="kwcs" id="cyfradruk" data-project="cyfradruk" aria-label="Case Study: CyfraDruk – Wtyczka automatyzująca pre-press">
 
     <!-- ============================================================
-         1. HERO BODY — chipsy po lewej, zdjęcie po prawej
+         1. HERO HEAD — eyebrow, h1, sub, meta
+    ============================================================ -->
+    <div class="kwcs-hero-head">
+      <div class="wrap">
+        <p class="eyebrow">Case Study · Automatyzacja Adobe Illustrator</p>
+        <h1>CyfraDruk<br>wtyczka, która wykrywa błędy pre-press przed drukiem</h1>
+        <p class="sub">
+          Panel CEP dla Adobe Illustrator, który eliminuje niewidzialne błędy grubości linii i mikro-obiektów — jedno kliknięcie zamiast tysięcy ręcznych sprawdzeń.
+        </p>
+        <div class="pm-hero-meta">
+          <span><strong>Rola</strong> Digital Product Designer</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Typ</strong> Automatyzacja DTP · Narzędzie wewnętrzne</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Technologia</strong> Adobe CEP · ExtendScript</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Wynik</strong> Inspekcja z 15 minut do 1 sekundy</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================
+         2. HERO BODY — chipsy po lewej, zdjęcie po prawej
     ============================================================ -->
     <div class="kwcs-hero-body">
       <div class="wrap inner">
@@ -63,18 +85,18 @@
             </div>
 
             <div class="kwcs-chip chip-stack">
-              <strong>Narzędzia</strong><br>
-              Adobe Illustrator, CEP Framework, ExtendScript, Adobe CC SDK
+              <strong>Technologie</strong><br>
+              Adobe Illustrator · CEP Framework · ExtendScript · Adobe CC SDK
             </div>
 
             <div class="kwcs-chip chip-automatyzacje">
-              <strong>Kategoria</strong><br>
-              Automatyzacja DTP · Narzędzie wewnętrzne · Pre-press
+              <strong>Co robiłem</strong><br>
+              Analiza procesu DTP · Projekt panelu · Implementacja · Testy
             </div>
 
             <div class="kwcs-chip chip-dostarczone">
-              <strong>Dostarczone</strong><br>
-              Redukcja czasu inspekcji z 15 min do 1 sek · 100% dokładności skanowania
+              <strong>Co dostarczyłem</strong><br>
+              Wtyczka CEP · Skaner kolorów i obiektów · Raport błędów w jednym panelu
             </div>
           </div>
 

--- a/projects/karoma.html
+++ b/projects/karoma.html
@@ -72,12 +72,12 @@
 
 <body>
   <!-- Case Study Content -->
-  <section class="kwcs" id="case-karoma" aria-label="Case Study: Karoma — E-commerce B2B & Branding">
+  <section class="kwcs" id="case-karoma" aria-label="Case Study: Karoma — Sklep B2B i identyfikacja wizualna">
 
     <!-- Hero Head PM -->
     <div class="kwcs-hero-head">
       <div class="wrap">
-        <p class="eyebrow">Case Study · E-commerce B2B & Branding</p>
+        <p class="eyebrow">Case Study · Sklep B2B i identyfikacja wizualna</p>
         <h1>Karoma<br>od rebrandingu do pełnego sklepu CNC B2B</h1>
         <p class="sub">Nowa marka + sklep WooCommerce + dedykowane skrypty pod proces B2B. Od analizy do wdrożenia.</p>
         <div class="pm-hero-meta">
@@ -105,15 +105,20 @@
     <strong>Zakres</strong><br>
     Logo, strona internetowa, wdrożenie, płatności, obróbka zdjęć, skrypty
   </div>
-  
+
   <div class="kwcs-chip chip-stack">
-    <strong>Narzędzia</strong><br>
-    Adobe CC, ChatGPT, Home.pl, Cloudflare, Przelewy24
+    <strong>Technologie</strong><br>
+    Adobe CC · WordPress · WooCommerce · Cloudflare · Przelewy24
   </div>
-  
+
+  <div class="kwcs-chip chip-automatyzacje">
+    <strong>Co robiłem</strong><br>
+    Analiza · Strategia marki · Projekt · Wdrożenie sklepu · Skrypty
+  </div>
+
   <div class="kwcs-chip chip-dostarczone">
-    <strong>Efekt</strong><br>
-    Pełen branding, sklep, SEO, dedykowane funkcje
+    <strong>Co dostarczyłem</strong><br>
+    Branding · Sklep WooCommerce · Płatności · Dedykowane skrypty
   </div>
 </div>
           
@@ -573,7 +578,7 @@
     <!-- Lessons Learned -->
     <div class="kwcs-sec" style="background:#f8fafc;">
       <div class="wrap">
-        <h2>Lessons Learned</h2>
+        <h2>Czego się nauczyłem</h2>
         <div class="kwcs-trio" style="margin-top:1.5rem;">
           <article class="kwcs-card">
             <h3>Ograniczenia kreatora ≠ koniec świata</h3>
@@ -594,7 +599,7 @@
     <!-- Artifacts -->
     <div class="kwcs-sec">
       <div class="wrap">
-        <h2>Artifacts</h2>
+        <h2>Co dostarczyłem</h2>
         <div class="kwcs-trio" style="margin-top:1.5rem;">
           <article class="kwcs-card">
             <h3>Brand System Karoma</h3>

--- a/projects/power-of-mind.html
+++ b/projects/power-of-mind.html
@@ -100,20 +100,25 @@
         <div class="hero-content-grid">
           
           <!-- LEWA STRONA: Chipsy w kolumnie -->
-       <div class="hero-buttons-vertical"> 
+       <div class="hero-buttons-vertical">
   <div class="kwcs-chip chip-zakres">
     <strong>Zakres</strong><br>
-    Logo, strona WordPress, e-commerce, automatyzacje, integracje
+    Logo, strona WordPress, sklep, automatyzacje, integracje
   </div>
-  
+
   <div class="kwcs-chip chip-stack">
-    <strong>Narzędzia</strong><br>
-    WordPress, Elementor, WooCommerce, Google Apps Script, Przelewy24
+    <strong>Technologie</strong><br>
+    WordPress · Elementor · WooCommerce · Google Apps Script · Przelewy24
   </div>
-  
+
+  <div class="kwcs-chip chip-automatyzacje">
+    <strong>Co robiłem</strong><br>
+    Analiza platform · Branding · Wdrożenie · Automatyzacje · Szkolenie
+  </div>
+
   <div class="kwcs-chip chip-dostarczone">
-    <strong>Efekt</strong><br>
-    Kompletna platforma sprzedażowa z systemem rezerwacji i powiadomieniami
+    <strong>Co dostarczyłem</strong><br>
+    Platforma sprzedażowa · System rezerwacji · Powiadomienia
   </div>
 </div>
 
@@ -139,7 +144,7 @@
     <!-- Executive Summary -->
     <div class="kwcs-sec" style="background:#f0f9ff;">
       <div class="wrap">
-        <h2>Executive Summary</h2>
+        <h2>Podsumowanie</h2>
         <div class="context-intro">
           <p>
             Power of Mind — nowa marka development/wellness prowadzona przez trenerkę oddechu 9D i odporności psychicznej MTQ — potrzebowała pełnej tożsamości wizualnej i platformy sprzedażowej od zera. Zakres obejmował: rebranding, trzy iteracje wyboru platformy (Webflow → Wix → WordPress), wdrożenie WordPress + WooCommerce, system automatyzacji Google Apps Script i integrację Przelewy24.
@@ -595,7 +600,7 @@
     <!-- Lessons Learned -->
     <div class="kwcs-sec" style="background:#f8fafc;">
       <div class="wrap">
-        <h2>Lessons Learned</h2>
+        <h2>Czego się nauczyłem</h2>
         <div class="kwcs-trio" style="margin-top:1.5rem;">
           <article class="kwcs-card">
             <h3>Wybór platformy to decyzja PM, nie techniczna</h3>
@@ -616,7 +621,7 @@
     <!-- Artifacts -->
     <div class="kwcs-sec">
       <div class="wrap">
-        <h2>Artifacts</h2>
+        <h2>Co dostarczyłem</h2>
         <div class="kwcs-trio" style="margin-top:1.5rem;">
           <article class="kwcs-card">
             <h3>Brand Identity Power of Mind</h3>

--- a/projects/razdwa.html
+++ b/projects/razdwa.html
@@ -536,7 +536,7 @@
     ============================================================ -->
     <div class="kwcs-sec" style="background:#f0f9ff;">
       <div class="wrap">
-        <h2>Executive Summary</h2>
+        <h2>Podsumowanie</h2>
         <div class="context-intro">
           <p>
             Drukarnia Raz Dwa wyceniała każde zamówienie ręcznie — przeszukiwanie tabel w Excelu, przeliczanie metrów bieżących, sumowanie dopłat. Cały proces zajmował około godziny. Projekt polegał na zaprojektowaniu i wdrożeniu kompletnego rozwiązania: kalkulatora wycen z 21 kategoriami cennikowymi, instalowanej aplikacji PWA i strony internetowej — w 6 miesięcy, bez zewnętrznego zespołu IT.
@@ -691,7 +691,7 @@
       <div class="wrap">
         <h2>Kluczowe decyzje produktowe</h2>
         <p class="section-lead">
-          Sześć decyzji — każda z kontekstem, trade-offem i uzasadnieniem. To one ukształtowały architekturę i sposób działania systemu.
+          Sześć decyzji — każda z kontekstem, kompromisem i uzasadnieniem. To one ukształtowały architekturę i sposób działania systemu.
         </p>
 
         <div class="pm-decisions">

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -335,6 +335,26 @@
 <body>
   <section class="kwcs" id="case-razdwa-pelne" aria-label="Pełne Case Study: Raz Dwa Druk">
 
+    <!-- Hero Head -->
+    <div class="kwcs-hero-head">
+      <div class="wrap">
+        <p class="eyebrow">Case Study · Aplikacja biznesowa dla drukarni</p>
+        <h1>Raz Dwa Druk<br>aplikacja, która skróciła wycenę z godziny do około 5 minut</h1>
+        <p class="sub">
+          Kalkulator wycen, koszyk, eksport PDF i integracja z Google Sheets — wszystko w aplikacji PWA działającej offline w warsztacie.
+        </p>
+        <div class="pm-hero-meta">
+          <span><strong>Rola</strong> Digital Product Designer</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Czas</strong> ok. 6 miesięcy</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Typ</strong> Aplikacja biznesowa — PWA</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Wynik</strong> ok. −90% czasu wyceny</span>
+        </div>
+      </div>
+    </div>
+
     <div class="kwcs-hero-body">
       <div class="wrap inner">
         <div class="hero-content-grid">

--- a/projects/savage.html
+++ b/projects/savage.html
@@ -16,7 +16,7 @@
   <!-- Open Graph Meta Tags (Facebook, LinkedIn) -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://kwyszynskidesign.github.io/KWdesignnew/projects/pakiet-marka-f.html">
-  <meta property="og:title" content="Case Study: Pakiet Marka F | Karol Wyszyński">
+  <meta property="og:title" content="Case Study: Savage | Karol Wyszyński">
   <meta property="og:description" content="Kompleksowy pakiet branding + strona WWW dla nowej marki. Od koncepcji logo do wdrożenia strony.">
   <meta property="og:image" content="https://kwyszynskidesign.github.io/KWdesignnew/assets/images/marka-f-pakiet.png">
   <meta property="og:image:width" content="1200">
@@ -27,7 +27,7 @@
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:url" content="https://kwyszynskidesign.github.io/KWdesignnew/projects/pakiet-marka-f.html">
-  <meta name="twitter:title" content="Case Study: Pakiet Marka F | Karol Wyszyński">
+  <meta name="twitter:title" content="Case Study: Savage | Karol Wyszyński">
   <meta name="twitter:description" content="Kompleksowy pakiet branding + strona WWW – księga znaku i wdrożona strona.">
   <meta name="twitter:image" content="https://kwyszynskidesign.github.io/KWdesignnew/assets/images/marka-f-pakiet.png">
   
@@ -51,8 +51,26 @@
 <body>
 
   <!-- Case Study Content -->
-  <section class="kwcs" id="case-pakiet-marka-f" aria-label="Case Study: Pakiet Marka F - kompleksowy branding i strona WWW">
-    
+  <section class="kwcs" id="case-savage" aria-label="Case Study: Savage — branding i strona internetowa">
+
+    <!-- Hero Head -->
+    <div class="kwcs-hero-head">
+      <div class="wrap">
+        <p class="eyebrow">Case Study · Branding + strona internetowa</p>
+        <h1>Savage<br>spójna marka i strona internetowa od zera</h1>
+        <p class="sub">
+          Pełna identyfikacja wizualna i strona internetowa dla nowej marki — od logo i księgi znaku po wdrożenie strony i materiałów drukowych.
+        </p>
+        <div class="pm-hero-meta">
+          <span><strong>Rola</strong> Digital Product Designer</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Typ</strong> Branding · Strona internetowa</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Wynik</strong> Wdrożona strona + księga znaku</span>
+        </div>
+      </div>
+    </div>
+
     <!-- Hero Body with Image -->
     <div class="kwcs-hero-body">
       <div class="wrap inner">
@@ -64,29 +82,34 @@
           <div class="hero-buttons-vertical">
             <div class="kwcs-chip chip-zakres">
               <strong>Zakres</strong><br>
-              Logo + Strona WWW + Branding
+              Logo, identyfikacja, strona internetowa, materiały drukowe
             </div>
-            
+
             <div class="kwcs-chip chip-stack">
-              <strong>Stack</strong><br>
-              Adobe CC + WordPress + Elementor
+              <strong>Technologie</strong><br>
+              Adobe CC · WordPress · Elementor
             </div>
-            
+
+            <div class="kwcs-chip chip-automatyzacje">
+              <strong>Co robiłem</strong><br>
+              Strategia marki · Logo · Iteracje · Wdrożenie strony
+            </div>
+
             <div class="kwcs-chip chip-dostarczone">
-              <strong>Dostarczone</strong><br>
-              Księga znaku + wdrożona strona
+              <strong>Co dostarczyłem</strong><br>
+              Księga znaku · Strona WWW · Wizytówki i ulotki
             </div>
           </div>
           
           <!-- PRAWA STRONA: Zdjęcie -->
           <div class="hero-image">
-            <img class="cover" src="/KWdesignnew/assets/images/placeholder.jpg" alt="Pakiet Marka F - kompleksowy branding i strona internetowa" loading="lazy" decoding="async" width="1200" height="630" data-caption="Pakiet Marka F - branding i strona WWW">
+            <img class="cover" src="/KWdesignnew/assets/images/placeholder.jpg" alt="Savage — pełny pakiet brandingu i strony internetowej" loading="lazy" decoding="async" width="1200" height="630" data-caption="Savage — branding i strona internetowa">
           </div>
           
         </div>
         
         <!-- PRZYCISK HERO IMAGE - POD CAŁOŚCIĄ -->
-        <a class="hero-image-cta" href="#" target="_blank" rel="noopener noreferrer" aria-label="Skontaktuj się w sprawie kompleksowego projektu">
+        <a class="hero-image-cta" href="/KWdesignnew/index.html#contact" rel="noopener noreferrer" aria-label="Zapytaj o kompleksowy pakiet">
           Zapytaj o kompleksowy pakiet
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <polyline points="9 18 15 12 9 6"></polyline>
@@ -154,7 +177,7 @@
         <!-- Galeria 2-kolumnowa: Iteracje -->
         <div class="kwcs-gallery-grid">
           <div class="gallery-item">
-            <img src="/KWdesignnew/assets/images/placeholder.jpg" alt="Runda 1 - szkice logo Marka F" loading="lazy">
+            <img src="/KWdesignnew/assets/images/placeholder.jpg" alt="Runda 1 — szkice logo Savage" loading="lazy">
             <p class="img-desc">Runda 1: Wstępne koncepty</p>
           </div>
           <div class="gallery-item">
@@ -451,7 +474,7 @@
             </div>
           </div>
 
-          <a class="kwcs-cta" href="#" target="_blank" rel="noopener noreferrer" aria-label="Skontaktuj się w sprawie kompleksowego projektu">
+          <a class="kwcs-cta" href="/KWdesignnew/index.html#contact" rel="noopener noreferrer" aria-label="Zapytaj o kompleksowy pakiet brandingu i strony">
             Zapytaj o kompleksowy pakiet
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <polyline points="9 18 15 12 9 6"></polyline>

--- a/projects/sir-roger.html
+++ b/projects/sir-roger.html
@@ -16,7 +16,7 @@
   <!-- Open Graph Meta Tags (Facebook, LinkedIn) -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://kwyszynskidesign.github.io/KWdesignnew/projects/strona-marka-e.html">
-  <meta property="og:title" content="Case Study: Strona Marka E | Karol Wyszyński">
+  <meta property="og:title" content="Case Study: Sir Roger | Karol Wyszyński">
   <meta property="og:description" content="Projekt strony firmowej dla branży usługowej – lead generation i optymalizacja konwersji.">
   <meta property="og:image" content="https://kwyszynskidesign.github.io/KWdesignnew/assets/images/marka-e-strona.png">
   <meta property="og:image:width" content="1200">
@@ -27,7 +27,7 @@
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:url" content="https://kwyszynskidesign.github.io/KWdesignnew/projects/strona-marka-e.html">
-  <meta name="twitter:title" content="Case Study: Strona Marka E | Karol Wyszyński">
+  <meta name="twitter:title" content="Case Study: Sir Roger | Karol Wyszyński">
   <meta name="twitter:description" content="Strona firmowa dla branży usługowej – WordPress, lead generation, konwersja.">
   <meta name="twitter:image" content="https://kwyszynskidesign.github.io/KWdesignnew/assets/images/marka-e-strona.png">
   
@@ -51,8 +51,28 @@
 <body>
 
   <!-- Case Study Content -->
-  <section class="kwcs" id="case-strona-marka-e" aria-label="Case Study: Strona Marka E">
-    
+  <section class="kwcs" id="case-sir-roger" aria-label="Case Study: Sir Roger — rebranding i opakowania herbat">
+
+    <!-- Hero Head -->
+    <div class="kwcs-hero-head">
+      <div class="wrap">
+        <p class="eyebrow">Case Study · Rebranding i opakowania</p>
+        <h1>Sir Roger<br>nowa odsłona marki herbat premium</h1>
+        <p class="sub">
+          Rebranding wizualny i nowy system opakowań dla marki herbat premium. Spójna identyfikacja od logo po wzory na opakowania, gotowa do druku.
+        </p>
+        <div class="pm-hero-meta">
+          <span><strong>Rola</strong> Digital Product Designer</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Typ</strong> Rebranding · Opakowania</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Branża</strong> Herbaty premium</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Wynik</strong> Spójna identyfikacja gotowa do produkcji</span>
+        </div>
+      </div>
+    </div>
+
     <!-- Hero Body with Image -->
     <div class="kwcs-hero-body">
       <div class="wrap inner">
@@ -64,29 +84,34 @@
           <div class="hero-buttons-vertical">
             <div class="kwcs-chip chip-zakres">
               <strong>Zakres</strong><br>
-              Strona WWW + UX/UI
+              Rebranding, projekt opakowań, przygotowanie do druku
             </div>
-            
+
             <div class="kwcs-chip chip-stack">
-              <strong>Stack</strong><br>
-              WordPress + Elementor
+              <strong>Technologie</strong><br>
+              Adobe Illustrator, Photoshop, InDesign
             </div>
-            
+
+            <div class="kwcs-chip chip-automatyzacje">
+              <strong>Co robiłem</strong><br>
+              Analiza marki · Projekt · Iteracje · Pliki produkcyjne
+            </div>
+
             <div class="kwcs-chip chip-dostarczone">
-              <strong>Dostarczone</strong><br>
-              Wdrożona strona + formularze
+              <strong>Co dostarczyłem</strong><br>
+              Logo · Wzory na opakowania · Pliki gotowe do druku
             </div>
           </div>
           
           <!-- PRAWA STRONA: Zdjęcie -->
           <div class="hero-image">
-            <img class="cover" src="/KWdesignnew/assets/images/placeholder.jpg" alt="Strona Marka E - projekt UX/UI dla branży usługowej" loading="lazy" decoding="async" width="1200" height="630" data-caption="Strona Marka E - lead generation">
+            <img class="cover" src="/KWdesignnew/assets/images/Roger.png" alt="Sir Roger — rebranding marki herbat premium" loading="lazy" decoding="async" width="1200" height="630" data-caption="Sir Roger — rebranding i opakowania">
           </div>
           
         </div>
         
         <!-- PRZYCISK HERO IMAGE - POD CAŁOŚCIĄ -->
-        <a class="hero-image-cta" href="#" target="_blank" rel="noopener noreferrer" aria-label="Skontaktuj się w sprawie projektu strony">
+        <a class="hero-image-cta" href="/KWdesignnew/index.html#contact" rel="noopener noreferrer" aria-label="Zapytaj o podobny projekt rebrandingu">
           Zapytaj o podobny projekt
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <polyline points="9 18 15 12 9 6"></polyline>
@@ -364,7 +389,7 @@
             </div>
           </div>
 
-          <a class="kwcs-cta" href="#" target="_blank" rel="noopener noreferrer" aria-label="Skontaktuj się w sprawie projektu strony">
+          <a class="kwcs-cta" href="/KWdesignnew/index.html#contact" rel="noopener noreferrer" aria-label="Zapytaj o podobny projekt rebrandingu">
             Zapytaj o podobny projekt
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <polyline points="9 18 15 12 9 6"></polyline>

--- a/projects/voucher-salon-magdy.html
+++ b/projects/voucher-salon-magdy.html
@@ -51,8 +51,28 @@
 <body>
 
   <!-- Case Study Content -->
-  <section class="kwcs" id="case-voucher-magdy" aria-label="Case Study: Voucher Salon u Magdy">
-    
+  <section class="kwcs" id="case-voucher-magdy" aria-label="Case Study: Voucher Salon u Magdy — elegancki design vouchera prezentowego">
+
+    <!-- Hero Head -->
+    <div class="kwcs-hero-head">
+      <div class="wrap">
+        <p class="eyebrow">Case Study · Projekt graficzny i przygotowanie do druku</p>
+        <h1>Voucher Salon u Magdy<br>elegancki prezent z myślą o aukcji charytatywnej</h1>
+        <p class="sub">
+          Projekt vouchera prezentowego dla salonu fryzjerskiego — luksusowy wygląd, funkcjonalność na aukcji i pełne wsparcie przy druku.
+        </p>
+        <div class="pm-hero-meta">
+          <span><strong>Rola</strong> Digital Product Designer</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Typ</strong> Projekt graficzny · DTP</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Branża</strong> Salon fryzjerski</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Wynik</strong> Plik produkcyjny + wsparcie przy druku</span>
+        </div>
+      </div>
+    </div>
+
     <!-- Hero Body with Image -->
     <div class="kwcs-hero-body">
       <div class="wrap inner">
@@ -64,17 +84,22 @@
           <div class="hero-buttons-vertical">
             <div class="kwcs-chip chip-zakres">
               <strong>Zakres</strong><br>
-              Projekt graficzny wraz przygotowaniem do druku, wsparcie przy wyborze drukarni i wydruk 
+              Projekt graficzny, przygotowanie do druku, wsparcie przy wyborze drukarni
             </div>
-            
+
             <div class="kwcs-chip chip-stack">
-              <strong>Narzędzia</strong><br>
-              Adobe Photoshop, Illustrator
+              <strong>Technologie</strong><br>
+              Adobe Photoshop · Illustrator · InDesign
             </div>
-            
+
+            <div class="kwcs-chip chip-automatyzacje">
+              <strong>Co robiłem</strong><br>
+              Koncepcja · Projekt · Mockupy · Pliki produkcyjne
+            </div>
+
             <div class="kwcs-chip chip-dostarczone">
-              <strong>Dostarczone</strong><br>
-              Plik PDF do druku, wsparcie w procesie druku 
+              <strong>Co dostarczyłem</strong><br>
+              Plik PDF do druku · Mockupy prezentacyjne · Wsparcie w druku
             </div>
           </div>
           


### PR DESCRIPTION
## Audit i naprawy spojnosci case studies

Audyt UX/UI wszystkich plikow w \`projects/\` wzgledem wzorca z \`razdwa.html\`. Wszystkie case studies maja teraz spojny uklad hero, identyczne etykiety chipow i sprawne linki.

## Wzorzec referencyjny (razdwa.html)

\`\`\`
kwcs-hero-head: eyebrow + h1 + sub + pm-hero-meta (4 metadane)
kwcs-hero-body: 4 chipy (Zakres / Technologie / Co robilem / Co dostarczylem)
hero-image-cta: link do zywego projektu lub #contact
\`\`\`

## Naprawione case studies

| Plik | Hero head dodane | Chipy ujednolicone | Linki naprawione |
|---|---|---|---|
| \`razdwa_aplikacja.html\` | ✅ | (juz mial 4) | — |
| \`cyfradruk.html\` | ✅ | ✅ etykiety PL | — |
| \`sir-roger.html\` | ✅ | ✅ + 4 chipy | ✅ # -> #contact |
| \`savage.html\` | ✅ | ✅ + 4 chipy | ✅ # -> #contact |
| \`voucher-salon-magdy.html\` | ✅ | ✅ + 4 chipy | — |
| \`karoma.html\` | (mial) | ✅ + 4 chipy | — |
| \`power-of-mind.html\` | (mial) | ✅ + 4 chipy | — |
| \`KW-Design.html\` | ✅ | ✅ + 4 chipy + CTA | ✅ dodany CTA |

## Inne poprawki

- Usuniete robocze nazwy "Marka D/E/F" z ID, aria-label, alt i meta title (Sir Roger, Savage, KW Design)
- Anglicyzmy w naglowkach sekcji -> polskie odpowiedniki:
  - Executive Summary -> Podsumowanie
  - Lessons Learned -> Czego sie nauczylem
  - Artifacts -> Co dostarczylem
  - trade-offem -> kompromisem
- Karoma eyebrow "E-commerce B2B & Branding" -> "Sklep B2B i identyfikacja wizualna"
- Sir Roger placeholder.jpg zastapiony wlasciwym obrazkiem Roger.png

## Co zostalo bez zmian

- \`wizualizacje.html\` - inny typ strony (karuzela 3D), nie pasuje do wzorca case study
- Sekcje glowne (kontekst, dekompozycja, decyzje) - audytowane tylko pod katem hero, nie tresci
- Style CSS - bez modyfikacji \`projects.css\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)