### PR TITLE
Hero: scalona lewa kolumna, hierarchia CTA, WCAG AA

### DIFF
--- a/assets/css/index-styles.css
+++ b/assets/css/index-styles.css
@@ -3817,3 +3817,78 @@ header * {
 .ghost-danger:hover {
     background: #fef2f2;
 }
+
+/* ========== HERO RESTRUCTURE – scalona lewa kolumna ========== */
+
+/* Lewa kolumna hero: usuń ograniczenie szerokości, dopasuj odstępy */
+.hero-text {
+    max-width: none;
+    padding-top: var(--space-8);
+    gap: var(--space-5);
+}
+
+/* Eyebrow jest pierwszym dzieckiem flex – usuń dodatkowy margines z góry */
+.hero-text .hero-eyebrow {
+    margin-top: 0;
+}
+
+/* WCAG AA dla akcentu w h1: #0891b2 ma kontrast 3.2:1 na #f8fafc (duży tekst ✓) */
+.highlight-digits-tyt {
+    color: #0891b2;
+}
+
+/* Zdanie-pomost pod h1: bez automatycznego centrowania (to robi flex-col) */
+.hero-text .hero-subtitle {
+    margin-left: 0;
+    margin-right: 0;
+    max-width: none;
+    font-size: 1.1rem;
+    margin-bottom: 0;
+}
+
+/* Tekstowy link CV – wizualnie lżejszy niż przycisk */
+.hero-cv-link {
+    display: inline-block;
+    font-size: 0.875rem;
+    color: var(--color-text-light);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    transition: var(--transition-fast);
+    align-self: flex-start;
+}
+.hero-cv-link:hover {
+    color: var(--color-primary);
+}
+
+/* Desktop: CTA wyrównane do lewej */
+@media (min-width: 1025px) {
+    .hero-text .cta-group {
+        justify-content: flex-start;
+    }
+}
+
+/* Tablet i mobile (≤768px): jeden pionowy stos, centrowanie treści */
+@media (max-width: 768px) {
+    .hero-main-content {
+        grid-template-columns: 1fr !important;
+    }
+    .hero-text {
+        padding-top: var(--space-4);
+        text-align: center;
+    }
+    .hero-text .hero-eyebrow {
+        text-align: center;
+    }
+    .hero-text .hero-subtitle {
+        margin-left: auto;
+        margin-right: auto;
+        max-width: 520px;
+    }
+    .hero-text .cta-group {
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+    .hero-cv-link {
+        align-self: center;
+    }
+}

--- a/assets/js/index-scripts.js
+++ b/assets/js/index-scripts.js
@@ -187,7 +187,7 @@ function getCurrentStatus() {
     if (hour >= 6 && hour < 22) {
         return {
             status: 'available',
-            text: 'Otwarty na rozmowy'
+            text: 'Otwarty na współpracę — odpowiadam w 24h'
         };
     }
     // Noc (22:00 - 6:00) - żółty

--- a/index.html
+++ b/index.html
@@ -93,26 +93,37 @@
         <div class="hero-bg-animation" aria-hidden="true"></div>
 
         <div class="container hero-section-content">
-            <div class="hero-main-title">
-                <p class="hero-eyebrow">Digital Product Designer · Automatyzacje · Procesy</p>
-                <h1 class="hero-title">
-                    Produkty cyfrowe,<span class="highlight-digits-tyt"> które porządkują pracę w firmie.</span>
-                </h1>
-            </div>
-
             <div class="hero-main-content">
-                <div class="hero-info-icons">
-                    <div class="info-icon">
-                        <span class="text"><span class="highlight-digits">−90%</span> czasu wyceny — z godziny do ok. 5 minut</span>
+
+                <!-- Lewa kolumna: eyebrow → h1 → zdanie-pomost → liczby → CTA -->
+                <div class="hero-text">
+                    <p class="hero-eyebrow">Digital Product Designer · Automatyzacje · Procesy</p>
+                    <h1 class="hero-title">
+                        Produkty cyfrowe,<span class="highlight-digits-tyt"> które porządkują pracę w firmie.</span>
+                    </h1>
+                    <p class="hero-subtitle">
+                        Projektuję aplikacje i strony oraz automatyzuję procesy, dzięki którym zespoły przestają tonąć w ręcznej robocie — od analizy po działający produkt.
+                    </p>
+                    <div class="hero-info-icons">
+                        <div class="info-icon">
+                            <span class="text"><span class="highlight-digits">−90%</span> czasu wyceny — proces z godziny skrócony do ok. 5 minut</span>
+                        </div>
+                        <div class="info-icon">
+                            <span class="text"><span class="highlight-digits">10+</span> zautomatyzowanych procesów w realnych firmach</span>
+                        </div>
+                        <div class="info-icon">
+                            <span id="availability-dot" class="dot green"></span>
+                            <span id="availability-text" class="text">Otwarty na współpracę — odpowiadam w 24h</span>
+                        </div>
                     </div>
-                    <div class="info-icon">
-                        <span class="text"><span class="highlight-digits">10+</span> zautomatyzowanych procesów w realnych firmach</span>
+                    <div class="cta-group">
+                        <a href="portfolio.html" class="btn btn-primary">Zobacz projekty →</a>
+                        <a href="#contact" class="btn btn-secondary smooth">Porozmawiajmy o współpracy</a>
                     </div>
-                    <div class="info-icon">
-                        <span id="availability-dot" class="dot green"></span>
-                        <span id="availability-text" class="text"></span>
-                    </div>
+                    <a href="assets/CV_KarolWyszynski.pdf" class="hero-cv-link" target="_blank" rel="noopener" download>Pobierz CV (PDF)</a>
                 </div>
+
+                <!-- Prawa kolumna: zdjęcie -->
                 <div class="hero-image">
                     <div class="hero-image-container">
                         <img src="assets/images/ja-skupiony2.webp" alt="Karol Wyszyński - Digital Product Designer" />
@@ -126,17 +137,7 @@
                         </div>
                     </div>
                 </div>
-            </div>
 
-            <div class="hero-bottom-content">
-                <p class="hero-subtitle">
-                    Aplikacje, strony i automatyzacje — od analizy procesu po działający produkt.
-                </p>
-                <div class="cta-group">
-                    <a href="portfolio.html" class="btn btn-primary">Zobacz projekty →</a>
-                    <a href="#contact" class="btn btn-secondary smooth">Porozmawiajmy o procesie</a>
-                    <a href="assets/CV_KarolWyszynski.pdf" class="btn btn-secondary" target="_blank" rel="noopener" download>Pobierz CV PDF</a>
-                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Zmiany w sekcji hero

### Problem
Nagłówek i liczby były na górze, a zdanie wyjaśniające i przyciski CTA osobno poniżej linii zgięcia — pierwsza strona nie miała żadnego CTA i rozrywała jedną myśl na dwa ekrany.

### Co zmieniono

**`index.html`**
- Usunięto osobny blok `.hero-main-title` (wyśrodkowany tytuł ponad gridem)
- Usunięto osobny blok `.hero-bottom-content` (subtitle + CTA poniżej gridu)
- Całość scalono w lewą kolumnę `.hero-text` w kolejności: eyebrow → h1 → zdanie-pomost → liczby → CTA → link CV
- Zdjęcie pozostaje w prawej kolumnie (bez zmian)
- Dodano zdanie-pomost między h1 a liczbami
- Zaktualizowano etykiety statystyk (format „przed → po")
- Zmieniono tekst przycisku: „Porozmawiajmy o procesie" → „Porozmawiajmy o współpracy"
- „Pobierz CV (PDF)" przeniesiono z trzeciego przycisku do lekkiego linku tekstowego

**`assets/css/index-styles.css`**
- Nowy blok na końcu pliku z nadpisaniami dla nowego układu
- `highlight-digits-tyt` pociemniony do `#0891b2` (kontrast 3.2:1 na #f8fafc — WCAG AA dla dużego tekstu ✓)
- `.hero-cv-link` — styl lekkiego linku tekstowego z podkreśleniem
- Na desktop (≥1025px): CTA wyrównane do lewej
- Na mobile/tablet (≤768px): kolumny stackują się pionowo, tekst i przyciski centrowane

**`assets/js/index-scripts.js`**
- Tekst statusu „Otwarty na rozmowy" → „Otwarty na współpracę — odpowiadam w 24h"

https://claude.ai/code/session_018ZCaxtA8dnJJHWiK17bfHD

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZCaxtA8dnJJHWiK17bfHD)_