### PR TITLE
Poprawki UI/UX: layout, tło hero, CTA, nawigacja projektów

### DIFF
--- a/assets/css/index-styles.css
+++ b/assets/css/index-styles.css
@@ -570,18 +570,13 @@ section {
     min-height: 100vh;
     display: flex;
     align-items: center;
-    background:
-        radial-gradient(circle at 15% 50%, rgba(6, 182, 212, 0.07) 0%, transparent 55%),
-        radial-gradient(circle at 85% 20%, rgba(20, 184, 166, 0.05) 0%, transparent 50%),
-        radial-gradient(circle at 60% 85%, rgba(6, 182, 212, 0.05) 0%, transparent 45%),
-        radial-gradient(circle, #cbd5e1 1px, transparent 1px) 0 0 / 32px 32px,
-        #f8fafc;
+    background: #f8fafc;
     position: relative;
     overflow: hidden;
     padding-top: 150px;
 }
 
-/* Hero Background Animation - Unchanged */
+/* Fancy animated mesh gradient background */
 .hero-bg-animation {
     position: absolute;
     top: 0;
@@ -591,7 +586,44 @@ section {
     pointer-events: none;
     z-index: 1;
     max-width: 100vw;
-    overflow-x: hidden;
+    overflow: hidden;
+    background:
+        radial-gradient(ellipse 60% 50% at 20% 30%, rgba(6, 182, 212, 0.18) 0%, transparent 60%),
+        radial-gradient(ellipse 50% 40% at 80% 20%, rgba(20, 184, 166, 0.16) 0%, transparent 60%),
+        radial-gradient(ellipse 50% 45% at 70% 80%, rgba(99, 102, 241, 0.12) 0%, transparent 60%),
+        radial-gradient(ellipse 45% 40% at 10% 90%, rgba(14, 165, 233, 0.14) 0%, transparent 60%);
+    filter: blur(40px);
+    animation: meshDrift 24s ease-in-out infinite alternate;
+}
+
+/* Subtle grain texture overlay */
+.hero-bg-animation::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.1 0 0 0 0 0.2 0 0 0 0 0.3 0 0 0 0.5 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    opacity: 0.35;
+    mix-blend-mode: overlay;
+    pointer-events: none;
+}
+
+@keyframes meshDrift {
+    0% {
+        background-position: 0% 0%, 100% 0%, 100% 100%, 0% 100%;
+        transform: scale(1);
+    }
+    50% {
+        background-position: 10% 5%, 95% 8%, 90% 95%, 8% 90%;
+        transform: scale(1.05);
+    }
+    100% {
+        background-position: -5% -5%, 105% -5%, 105% 105%, -5% 105%;
+        transform: scale(1);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .hero-bg-animation { animation: none; }
 }
 
 .floating-element {
@@ -1114,12 +1146,17 @@ section {
     color: white;
 }
 
+.social-proof-section .section-subtitle {
+    color: #cbd5e1;
+    opacity: 1;
+}
+
 .benefits-grid {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: var(--space-10); /* ✅ WIĘKSZY GAP (było 6) */
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-10);
     margin-bottom: var(--space-20);
-    max-width: 1300px; /* ✅ SZERSZY (było 1200px) */
+    max-width: 1200px;
     margin-left: auto;
     margin-right: auto;
     align-items: stretch;
@@ -3236,9 +3273,9 @@ section {
         padding: var(--space-4) var(--space-4) !important;
     }
 
-    /* 2. BENEFITS - 4 kolumny */
+    /* 2. BENEFITS - 3 kolumny (6 kart w 2 rzędach) */
     .benefits-grid {
-        grid-template-columns: repeat(4, 1fr) !important;
+        grid-template-columns: repeat(3, 1fr) !important;
     }
 
     /* 3. PORTFOLIO - 3 kolumny */

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -2111,3 +2111,123 @@ body.lightbox-open {
 @media (max-width: 480px) {
   .contribution-grid { grid-template-columns: 1fr; }
 }
+
+
+/* ============================================================
+   FLOATING PROJECT NAVIGATION (Previous / Next)
+   ============================================================ */
+#project-floating-nav {
+  position: fixed;
+  right: 24px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 1000;
+  pointer-events: auto;
+  animation: pfnFadeIn 0.4s ease;
+}
+
+@keyframes pfnFadeIn {
+  from { opacity: 0; transform: translate(20px, -50%); }
+  to   { opacity: 1; transform: translate(0, -50%); }
+}
+
+.pfn-btn {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  background: rgba(15, 23, 42, 0.92);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  cursor: pointer;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.25);
+  transition: all 0.25s ease;
+  max-width: 240px;
+  font-family: inherit;
+  text-align: left;
+}
+
+.pfn-btn:hover {
+  background: #06b6d4;
+  border-color: #06b6d4;
+  box-shadow: 0 14px 36px rgba(6, 182, 212, 0.35);
+}
+
+.pfn-btn.pfn-prev:hover { transform: translateX(-4px); }
+.pfn-btn.pfn-next:hover { transform: translateX(4px); }
+
+.pfn-btn svg {
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
+.pfn-btn:hover svg { opacity: 1; }
+
+.pfn-label {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+  min-width: 0;
+}
+
+.pfn-btn.pfn-next .pfn-label { text-align: right; }
+
+.pfn-label small {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.7;
+  margin-bottom: 2px;
+  font-weight: 500;
+}
+
+.pfn-label strong {
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Tablet: smaller buttons */
+@media (max-width: 1100px) and (min-width: 769px) {
+  #project-floating-nav { right: 16px; gap: 10px; }
+  .pfn-btn { padding: 12px 14px; max-width: 200px; }
+  .pfn-label strong { font-size: 12px; }
+}
+
+/* Mobile: stick to bottom, side by side */
+@media (max-width: 768px) {
+  #project-floating-nav {
+    top: auto;
+    bottom: 16px;
+    left: 16px;
+    right: 16px;
+    transform: none;
+    flex-direction: row;
+    justify-content: space-between;
+    gap: 8px;
+    animation: pfnFadeInMobile 0.4s ease;
+  }
+  @keyframes pfnFadeInMobile {
+    from { opacity: 0; transform: translateY(20px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  .pfn-btn {
+    flex: 1;
+    min-width: 0;
+    max-width: none;
+    padding: 10px 12px;
+    gap: 8px;
+  }
+  .pfn-label small { display: none; }
+  .pfn-label strong { font-size: 12px; }
+  .pfn-btn.pfn-prev:hover,
+  .pfn-btn.pfn-next:hover { transform: translateY(-2px); }
+}

--- a/assets/css/services-page.css
+++ b/assets/css/services-page.css
@@ -727,15 +727,22 @@
 }
 
 .btn-large {
-    padding: 18px 48px;
-    font-size: 1.125rem;
+    padding: 18px 40px;
+    font-size: 1.0625rem;
     background: #ffffff;
     color: var(--color-primary);
     font-weight: 600;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
     border-radius: 12px;
     text-decoration: none;
     transition: all 0.3s ease;
+    white-space: nowrap;
+    overflow: visible;
+    min-height: auto;
+    max-width: 90vw;
 }
 
 .btn-large:hover {

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -25,6 +25,77 @@ document.addEventListener('DOMContentLoaded', () => {
      'cyfradruk' : 'projects/cyfradruk.html',
   };
 
+  // Kolejność i etykiety projektów dla pływającej nawigacji
+  const projectOrder = ['RazDwa', 'karoma', 'power-of-mind', 'cyfradruk', 'KW-Design', 'sir-roger', 'savage', 'voucher-magdy'];
+  const projectLabels = {
+    'voucher-magdy': 'Voucher Salon u Magdy',
+    'karoma': 'Karoma',
+    'power-of-mind': 'Power of Mind',
+    'KW-Design': 'KW Design',
+    'sir-roger': 'Sir Roger',
+    'savage': 'Savage',
+    'RazDwa': 'Raz Dwa Druk',
+    'cyfradruk': 'CyfraDruk'
+  };
+
+  function getAdjacentProjects(currentId) {
+    const idx = projectOrder.indexOf(currentId);
+    if (idx === -1) return { prev: null, next: null };
+    const len = projectOrder.length;
+    return {
+      prev: projectOrder[(idx - 1 + len) % len],
+      next: projectOrder[(idx + 1) % len]
+    };
+  }
+
+  function renderProjectNavigation(currentId) {
+    const existing = document.getElementById('project-floating-nav');
+    if (existing) existing.remove();
+
+    const { prev, next } = getAdjacentProjects(currentId);
+    if (!prev && !next) return;
+
+    const nav = document.createElement('div');
+    nav.id = 'project-floating-nav';
+    nav.setAttribute('aria-label', 'Nawigacja między projektami');
+
+    nav.innerHTML = `
+      ${prev ? `
+        <button class="pfn-btn pfn-prev" data-target="${prev}" aria-label="Poprzedni projekt: ${projectLabels[prev]}">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+          <span class="pfn-label">
+            <small>Poprzedni</small>
+            <strong>${projectLabels[prev]}</strong>
+          </span>
+        </button>
+      ` : ''}
+      ${next ? `
+        <button class="pfn-btn pfn-next" data-target="${next}" aria-label="Następny projekt: ${projectLabels[next]}">
+          <span class="pfn-label">
+            <small>Następny</small>
+            <strong>${projectLabels[next]}</strong>
+          </span>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+        </button>
+      ` : ''}
+    `;
+    document.body.appendChild(nav);
+
+    nav.querySelectorAll('.pfn-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const target = btn.dataset.target;
+        if (target && window.showProjectDetails) {
+          window.showProjectDetails(target);
+        }
+      });
+    });
+  }
+
+  function removeProjectNavigation() {
+    const existing = document.getElementById('project-floating-nav');
+    if (existing) existing.remove();
+  }
+
   window.showProjectDetails = async function(projectId) {
     const container = document.getElementById('project-details-container');
     const content = document.getElementById('project-details-content');
@@ -74,6 +145,9 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       history.pushState({ project: projectId }, '', `#${projectId}`);
+
+      // Renderuj pływającą nawigację Poprzedni/Następny
+      renderProjectNavigation(projectId);
 
     } catch (error) {
       content.innerHTML = `
@@ -168,6 +242,9 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.portfolio-new-card').forEach(card => {
       card.classList.remove('active');
     });
+
+    // Usuń pływającą nawigację
+    removeProjectNavigation();
 
     history.pushState('', document.title, window.location.pathname);
   };

--- a/index.html
+++ b/index.html
@@ -558,21 +558,7 @@
     <section id="social-proof" class="social-proof-section">
         <div class="container">
             <h2 class="section-title">Co wnoszę do projektu</h2>
-            <p class="section-subtitle benefits-subtitle">Dlaczego współpraca ze mną wygląda inaczej niż z agencją albo freelancerem od jednej rzeczy</p>
-            <style>
-                .social-proof-section .benefits-subtitle { color: #cbd5e1; opacity: 1; }
-                .social-proof-section .benefits-grid {
-                    display: grid;
-                    grid-template-columns: repeat(3, 1fr);
-                    gap: 1.5rem;
-                }
-                @media (max-width: 900px) {
-                    .social-proof-section .benefits-grid { grid-template-columns: repeat(2, 1fr); }
-                }
-                @media (max-width: 600px) {
-                    .social-proof-section .benefits-grid { grid-template-columns: 1fr; }
-                }
-            </style>
+            <p class="section-subtitle">Dlaczego współpraca ze mną wygląda inaczej niż z agencją albo freelancerem od jednej rzeczy</p>
             <div class="benefits-grid">
                 <div class="benefit-card">
                     <div class="benefit-icon">

--- a/uslugi.html
+++ b/uslugi.html
@@ -579,7 +579,7 @@
         <h2 id="cta-title">Masz proces, który zjada za dużo czasu?</h2>
         <p>Pierwsza rozmowa nic nie kosztuje — sprawdzimy, czy w ogóle warto się brać i jaki obszar będzie najlepszym punktem wyjścia. Odpowiadam w ciągu 24 godzin.</p>
         <a href="index.html#contact" class="btn btn-primary btn-large">
-          Porozmawiajmy o Twoim procesie
+          Porozmawiajmy
           <svg width="18" height="18" viewBox="0 0 20 20" fill="none" aria-hidden="true">
             <path d="M9.5 3.5h7v7m-7-7l7.5 7.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>


### PR DESCRIPTION
## Cztery poprawki wedlug feedbacku

### 1. Sekcja \"Co wnosze do projektu\" - layout 3 kolumny

6 kart ukladalo sie 4+2 (drugi rzad pusty po prawej). Glowny CSS mial \`repeat(4, 1fr) !important\` w media query desktop, ktore nadpisywalo moj wczesniejszy inline style.

**Fix:** \`.benefits-grid\` w \`index-styles.css\` zmienione na \`repeat(3, 1fr)\` (z 4) - karty teraz lozcza sie ladnie w 3x2. Tablet 2 kolumny, mobile 1. Inline \`<style>\` z HTML usuniety.

### 2. Tlo hero - elegancki gradient mesh zamiast kropek

Stary wzor: siatka kropek (\`radial-gradient(circle, #cbd5e1 1px ...)\`). User: \"te kropki sa zbyt rozmijajace\".

**Fix:** Nowe tlo to **animowany gradient mesh**:
- 4 elipsoidalne blob'y w roznych kolorach (cyan, teal, indigo, sky)
- \`filter: blur(40px)\` - miekkie, premium wrazenie
- \`@keyframes meshDrift\` - delikatny ruch 24s (subtle)
- **Subtle grain texture overlay** przez inline SVG noise filter
- Respektuje \`prefers-reduced-motion\`

### 3. uslugi.html CTA - obcinany przycisk

Zrzut ekranu pokazywal \"Porozmawiajmy o Twoim pro\" - tekst byl ciety. Powod: \`.btn\` ma \`white-space: nowrap\` + \`overflow: hidden\`, a \`.btn-large\` mial \`display: inline-block\` zamiast \`inline-flex\`.

**Fix:**
- \`.btn-large\` w \`services-page.css\`: \`display: inline-flex\` + \`align-items: center\` + \`overflow: visible\` + \`max-width: 90vw\`
- Tekst CTA \"Porozmawiajmy o Twoim procesie\" -> **\"Porozmawiajmy\"** (krotszy, czytelny)

### 4. portfolio.html - plywajaca nawigacja Poprzedni / Nastepny

User: \"daj z prawej strony plywajacy przycisk ktory pozwoli przejsc np do Power of Mind bez koniecznosci powrotu na gore\".

**Implementacja:**
- \`portfolio.js\`: \`getAdjacentProjects()\` + \`renderProjectNavigation()\` + \`removeProjectNavigation()\`
- Po zaladowaniu projektu (\`showProjectDetails\`) - pojawia sie pivot po prawej stronie z **dwoma przyciskami** (Poprzedni / Nastepny) z nazwa konkretnego projektu
- Po zamknieciu modala (\`closeProjectDetails\`) - znika
- Cykliczna kolejnosc: Raz Dwa Druk -> Karoma -> Power of Mind -> CyfraDruk -> KW Design -> Sir Roger -> Savage -> Voucher Salon u Magdy
- **CSS w \`projects.css\`:** glassmorphism (rgba dark + backdrop-blur), hover w akcencie cyan, subtelne fadeIn na wejsciu
- **Responsywne:** desktop sticky po prawej (top: 50%), mobile sticky na dole strony (row layout, side-by-side)

## Pliki

- \`assets/css/index-styles.css\` - hero bg + benefits grid + subtitle color
- \`assets/css/projects.css\` - styl plywajacej nawigacji projektow
- \`assets/css/services-page.css\` - fix btn-large
- \`assets/js/portfolio.js\` - logika nawigacji Prev/Next
- \`index.html\` - usuniecie inline style, cleanup hero
- \`uslugi.html\` - krotszy tekst CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)