### PR TITLE
Restore uslugi.html nav cards and missing produkty section

### DIFF
--- a/uslugi.html
+++ b/uslugi.html
@@ -141,67 +141,32 @@
           </div>
           <div class="card-features">
             <ul aria-label="Co obejmuje obszar Produkty cyfrowe">
-                 <li>Aplikacje webowe pod konkretny proces</li>
-      <li>Strony, sklepy i integracje</li>
-      <li>Projekt, wdrożenie i wsparcie po starcie</li>
-    </ul>
-  </div>
-
-  <div class="card-meta">
-    <span class="meta-item">
-      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-        <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/>
-        <path d="M8 4v4l2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-      </svg>
-      <time datetime="P4M">Większe projekty: 4–5 miesięcy</time>
-    </span>
-  </div>
-
-  <a href="#produkty" class="card-btn btn-secondary" data-area="produkty">
-    Zobacz szczegóły
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M6 2L12 8L6 14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  </a>
-</div>
+              <li>Aplikacje webowe pod konkretny proces</li>
+              <li>Strony, sklepy i integracje</li>
+              <li>Projekt, wdrożenie i wsparcie po starcie</li>
+            </ul>
+          </div>
+          <span class="card-btn btn-secondary">Zobacz szczegóły →</span>
+        </a>
 
         <!-- Obszar 2: Automatyzacje (najczęściej wybierane) -->
-        <div class="pricing-card featured" id="automatyzacje-card">
-          <div class="popular-badge">
-            Najczęściej wybierane
+        <a href="#automatyzacje" class="pricing-card featured" id="automatyzacje-card">
+          <div class="popular-badge">Najczęściej wybierane</div>
+          <div class="card-header">
+            <div class="card-icon" aria-hidden="true">⚙️</div>
+            <h3 class="card-title">Automatyzacje procesów</h3>
+            <p class="card-subtitle">Z ręcznej roboty do działającego automatu</p>
           </div>
+          <div class="card-features">
+            <ul aria-label="Co obejmuje obszar Automatyzacje procesów">
+              <li>Automatyzacje w Google Apps Script i arkuszach</li>
+              <li>Integracje, kalkulatory i logika biznesowa</li>
+              <li>Testy, wdrożenie i realna oszczędność czasu</li>
+            </ul>
+          </div>
+          <span class="card-btn btn-primary">Zobacz szczegóły →</span>
+        </a>
 
-        <div class="card-header">
-    <div class="card-icon" aria-hidden="true">⚙️</div>
-    <h3 class="card-title">Automatyzacje procesów</h3>
-    <p class="card-subtitle">Z ręcznej roboty do działającego automatu</p>
-  </div>
-
-  <div class="card-features">
-    <ul aria-label="Co obejmuje obszar Automatyzacje procesów">
-      <li>Automatyzacje w Google Apps Script i arkuszach</li>
-      <li>Integracje, kalkulatory i logika biznesowa</li>
-      <li>Testy, wdrożenie i realna oszczędność czasu</li>
-    </ul>
-  </div>
-
-  <div class="card-meta">
-    <span class="meta-item">
-      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-        <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/>
-        <path d="M8 4v4l2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-      </svg>
-      <time>Realny efekt: z godziny do kilku minut</time>
-    </span>
-  </div>
-
-  <a href="#automatyzacje" class="card-btn btn-primary" data-area="automatyzacje">
-    Zobacz szczegóły
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M6 2L12 8L6 14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  </a>
-</div>
         <!-- Obszar 3: Usprawnienia procesów -->
         <a href="#usprawnienia" class="pricing-card" id="usprawnienia-card">
           <div class="card-header">
@@ -209,32 +174,91 @@
             <h3 class="card-title">Usprawnienia procesów</h3>
             <p class="card-subtitle">Analiza i porządkowanie tego, co dziś działa „jakoś"</p>
           </div>
-
           <div class="card-features">
-    <ul aria-label="Co obejmuje obszar Usprawnienia procesów">
-      <li>Analiza procesu i wskazanie wąskich gardeł</li>
-      <li>Decyzja: automat, aplikacja lub zmiana pracy</li>
-      <li>Wdrożenie zmian i uporządkowanie działania zespołu</li>
-    </ul>
-  </div>
+            <ul aria-label="Co obejmuje obszar Usprawnienia procesów">
+              <li>Analiza procesu i wskazanie wąskich gardeł</li>
+              <li>Decyzja: automat, aplikacja lub zmiana pracy</li>
+              <li>Wdrożenie zmian i uporządkowanie działania zespołu</li>
+            </ul>
+          </div>
+          <span class="card-btn btn-secondary">Zobacz szczegóły →</span>
+        </a>
 
