### PR TITLE
Napraw układ bloków w sekcjach usług: 4 kolumny → 2×2

### DIFF
--- a/assets/css/services-page.css
+++ b/assets/css/services-page.css
@@ -1133,3 +1133,305 @@
         font-size: 1rem;
     }
 }
+
+/* ========== KLIKALNE KARTY NAWIGACYJNE ========== */
+a.pricing-card {
+    text-decoration: none;
+    color: inherit;
+    display: flex;
+    flex-direction: column;
+}
+
+a.pricing-card:hover,
+a.pricing-card:focus {
+    color: inherit;
+}
+
+a.pricing-card:hover span.card-btn.btn-secondary {
+    background: var(--color-primary);
+    color: #ffffff;
+}
+
+/* Span udający przycisk (cała karta jest linkiem) */
+span.card-btn {
+    display: block;
+    width: 100%;
+    padding: 16px 24px;
+    text-align: center;
+    font-weight: 600;
+    border-radius: 12px;
+    font-size: 1rem;
+    margin-top: auto;
+    transition: background 0.3s ease, color 0.3s ease;
+    cursor: pointer;
+}
+
+/* ========== SEKCJE SZCZEGÓŁÓW USŁUG ========== */
+.service {
+    padding: 88px 0 96px;
+    border-top: 1px solid #e8ecef;
+    scroll-margin-top: 90px;
+}
+
+.service:first-of-type {
+    border-top: none;
+}
+
+/* Nagłówek sekcji: duży numer + kolumna z tytułem */
+.service-head {
+    display: flex;
+    gap: 40px;
+    align-items: flex-start;
+    margin-bottom: 56px;
+}
+
+.service-num {
+    font-size: 5.5rem;
+    font-weight: 900;
+    line-height: 1;
+    color: var(--color-primary);
+    opacity: 0.12;
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
+    user-select: none;
+}
+
+.service-title-wrap {
+    flex: 1;
+}
+
+.service-eyebrow {
+    font-size: 0.8125rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-primary);
+    margin-bottom: 10px;
+}
+
+.service-title {
+    font-size: clamp(1.625rem, 3vw, 2.25rem);
+    font-weight: 700;
+    color: #1a1a1a;
+    margin-bottom: 16px;
+    line-height: 1.25;
+}
+
+.service-lead {
+    font-size: 1.0625rem;
+    color: #555;
+    line-height: 1.75;
+    max-width: 640px;
+}
+
+/* Siatka bloków treści */
+.blocks {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+    margin-bottom: 40px;
+}
+
+.block {
+    background: #ffffff;
+    border: 1px solid #e8ecef;
+    border-radius: 14px;
+    padding: 24px 28px;
+}
+
+.block h4 {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.9375rem;
+    font-weight: 700;
+    color: #1a1a1a;
+    margin-bottom: 14px;
+}
+
+.dot {
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    background: var(--color-primary);
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.block ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+}
+
+.block li {
+    font-size: 0.9375rem;
+    color: #555;
+    line-height: 1.55;
+    padding-left: 18px;
+    position: relative;
+}
+
+.block li::before {
+    content: '–';
+    position: absolute;
+    left: 0;
+    color: var(--color-primary);
+    font-weight: 700;
+}
+
+/* Wyciszony blok "Czego NIE robię" */
+.block.muted {
+    background: #f8f9fa;
+    border-color: #e0e0e0;
+}
+
+.block.muted h4 {
+    color: #888;
+}
+
+.block.muted .dot {
+    background: #c0c8d0;
+}
+
+.block.muted li {
+    color: #888;
+}
+
+.block.muted li::before {
+    color: #bbb;
+}
+
+/* Oś czasu kroków projektu */
+.timeline {
+    background: #f4f8fa;
+    border-radius: 14px;
+    padding: 28px 32px;
+    margin-bottom: 40px;
+}
+
+.timeline h4 {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.9375rem;
+    font-weight: 700;
+    color: #1a1a1a;
+    margin-bottom: 24px;
+}
+
+.steps-row {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+}
+
+.step-mini {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    text-align: center;
+}
+
+.sn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    background: var(--color-primary);
+    color: #ffffff;
+    font-weight: 700;
+    font-size: 0.8125rem;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.st {
+    font-size: 0.8125rem;
+    color: #555;
+    line-height: 1.4;
+    font-weight: 500;
+}
+
+/* CTA na dole każdej sekcji usługi */
+.service-cta {
+    display: flex;
+    align-items: center;
+    gap: 28px;
+    flex-wrap: wrap;
+}
+
+.service-cta .meta-txt {
+    font-size: 0.9375rem;
+    color: #777;
+    line-height: 1.5;
+}
+
+.service-cta a {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 13px 28px;
+    background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
+    color: #ffffff;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    border-radius: 10px;
+    text-decoration: none;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    box-shadow: 0 4px 12px rgba(6, 182, 212, 0.28);
+    white-space: nowrap;
+}
+
+.service-cta a:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(6, 182, 212, 0.38);
+}
+
+/* ========== RESPONSIVE — SEKCJE USŁUG ========== */
+@media (max-width: 900px) {
+    .steps-row {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 14px;
+    }
+}
+
+@media (max-width: 768px) {
+    .service {
+        padding: 56px 0 64px;
+    }
+
+    .service-head {
+        flex-direction: column;
+        gap: 8px;
+        margin-bottom: 32px;
+    }
+
+    .service-num {
+        font-size: 3rem;
+    }
+
+    .blocks {
+        grid-template-columns: 1fr;
+    }
+
+    .timeline {
+        padding: 20px;
+    }
+
+    .service-cta {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 16px;
+    }
+
+    .service-cta a {
+        width: 100%;
+        justify-content: center;
+    }
+}

