### PR TITLE
Sekcja usług + tła sekcji + sticky-header (ZESTAW A+B)

### DIFF
--- a/assets/css/index-styles.css
+++ b/assets/css/index-styles.css
@@ -1432,7 +1432,7 @@ section {
 
 /* Enhanced Services Section with 3D Effect */
 .services-section {
-    background: linear-gradient(180deg, var(--color-background) 0%, var(--color-background-light) 50%, var(--color-background) 100%);
+    background: #ffffff;
    padding-top: 100px; /* ✅ ~6rem */
     padding-bottom: 100px; /* ✅ ~6rem */
     position: relative;
@@ -1503,23 +1503,23 @@ section {
 
 .service-card.featured {
     border-color: var(--color-primary);
-    box-shadow: 
-        0 15px 40px -8px rgba(0, 0, 0, 0.2),
-        0 10px 25px -5px rgba(6, 182, 212, 0.25),
-        0 0 0 2px rgba(6, 182, 212, 0.1);
+    box-shadow:
+        0 24px 56px -10px rgba(0, 0, 0, 0.24),
+        0 14px 32px -6px rgba(6, 182, 212, 0.32),
+        0 0 0 2px rgba(6, 182, 212, 0.18);
     background: linear-gradient(145deg, white 0%, #f0f9ff 100%);
-    transform: translateY(-4px);
+    transform: translateY(-14px);
 }
 
 .service-card.featured.fade-slide-in {
-    transform: translateY(-4px);
+    transform: translateY(-14px);
 }
 
 .service-card.featured:hover {
-    transform: translateY(-16px);
-    box-shadow: 
-        0 30px 60px -12px rgba(0, 0, 0, 0.3),
-        0 20px 45px -8px rgba(6, 182, 212, 0.35),
+    transform: translateY(-20px);
+    box-shadow:
+        0 32px 64px -12px rgba(0, 0, 0, 0.3),
+        0 20px 48px -8px rgba(6, 182, 212, 0.38),
         0 0 0 2px var(--color-primary);
 }
 .popular-badge {
@@ -1895,7 +1895,7 @@ section {
 
 .process-section {
     padding: 100px 0 80px;
-    background: linear-gradient(180deg, #ffffff 0%, #f8f9fa 100%);
+    background: #f4f8fa;
     position: relative;
     overflow: hidden;
 }
@@ -2020,7 +2020,7 @@ section {
 }
 .faq-section {
   padding: var(--space-24) 0;
-  background: var(--color-background);
+  background: #f4f8fa;
 }
 .faq-container {
   max-width: 800px;
@@ -3365,7 +3365,7 @@ section {
    ======================================== */
 
 .mini-portfolio-section-new {
-    background: linear-gradient(180deg, #f8fafc 0%, #ffffff 60%, #f1f5f9 100%);
+    background: #ffffff;
     padding: var(--space-24) 0;
     position: relative;
     overflow: visible;
@@ -3911,4 +3911,24 @@ header * {
     .hero-cv-link {
         align-self: center;
     }
+}
+
+/* ========== ZESTAW A: outline CTA dla bocznych kart usług ========== */
+/* Środkowa karta (featured) zachowuje pełny cyan. Boczne dostają styl outline. */
+.service-card:not(.featured) .service-btn {
+    background: transparent;
+    color: var(--color-primary);
+    border: 2px solid var(--color-primary);
+    box-shadow: none;
+}
+.service-card:not(.featured) .service-btn:hover {
+    background: var(--color-primary);
+    color: #ffffff;
+    box-shadow: var(--shadow-md);
+}
+
+/* ========== ZESTAW B: sticky-header cień po scroll ========== */
+/* Override globalnego "box-shadow: none !important" dla stanu .scrolled */
+.header.scrolled {
+    box-shadow: 0 4px 12px -4px rgba(0, 0, 0, 0.1) !important;
 }

--- a/assets/js/index-scripts.js
+++ b/assets/js/index-scripts.js
@@ -422,7 +422,7 @@ function initScrollEffects() {
     if (!header) return;
 
     window.addEventListener('scroll', () => {
-        if (window.scrollY > 50) {
+        if (window.scrollY > 10) {
             header.classList.add('scrolled');
         } else {
             header.classList.remove('scrolled');

--- a/index.html
+++ b/index.html
@@ -503,14 +503,16 @@
                     <p class="service-time">Czas większych projektów: 4–5 miesięcy</p>
                     <p class="service-price">wycena indywidualna</p>
                 </div>
-                <a href="uslugi.html" class="service-btn">Więcej informacji</a>
+                <a href="uslugi.html#produkty-cyfrowe" class="service-btn">Więcej informacji →</a>
             </div>
 
             <!-- OBSZAR 2: Automatyzacje procesów -->
             <div class="service-card featured">
                 <div class="popular-badge">Najczęściej wybierane</div>
                 <div class="service-icon">
-                    <img src="assets/images/KW_PRO.svg" alt="Ikona automatyzacje" width="56" height="56">
+                    <svg width="56" height="56" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <path stroke="#0f172a" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"/>
+                    </svg>
                 </div>
                 <h3>Automatyzacje procesów</h3>
                 <p class="service-description">Zamieniam ręczne czynności w działające automaty</p>
@@ -525,7 +527,7 @@
                     <p class="service-time">Realny efekt: z godziny do kilku minut</p>
                     <p class="service-price">wycena indywidualna</p>
                 </div>
-                <a href="uslugi.html" class="service-btn">Więcej informacji</a>
+                <a href="uslugi.html#automatyzacje" class="service-btn">Więcej informacji →</a>
             </div>
 
             <!-- OBSZAR 3: Usprawnienia procesów -->
@@ -546,11 +548,11 @@
                     <p class="service-time">Zakres ustalany po analizie</p>
                     <p class="service-price">wycena indywidualna</p>
                 </div>
-                <a href="uslugi.html" class="service-btn">Więcej informacji</a>
+                <a href="uslugi.html#usprawnienia" class="service-btn">Więcej informacji →</a>
             </div>
 
         </div>
-        
+
     </div>
 </section>
 


### PR DESCRIPTION
$(cat <<'EOF'
## ZESTAW A — sekcja „Co robię"

- **A1 — Wyróżnienie featured card:** `translateY(-14px)` (poprzednio -4px), mocniejszy cień cyjanowy (`0 24px 56px` + cyjan 0.32 opacity); hover podnosi do -20px
- **A1 — CTA hierarchy:** boczne karty (Produkty / Usprawnienia) dostają styl outline (`background: transparent; border: 2px solid cyan`); środkowa karta zachowuje pełny wypełniony cyan
- **A2 — Linki z kotwicami:** `uslugi.html#produkty-cyfrowe`, `uslugi.html#automatyzacje`, `uslugi.html#usprawnienia`; tekst „Więcej informacji →"
- **A3 — Ikona automatyzacji:** zastąpiono `KW_PRO.svg` (ciężkie gear+wykres, stroke 11px) inline SVG Heroicons `arrow-path` (thin-line, stroke-width 1.5, spójny wizualnie z laptop.svg i rocket.svg)
- **A5 — Mobile:** istniejące reguły `transform: none !important` na `.service-card.featured` w breakpointach ≤768px pozostają bez zmian — karta nie wyskakuje na mobile

## ZESTAW B — tła sekcji + sticky-header

- **B1 — Naprzemienne tła:**
  | Sekcja | Poprzednio | Teraz |
  |--------|-----------|-------|
  | Ostatnie projekty | gradient f8fafc→fff→f1f5f9 | `#ffffff` |
  | Jak pracuję | gradient fff→f8f9fa | `#f4f8fa` |
  | Co robię | gradient biały | `#ffffff` |
  | Q&A | `var(--color-background)` = biały | `#f4f8fa` |
  | Co wnoszę / Kontakt | bez zmian (dark navy / cyan) | — |
- **B2 — Widoczność kart:** usługi na białym tle mają border `1px solid` + cień `0 10px 30px -5px rgba(0,0,0,0.15)` — wystarczająco widoczne
- **B3 — Sticky-header:** próg scroll `50 → 10px`; dodano `.header.scrolled { box-shadow: 0 4px 12px -4px rgba(0,0,0,.1) !important }` na końcu CSS (override globalnego killera `box-shadow: none !important`)

https://claude.ai/code/session_018ZCaxtA8dnJJHWiK17bfHD
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZCaxtA8dnJJHWiK17bfHD)_