-  <div class="card-meta">
-    <span class="meta-item">
-      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-        <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/>
-        <path d="M8 4v4l2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-      </svg>
-      <time>Zakres ustalany po analizie</time>
-    </span>
-  </div>
+      </div><!-- /pricing-grid -->
+    </div><!-- /container -->
+  </section><!-- /services-pricing -->
 
-  <a href="#usprawnienia" class="card-btn btn-secondary" data-area="usprawnienia">
-    Zobacz szczegóły
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M6 2L12 8L6 14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  </a>
-</div>
+  <!-- ============ USŁUGA 1: PRODUKTY CYFROWE ============ -->
+  <section class="service service--alt" id="produkty">
+    <div class="container">
+
+      <div class="service-head">
+        <div class="service-num" aria-hidden="true">01</div>
+        <div class="service-title-wrap">
+          <div class="service-eyebrow">Produkty cyfrowe</div>
+          <h2 class="service-title">Aplikacje biznesowe i strony internetowe</h2>
+          <p class="service-lead">Dla firm, które potrzebują własnego narzędzia zamiast walki z gotowcem, albo strony, która faktycznie wspiera sprzedaż.</p>
+        </div>
+      </div>
+
+      <div class="blocks">
+        <div class="block">
+          <h4><span class="dot" aria-hidden="true"></span>Dla kogo</h4>
+          <ul>
+            <li>Firma, która ma proces nie do zamknięcia w gotowym SaaS</li>
+            <li>Zespół potrzebujący jednego, swojego narzędzia</li>
+            <li>Marka, która musi mieć stronę z indywidualną logiką</li>
+          </ul>
+        </div>
+
+        <div class="block">
+          <h4><span class="dot" aria-hidden="true"></span>Co dokładnie robię</h4>
+          <ul>
+            <li>Architektura informacji i projekt interfejsu (UX/UI)</li>
+            <li>Aplikacje webowe szyte pod proces</li>
+            <li>Strony i sklepy (WordPress, WooCommerce)</li>
+            <li>Integracje z zewnętrznymi systemami</li>
+            <li>Wdrożenie i wsparcie po starcie</li>
+          </ul>
+        </div>
+
+        <div class="block">
+          <h4><span class="dot" aria-hidden="true"></span>Co dostajesz</h4>
+          <ul>
+            <li>Działający produkt gotowy do użycia</li>
+            <li>Dokumentację i przekazanie wiedzy</li>
+            <li>Wsparcie w pierwszych tygodniach użycia</li>
+            <li>Możliwość dalszego rozwoju</li>
+          </ul>
+        </div>
+
+        <div class="block muted">
+          <h4><span class="dot" aria-hidden="true"></span>Czego NIE robię w tym obszarze</h4>
+          <ul>
+            <li>natywne aplikacje mobilne iOS/Android</li>
+            <li>systemy wymagające pełnego zespołu backendowego</li>
+            <li>projekty wymagające infrastruktury enterprise</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="timeline">
+        <h4><span class="dot" aria-hidden="true"></span>Jak przebiega projekt</h4>
+        <div class="steps-row">
+          <div class="step-mini"><div class="sn">01</div><div class="st">Zrozumienie problemu</div></div>
+          <div class="step-mini"><div class="sn">02</div><div class="st">Projekt rozwiązania</div></div>
+          <div class="step-mini"><div class="sn">03</div><div class="st">Budowa i testy</div></div>
+          <div class="step-mini"><div class="sn">04</div><div class="st">Wdrożenie i wsparcie</div></div>
+        </div>
+      </div>
+
+      <div class="service-cta">
+        <p class="meta-txt"><b>Czas większych projektów:</b> 4–5 miesięcy · Wycena indywidualna</p>
+        <a href="index.html#contact">Zapytaj o wycenę →</a>
+      </div>
+
+    </div>
+  </section>
 
   <!-- ============ USŁUGA 2: AUTOMATYZACJE ============ -->
   <section class="service" id="automatyzacje">


### PR DESCRIPTION
## Summary

- Fix pricing nav cards: remove leftover `card-meta`, replace nested `<a class="card-btn">` with `<span class="card-btn">` (valid HTML)
- Fix automatyzacje card: change `<div class="pricing-card featured">` back to `<a href="#automatyzacje" class="pricing-card featured">` (fully clickable)
- Restore missing `<section id="produkty">` (Produkty cyfrowe detail section with 4 blocks, timeline, CTA) — deleted by an external commit on main
- Properly close `services-pricing` section before the detail service sections

## Test plan

- [ ] All 3 nav cards scroll to their respective sections on click
- [ ] Automatyzacje card is fully clickable (entire card, not just button)
- [ ] Produkty cyfrowe section (`#produkty`) renders with 2×2 blocks grid, timeline, and CTA
- [ ] Section order: produkty → automatyzacje → usprawnienia
- [ ] Mobile layout looks correct

https://claude.ai/code/session_018ZCaxtA8dnJJHWiK17bfHD

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZCaxtA8dnJJHWiK17bfHD)_