--- a/assets/css/services-page.css
+++ b/assets/css/services-page.css
@@ -1171,6 +1171,11 @@ span.card-btn {
     padding: 88px 0 96px;
     border-top: 1px solid #e8ecef;
     scroll-margin-top: 90px;
+    background: #ffffff;
+}
+
+.service--alt {
+    background: #f4f8fa;
 }
 
 .service:first-of-type {
@@ -1227,7 +1232,7 @@ span.card-btn {
 /* Siatka bloków treści */
 .blocks {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: repeat(2, 1fr);
     gap: 20px;
     margin-bottom: 40px;
 }

--- a/index.html
+++ b/index.html
@@ -503,7 +503,7 @@
                     <p class="service-time">Czas większych projektów: 4–5 miesięcy</p>
                     <p class="service-price">wycena indywidualna</p>
                 </div>
-                <a href="uslugi.html#produkty-cyfrowe" class="service-btn">Więcej informacji →</a>
+                <a href="uslugi.html#produkty" class="service-btn">Więcej informacji →</a>
             </div>
 
             <!-- OBSZAR 2: Automatyzacje procesów -->

--- a/uslugi.html
+++ b/uslugi.html
@@ -128,24 +128,19 @@
   <section class="services-pricing" aria-labelledby="areas-title">
     <div class="container">
       <h2 class="section-title" id="areas-title">Trzy obszary, w których pomagam</h2>
-      <p class="section-subtitle">Każdy projekt zaczyna się od rozmowy o procesie i kończy działającym rozwiązaniem</p>
+      <p class="section-subtitle">Wybierz obszar, który Cię interesuje — szczegóły znajdziesz niżej na tej stronie</p>
 
       <div class="pricing-grid">
 
         <!-- Obszar 1: Produkty cyfrowe -->
-        <div class="pricing-card" id="produkty-cyfrowe-card">
+        <a href="#produkty" class="pricing-card" id="produkty-cyfrowe-card">
           <div class="card-header">
             <div class="card-icon" aria-hidden="true">💻</div>
             <h3 class="card-title">Produkty cyfrowe</h3>
-            <p class="card-subtitle">Aplikacje i strony projektowane pod proces</p>
+            <p class="card-subtitle">Aplikacje i strony projektowane pod proces.</p>
           </div>
-
-          <div class="card-pricing">
-            <span class="price-amount" style="font-size: 1.25rem; line-height: 1.3;">Wycena indywidualna</span>
-          </div>
-
           <div class="card-features">
-            <ul aria-label="Co obejmuje obszar Produkty cyfrowe">
+            <ul aria-label="Zakres obszaru Produkty cyfrowe">
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -156,65 +151,29 @@
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                Strony internetowe — od prezentacyjnych po z integracjami
+                Strony i sklepy z integracjami
               </li>
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                Sklepy i systemy zamówień (WordPress, WooCommerce)
-              </li>
-              <li>
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Architektura informacji, projekt interfejsu, wdrożenie
-              </li>
-              <li>
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Wsparcie po starcie i dopracowanie w praktyce
+                Projekt, wdrożenie i wsparcie
               </li>
             </ul>
           </div>
-
-          <div class="card-meta">
-            <span class="meta-item">
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/>
-                <path d="M8 4v4l2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-              </svg>
-              <time datetime="P4M">Większe projekty: 4–5 miesięcy</time>
-            </span>
-          </div>
-
-          <a href="#produkty-cyfrowe" class="card-btn btn-secondary" data-area="produkty">
-            Szczegóły obszaru
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-              <path d="M6 2L12 8L6 14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </a>
-        </div>
+          <span class="card-btn btn-secondary">Zobacz szczegóły →</span>
+        </a>
 
         <!-- Obszar 2: Automatyzacje (najczęściej wybierane) -->
-        <div class="pricing-card featured" id="automatyzacje-card">
-          <div class="popular-badge">
-            Najczęściej wybierane
-          </div>
-
+        <a href="#automatyzacje" class="pricing-card featured" id="automatyzacje-card">
+          <div class="popular-badge">Najczęściej wybierane</div>
           <div class="card-header">
             <div class="card-icon" aria-hidden="true">⚙️</div>
             <h3 class="card-title">Automatyzacje procesów</h3>
-            <p class="card-subtitle">Z ręcznej roboty do działającego automatu</p>
+            <p class="card-subtitle">Z ręcznej roboty do działającego automatu.</p>
           </div>
-
-          <div class="card-pricing">
-            <span class="price-amount" style="font-size: 1.25rem; line-height: 1.3;">Wycena indywidualna</span>
-          </div>
-
           <div class="card-features">
-            <ul aria-label="Co obejmuje obszar Automatyzacje procesów">
+            <ul aria-label="Zakres obszaru Automatyzacje procesów">
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -225,61 +184,28 @@
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                Integracje między systemami, bazami i plikami
+                Integracje, kalkulatory, powiadomienia
               </li>
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                Kalkulatory i konfiguratory na realnej logice biznesowej
-              </li>
-              <li>
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Skrócenie powtarzalnych zadań nawet o ponad 90%
-              </li>
-              <li>
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Testowanie i wdrożenie w realnym środowisku pracy
+                Realny efekt: z godzin do kilku minut
               </li>
             </ul>
           </div>
-
-          <div class="card-meta">
-            <span class="meta-item">
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/>
-                <path d="M8 4v4l2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-              </svg>
-              <time>Realny efekt: z godziny do kilku minut</time>
-            </span>
-          </div>
-
-          <a href="#automatyzacje" class="card-btn btn-primary" data-area="automatyzacje">
-            Szczegóły obszaru
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-              <path d="M6 2L12 8L6 14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </a>
-        </div>
+          <span class="card-btn btn-primary">Zobacz szczegóły →</span>
+        </a>
 
         <!-- Obszar 3: Usprawnienia procesów -->
-        <div class="pricing-card" id="usprawnienia-card">
+        <a href="#usprawnienia" class="pricing-card" id="usprawnienia-card">
           <div class="card-header">
             <div class="card-icon" aria-hidden="true">🎯</div>
             <h3 class="card-title">Usprawnienia procesów</h3>
-            <p class="card-subtitle">Analiza i porządkowanie tego, co dziś działa „jakoś"</p>
+            <p class="card-subtitle">Analiza i porządkowanie tego, co dziś działa „jakoś".</p>
           </div>
-
-          <div class="card-pricing">
-            <span class="price-amount" style="font-size: 1.25rem; line-height: 1.3;">Wycena indywidualna</span>
-          </div>
-
           <div class="card-features">
-            <ul aria-label="Co obejmuje obszar Usprawnienia procesów">
+            <ul aria-label="Zakres obszaru Usprawnienia procesów">
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -290,13 +216,7 @@
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
                   <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                Projekt nowego przebiegu pracy lub narzędzia
-              </li>
-              <li>
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Decyzja: aplikacja, automat, skrypt czy zmiana sposobu pracy
+                Decyzja: automat, aplikacja lub zmiana pracy
               </li>
               <li>
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
@@ -304,130 +224,228 @@
                 </svg>
                 Wdrożenie zmian razem z zespołem
               </li>
-              <li>
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                  <path d="M16.667 5L7.5 14.167L3.333 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Mniej błędów, większa przewidywalność, mniej „ratowania"
-              </li>
             </ul>
           </div>
+          <span class="card-btn btn-secondary">Zobacz szczegóły →</span>
+        </a>
 
-          <div class="card-meta">
-            <span class="meta-item">
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/>
-                <path d="M8 4v4l2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-              </svg>
-              <time>Zakres ustalany po analizie</time>
-            </span>
-          </div>
-
-          <a href="#usprawnienia" class="card-btn btn-secondary" data-area="usprawnienia">
-            Szczegóły obszaru
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-              <path d="M6 2L12 8L6 14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </a>
-        </div>
       </div>
     </div>
   </section>
 
-  <!-- ========== SZCZEGÓŁY OBSZARÓW ========== -->
-  <section class="package-details" aria-labelledby="details-title">
+  <!-- ============ USŁUGA 1: PRODUKTY CYFROWE ============ -->
+  <section class="service" id="produkty">
     <div class="container">
-      <h2 class="section-title" id="details-title">Co konkretnie robię w każdym obszarze</h2>
 
-      <div class="details-grid">
-        <!-- Obszar 1 -->
-        <div class="detail-card" id="produkty-cyfrowe">
-          <div class="detail-header">
-            <div class="detail-icon" aria-hidden="true">💻</div>
-            <h3>Produkty cyfrowe</h3>
-            <p class="detail-tagline">Aplikacje i strony projektowane pod proces</p>
-          </div>
-
-          <div class="detail-section">
-            <h4>Dla kogo</h4>
-            <p>Dla firm, które potrzebują narzędzia dopasowanego do tego, jak realnie pracują — nie kolejnego szablonu. Najczęściej są to firmy, które dziś używają arkuszy, plików i kilku oderwanych systemów, a chcą mieć jedno, spójne rozwiązanie.</p>
-          </div>
-
-          <div class="detail-section">
-            <h4>Co dokładnie robię</h4>
-            <p>Zaczynam od rozmowy o procesie i ludziach, którzy z niego korzystają. Projektuję strukturę produktu, interfejs i logikę działania. Buduję rozwiązanie, integruję je z tym, co już macie, i testuję ręcznie w realnych scenariuszach. Zostaję na tyle blisko, żeby wesprzeć pierwsze tygodnie użycia.</p>
-          </div>
-
-          <div class="detail-benefits">
-            <h4>Co zyskujesz</h4>
-            <ul>
-              <li>Narzędzie dopasowane do realnego procesu, nie odwrotnie</li>
-              <li>Spójność: jeden produkt zamiast pięciu oderwanych plików</li>
-              <li>Wdrożenie do końca, bez „dokończymy potem"</li>
-              <li>Wsparcie w pierwszych tygodniach użycia</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Obszar 2 -->
-        <div class="detail-card featured" id="automatyzacje">
-          <div class="popular-badge-detail">Największa różnica w czasie pracy</div>
-          <div class="detail-header">
-            <div class="detail-icon" aria-hidden="true">⚙️</div>
-            <h3>Automatyzacje procesów</h3>
-            <p class="detail-tagline">Z ręcznej roboty do działającego automatu</p>
-          </div>
-
-          <div class="detail-section">
-            <h4>Dla kogo</h4>
-            <p>Dla firm, w których ten sam zestaw kroków powtarza się codziennie albo co tydzień: liczenie ofert, przygotowywanie plików, wprowadzanie danych, generowanie raportów. Tam, gdzie ktoś od miesięcy mówi „przydałby się skrypt".</p>
-          </div>
-
-          <div class="detail-section">
-            <h4>Co dokładnie robię</h4>
-            <p>Rozbieram proces na czynniki pierwsze, identyfikuję miejsca, które naprawdę można zautomatyzować, i piszę rozwiązanie (najczęściej w Google Apps Script, w połączeniu z arkuszami, bazami danych i plikami). Najmocniejszy zrealizowany przykład: aplikacja dla drukarni, która skróciła proces wyceny z około godziny do około 5 minut. Inny — przygotowanie dużej liczby plików z godziny do około 1,5 minuty.</p>
-          </div>
-
-          <div class="detail-benefits">
-            <h4>Co zyskujesz</h4>
-            <ul>
-              <li>Realne godziny pracy odzyskane co tydzień</li>
-              <li>Mniej błędów wynikających ze zmęczenia i ręcznego przepisywania</li>
-              <li>Przewidywalność: ten sam proces, ten sam wynik</li>
-              <li>Rozwiązanie wpisane w realne narzędzia, których już używacie</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Obszar 3 -->
-        <div class="detail-card" id="usprawnienia">
-          <div class="detail-header">
-            <div class="detail-icon" aria-hidden="true">🎯</div>
-            <h3>Usprawnienia procesów</h3>
-            <p class="detail-tagline">Analiza i porządkowanie tego, co dziś działa „jakoś"</p>
-          </div>
-
-          <div class="detail-section">
-            <h4>Dla kogo</h4>
-            <p>Dla firm, które wiedzą, że coś nie działa, ale nie do końca wiedzą co. Najczęściej okazuje się, że odpowiedzią nie jest „kolejny system", tylko zmiana w samym przebiegu pracy — albo mały, dobrze zaprojektowany element, który porządkuje resztę.</p>
-          </div>
-
-          <div class="detail-section">
-            <h4>Co dokładnie robię</h4>
-            <p>Wchodzę głęboko w proces: rozmawiam z ludźmi, którzy go wykonują, sprawdzam realne narzędzia i dane. Pokazuję, gdzie tracony jest czas i pojawiają się błędy. Proponuję rozwiązanie — czasem to aplikacja, czasem prosty skrypt, czasem zmiana w sposobie pracy, której nie da się kupić w pudełku. I wdrażam to razem z zespołem.</p>
-          </div>
-
-          <div class="detail-benefits">
-            <h4>Co zyskujesz</h4>
-            <ul>
-              <li>Diagnoza, która pokazuje, gdzie naprawdę leży problem</li>
-              <li>Rozwiązanie dopasowane do tego, a nie do mody</li>
-              <li>Wdrożenie, a nie tylko raport na półkę</li>
-              <li>Spójniejszy, mniej awaryjny proces w codziennej pracy</li>
-            </ul>
-          </div>
+      <div class="service-head">
+        <div class="service-num" aria-hidden="true">01</div>
+        <div class="service-title-wrap">
+          <div class="service-eyebrow">Produkty cyfrowe</div>
+          <h2 class="service-title">Aplikacje biznesowe i strony internetowe</h2>
+          <p class="service-lead">Dla firm, które potrzebują własnego narzędzia zamiast walki z gotowcem, albo strony, która faktycznie wspiera sprzedaż.</p>
         </div>
       </div>
+
+      <div class="blocks">
+        <div class="block">
+          <h4><span class="dot" aria-hidden="true"></span>Dla kogo</h4>
+          <ul>
+            <li>Firma, która ma proces nie do zamknięcia w gotowym SaaS</li>
+            <li>Zespół potrzebujący jednego, swojego narzędzia</li>
+            <li>Marka, która musi mieć stronę z indywidualną logiką</li>
+          </ul>
+        </div>
+
+        <div class="block">
+          <h4><span class="dot" aria-hidden="true"></span>Co dokładnie robię</h4>
+          <ul>
+            <li>Architektura informacji i projekt interfejsu (UX/UI)</li>
+            <li>Aplikacje webowe szyte pod proces</li>
+            <li>Strony i sklepy (WordPress, WooCommerce)</li>
+            <li>Integracje z zewnętrznymi systemami</li>
+            <li>Wdrożenie i wsparcie po starcie</li>
+          </ul>
+        </div>
+
+        <div class="block">
+          <h4><span class="dot" aria-hidden="true"></span>Co dostajesz</h4>
+          <ul>
+            <li>Działający produkt gotowy do użycia</li>
+            <li>Dokumentację i przekazanie wiedzy</li>
+            <li>Wsparcie w pierwszych tygodniach użycia</li>
+            <li>Możliwość dalszego rozwoju</li>
+          </ul>
+        </div>
+
+        <div class="block muted">
+          <h4><span class="dot" aria-hidden="true"></span>Czego NIE robię w tym obszarze</h4>
+          <ul>
+            <li>natywne aplikacje mobilne iOS/Android</li>
+            <li>systemy wymagające pełnego zespołu backendowego</li>
+            <li>projekty wymagające infrastruktury enterprise</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="timeline">
+        <h4><span class="dot" aria-hidden="true"></span>Jak przebiega projekt</h4>
+        <div class="steps-row">
+          <div class="step-mini"><div class="sn">01</div><div class="st">Zrozumienie problemu</div></div>
+          <div class="step-mini"><div class="sn">02</div><div class="st">Projekt rozwiązania</div></div>
+          <div class="step-mini"><div class="sn">03</div><div class="st">Budowa i testy</div></div>
+          <div class="step-mini"><div class="sn">04</div><div class="st">Wdrożenie i wsparcie</div></div>
+        </div>
+      </div>
+
+      <div class="service-cta">
+        <p class="meta-txt"><b>Czas większych projektów:</b> 4–5 miesięcy · Wycena indywidualna</p>
+        <a href="index.html#contact">Zapytaj o wycenę →</a>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ============ USŁUGA 2: AUTOMATYZACJE ============ -->
+  <section class="service" id="automatyzacje">
+    <div class="container">
+
+      <div class="service-head">
+        <div class="service-num" aria-hidden="true">02</div>
+        <div class="service-title-wrap">
+          <div class="service-eyebrow">Automatyzacje procesów · najczęściej wybierane</div>
+          <h2 class="service-title">Zamieniam ręczne czynności w działające automaty</h2>
+          <p class="service-lead">Najszybszy sposób, żeby zobaczyć efekt współpracy — automatyzacja powtarzalnego zadania zwykle daje odczuwalną oszczędność czasu już na starcie.</p>
+        </div>
+      </div>
+
+      <div class="blocks">
+        <div class="block">
+          <h4><span class="dot" aria-hidden="true"></span>Dla kogo</h4>
+          <ul>
+            <li>Firma robiąca regularnie to samo „na piechotę"</li>
+            <li>Zespół, w którym dane krążą między arkuszami i mailami</li>
+            <li>Biuro tracące godziny na przepisywanie i sprawdzanie</li>
+          </ul>
+        </div>
+
+        <div class="block">
+          <h4><span class="dot" aria-hidden="true"></span>Co dokładnie robię</h4>
+          <ul>
+            <li>Automatyzacje w Google Apps Script i arkuszach</li>
+            <li>Integracje między systemami, bazami i plikami</li>
+            <li>Kalkulatory i konfiguratory oparte na realnej logice</li>
+            <li>Powiadomienia, raporty i wyzwalacze automatyczne</li>
+            <li>Testowanie i wdrożenie w realnym środowisku pracy</li>
+          </ul>
+        </div>
+
+        <div class="block">
+          <h4><span class="dot" aria-hidden="true"></span>Co dostajesz</h4>
+          <ul>
+            <li>Działający automat gotowy do użycia</li>
+            <li>Pomiar realnej oszczędności (przed/po)</li>
+            <li>Krótka instrukcja dla zespołu</li>
+            <li>Wsparcie przy ewentualnych poprawkach</li>
+          </ul>
+        </div>
+
+        <div class="block muted">
+          <h4><span class="dot" aria-hidden="true"></span>Czego NIE robię w tym obszarze</h4>
+          <ul>
+            <li>wdrożenia enterprise RPA typu UiPath</li>
+            <li>integracje wymagające własnej infrastruktury serwerowej</li>
+            <li>boty AI na własnych modelach</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="timeline">
+        <h4><span class="dot" aria-hidden="true"></span>Jak przebiega projekt</h4>
+        <div class="steps-row">
+          <div class="step-mini"><div class="sn">01</div><div class="st">Analiza procesu</div></div>
+          <div class="step-mini"><div class="sn">02</div><div class="st">Projekt automatu</div></div>
+          <div class="step-mini"><div class="sn">03</div><div class="st">Budowa i testy</div></div>
+          <div class="step-mini"><div class="sn">04</div><div class="st">Wdrożenie i pomiar</div></div>
+        </div>
+      </div>
+
+      <div class="service-cta">
+        <p class="meta-txt"><b>Realny efekt:</b> z godziny do kilku minut · Wycena indywidualna</p>
+        <a href="index.html#contact">Zapytaj o wycenę →</a>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ============ USŁUGA 3: USPRAWNIENIA ============ -->
+  <section class="service" id="usprawnienia">
+    <div class="container">
+
+      <div class="service-head">
+        <div class="service-num" aria-hidden="true">03</div>
+        <div class="service-title-wrap">
+          <div class="service-eyebrow">Usprawnienia procesów</div>
+          <h2 class="service-title">Analiza i porządkowanie tego, co dziś działa „jakoś"</h2>
+          <p class="service-lead">Zanim coś zaprogramuję albo zautomatyzuję, czasem trzeba najpierw zrozumieć, dlaczego proces nie działa i co faktycznie warto zmienić.</p>
+        </div>
+      </div>
+
+      <div class="blocks">
+        <div class="block">
+          <h4><span class="dot" aria-hidden="true"></span>Dla kogo</h4>
+          <ul>
+            <li>Firma, w której „wszystko jakoś działa", ale wolno i z błędami</li>
+            <li>Zespół, który nie wie, gdzie tkwi problem</li>
+            <li>Lider chcący wiedzieć, co usprawnić w pierwszej kolejności</li>
+          </ul>
+        </div>
+
+        <div class="block">
+          <h4><span class="dot" aria-hidden="true"></span>Co dokładnie robię</h4>
+          <ul>
+            <li>Analiza procesu i wskazanie wąskich gardeł</li>
+            <li>Projekt nowego przebiegu pracy lub narzędzia</li>
+            <li>Decyzja: aplikacja, automat, skrypt czy zmiana w pracy</li>
+            <li>Wdrożenie zmian razem z zespołem</li>
+            <li>Pomiar efektów i drobne korekty</li>
+          </ul>
+        </div>
+
+        <div class="block">
+          <h4><span class="dot" aria-hidden="true"></span>Co dostajesz</h4>
+          <ul>
+            <li>Mapę procesu „przed → po"</li>
+            <li>Konkretne rekomendacje uporządkowane wg priorytetu</li>
+            <li>Wdrożenie tego, co realne do zrobienia od razu</li>
+            <li>Mniej błędów i większą przewidywalność</li>
+          </ul>
+        </div>
+
+        <div class="block muted">
+          <h4><span class="dot" aria-hidden="true"></span>Czego NIE robię w tym obszarze</h4>
+          <ul>
+            <li>pełny consulting strategiczny</li>
+            <li>szkolenia zespołów z metodyk</li>
+            <li>audyty wymagające certyfikacji</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="timeline">
+        <h4><span class="dot" aria-hidden="true"></span>Jak przebiega projekt</h4>
+        <div class="steps-row">
+          <div class="step-mini"><div class="sn">01</div><div class="st">Wywiad i mapowanie</div></div>
+          <div class="step-mini"><div class="sn">02</div><div class="st">Diagnoza i rekomendacje</div></div>
+          <div class="step-mini"><div class="sn">03</div><div class="st">Wdrożenie zmian</div></div>
+          <div class="step-mini"><div class="sn">04</div><div class="st">Pomiar i korekty</div></div>
+        </div>
+      </div>
+
+      <div class="service-cta">
+        <p class="meta-txt"><b>Zakres ustalany po analizie</b> · Wycena indywidualna</p>
+        <a href="index.html#contact">Zapytaj o wycenę →</a>
+      </div>
+
     </div>
   </section>
 

--- a/uslugi.html
+++ b/uslugi.html
@@ -234,7 +234,7 @@
   </section>
 
   <!-- ============ USŁUGA 1: PRODUKTY CYFROWE ============ -->
-  <section class="service" id="produkty">
+  <section class="service service--alt" id="produkty">
     <div class="container">
 
       <div class="service-head">
@@ -378,7 +378,7 @@
   </section>
 
   <!-- ============ USŁUGA 3: USPRAWNIENIA ============ -->
-  <section class="service" id="usprawnienia">
+  <section class="service service--alt" id="usprawnienia">
     <div class="container">
 
       <div class="service-head">


### PR DESCRIPTION
## Zmiana

- `.blocks`: `repeat(auto-fit, minmax(260px, 1fr))` → `repeat(2, 1fr)` — 4 bloki treści tworzą siatkę 2×2 zamiast jednego szerokiego rzędu 4 kolumn
- Dodano `.service--alt { background: #f4f8fa }` — naprzemienne tła sekcji usług (Produkty + Usprawnienia szare, Automatyzacje białe)

https://claude.ai/code/session_018ZCaxtA8dnJJHWiK17bfHD

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZCaxtA8dnJJHWiK17bfHD)_