### PR TITLE
RAZ DWA case study: content edits + full consistency audit

### DIFF
--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -558,8 +558,8 @@
               <li>Parser DWG/DXF dla wektorów CAD</li>
               <li>Tryb klienta końcowego z ukrytymi marżami</li>
               <li>Integracja płatności</li>
-              <li>Żadnej funkcji nie wyciąłem na prośbę klienta ani z własnej inicjatywy. Ograniczyłem natomiast liczbę kategorii — powiązane typy usług zostały połączone, żeby zredukować szum i przyspieszyć nawigację do właściwej pozycji cennika.</li>
             </ul>
+            <p>Żadnej funkcji nie wyciąłem na prośbę klienta ani z własnej inicjatywy. Ograniczyłem natomiast liczbę kategorii — powiązane typy usług zostały połączone, żeby zredukować szum i przyspieszyć nawigację do właściwej pozycji cennika.</p>
           </article>
         </div>
       </div>
@@ -858,7 +858,7 @@
           <ul style="margin:0.75rem 0 0;color:#475569;font-size:0.9rem;line-height:1.7;">
             <li><strong>Materiał graficzny (P0):</strong> screenshot tworzenia własnej podgrupy (np. „Wizytówki Premium") w panelu</li>
             <li><strong>Pytanie do autora:</strong> Dlaczego ta funkcja w ogóle powstała? Jakie konkretne zlecenie / rozmowa z drukarnią ją wywołały? 2–3 zdania historii.</li>
-            <li>Klient nie utworzył jeszcze własnych wariantów po wdrożeniu. Informacja zostanie uzupełniona.</li>
+            <li><strong>Status:</strong> Klient nie utworzył jeszcze własnych wariantów po wdrożeniu. Informacja zostanie uzupełniona.</li>
           </ul>
         </div>
       </div>

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -405,7 +405,7 @@
 
         <div class="context-intro">
           <p>
-            <strong>Drukarnia Raz Dwa</strong> obsługuje klientów biznesowych jak i prywatnych zamawiane są wydruki wielkoformatowe,projekty CAD, plakaty A0–A3, banery i folie, wizytówki i wiele innych.
+            <strong>Drukarnia Raz Dwa</strong> obsługuje klientów biznesowych i prywatnych: wydruki wielkoformatowe, projekty CAD, plakaty A0–A3, banery i folie, wizytówki i wiele innych.
             Przed wdrożeniem aplikacji każda wycena wymagała ręcznego sprawdzenia tabeli w cenniku fizycznym, przeliczenia metrów bieżących i zsumowania dopłat. Cały proces zajmował <strong>od 10 minut do ok. 1 godziny</strong>.
           </p>
           <p>
@@ -416,7 +416,7 @@
         <div class="razdwa-stats">
           <div class="razdwa-stat">
             <div class="razdwa-stat-num">~5 min</div>
-            <div class="razdwa-stat-label">czas wyceny (wcześniej ok. godziny)<br></div>
+            <div class="razdwa-stat-label">czas wyceny (wcześniej ok. godziny)</div>
           </div>
           <div class="razdwa-stat">
             <div class="razdwa-stat-num">22</div>
@@ -457,7 +457,7 @@
             <div class="eco-node">
               <div class="eco-node-icon">📄</div>
               <div class="eco-node-label">PDF Export</div>
-              <div class="eco-node-sub">pdf-lib —  podsumowanie zamówienia w formie raportu PDF</div>
+              <div class="eco-node-sub">pdf-lib — podsumowanie zamówienia w formie raportu PDF</div>
             </div>
             <div class="eco-arrow">↔</div>
             <div class="eco-node">
@@ -491,20 +491,15 @@
 
         <h3 style="text-align:center">Jak rozpoznałem problem</h3>
         <div class="ux-decision-grid">
-          
+          <div class="ux-decision-box">
             <h4>Forma rozpoznania potrzeb</h4>
-            <p><strong>Zatrudniłem się w firmie i poznałem proces od środka.</strong>
-              <br>Rozmowa z właścicielem, obserwacja pracowników na żywo, analiza starych metod kalkulacji oraz własne doświadczenie jako klient. </p>
-            <p>Wywiad z pracownikami i analiza sytuacji, gdy ilość klientów przekracza możliwość obsłużenia </p>
+            <p><strong>Zatrudniłem się w firmie i poznałem proces od środka.</strong><br>
+              Rozmowa z właścicielem, obserwacja pracowników na żywo, analiza starych metod kalkulacji oraz własne doświadczenie jako klient.</p>
+            <p>Wywiad z pracownikami i analiza sytuacji, gdy liczba klientów przekracza możliwości obsługi.</p>
           </div>
-        
           <div class="ux-decision-box" style="border-left-color:#f59e0b;background:#fffbeb;">
-            <div class="ux-label" style="color:#f59e0b;"></div>
             <h4>Główne bóle, które usłyszałem</h4>
-            Obliczanie dużej ilości plików jest czasochłonne i żmudne. 
-            Gdy klient zamawia "to samo co ostatnio" nie zawsze wiadomo jak go policzyć i na jakim materiale był robiony wydruk.
-            Nie raz pomylona wycena spotykała się z niezadowoleniem klienta lub właścicielki drukarni
-        
+            <p>Obliczanie dużej ilości plików jest czasochłonne i żmudne. Gdy klient zamawia „to samo co ostatnio", nie zawsze wiadomo jak go policzyć i na jakim materiale był robiony wydruk. Pomylona wycena skutkowała niezadowoleniem klienta lub właścicielki drukarni.</p>
           </div>
         </div>
 
@@ -563,7 +558,7 @@
               <li>Parser DWG/DXF dla wektorów CAD</li>
               <li>Tryb klienta końcowego z ukrytymi marżami</li>
               <li>Integracja płatności</li>
-              <li style="color:#92400e;background:#fffbeb;padding:0.5rem;border-left:3px solid #f59e0b;border-radius:4px;">Żadnej funkcji nie wyciąłem na prośbę klienta ani z własnej inicjatywy. Ograniczyłem natomiast liczbę kategorii — powiązane typy usług zostały połączone, żeby zredukować szum i przyspieszyć nawigację do właściwej pozycji cennika.</li>
+              <li>Żadnej funkcji nie wyciąłem na prośbę klienta ani z własnej inicjatywy. Ograniczyłem natomiast liczbę kategorii — powiązane typy usług zostały połączone, żeby zredukować szum i przyspieszyć nawigację do właściwej pozycji cennika.</li>
             </ul>
           </article>
         </div>
@@ -609,7 +604,7 @@
           </p>
         </div>
 
-        <h3>User flow — zoptymalizowana ścieżka</h3>
+        <h3 style="text-align:center">User flow — zoptymalizowana ścieżka</h3>
         <div class="user-flow">
           <div class="flow-step">
             <div class="flow-step-icon">🏠</div>
@@ -649,7 +644,7 @@
         <div class="showcase-stack">
           <div class="showcase-section">
             <h3>🏗️ Wielokolumnowy layout PWA</h3>
-            <p class="tab-description">Zdecydowano się na stały podział na 3 kolumny: nawigacja kategorii (lewa), aktywny kalkulator (środek), koszyk zamówień (prawa) — dzięki temu użytkownik zawsze widzi stan zamówienia bez scrollowania.</p>
+            <p class="tab-description">Zdecydowałem się na stały podział na 3 kolumny: nawigacja kategorii (lewa), aktywny kalkulator (środek), koszyk zamówień (prawa) — dzięki temu użytkownik zawsze widzi stan zamówienia bez scrollowania.</p>
             <div class="showcase-row">
               <div class="showcase-item">
                 <img class="lightbox-trigger" src="/KWdesignnew/assets/images/strona 3kolumny_RAZDWA.webp" alt="Layout 3-kolumnowy — desktop" loading="lazy" data-caption="Layout 3-kolumnowy — nawigacja, kalkulator, koszyk">
@@ -678,7 +673,7 @@
           </div>
         </div>
 
-        <h3>Kluczowe decyzje UX</h3>
+        <h3 style="text-align:center">Kluczowe decyzje UX</h3>
         <div class="ux-decision-grid">
           <div class="ux-decision-box">
             <div class="ux-label">Problem → Rozwiązanie</div>
@@ -713,7 +708,7 @@
           <p>Najtrudniejszą kategorią do wyceny w drukarni był druk inżynieryjny (CAD). Wyzwaniem było stworzenie mechanizmu, który analizuje uploadowany plik, samodzielnie rozpoznaje czy to format (A0-A3) czy metry bieżące, przelicza piksele na milimetry i sprawdza szerokości zwojów (rolek papieru).</p>
         </div>
 
-        <h3>Iteracje interfejsu kalkulatora plików</h3>
+        <h3 style="text-align:center">Iteracje interfejsu kalkulatora plików</h3>
         <div class="kwcs-gallery-grid">
           <div class="gallery-item">
             <img src="/KWdesignnew/assets/images/kalkulator-cad-v1.png" alt="Iteracja 1" loading="lazy">
@@ -721,7 +716,7 @@
           </div>
           <div class="gallery-item">
             <img src="/KWdesignnew/assets/images/kalkulator-cad-v2.png" alt="Iteracja 2" loading="lazy">
-            <p class="img-desc">Wersja finalna: Model per-plik (Zabezpiecza przed pomyłką)</p>
+            <p class="img-desc">Wersja finalna: Model per-plik (zabezpiecza przed pomyłką)</p>
           </div>
           <div class="gallery-item">
             <img src="/KWdesignnew/assets/images/panel drukA4-A4skan_RAZDWA.webp" alt="Panel z przełącznikiem" loading="lazy">
@@ -733,7 +728,7 @@
 
     <div class="kwcs-sec" style="background: #f8fafc;">
       <div class="wrap">
-        <h3>Logika Kalkulatora CAD w detalach</h3>
+        <h3 style="text-align:center">Logika kalkulatora CAD — szczegóły</h3>
         <div class="kwcs-accordion">
           <div class="kwcs-item">
             <button class="kwcs-header" aria-expanded="false" aria-controls="content-cad-3" id="header-cad-3" type="button">
@@ -878,7 +873,7 @@
           <p>Od momentu, gdy operator dodaje pierwszą pozycję do koszyka, do momentu, gdy zamówienie ląduje w bazie firmy — przepływ został podzielony na etapy, w których trudno popełnić błąd. Każdy etap ma jeden cel i jedno zabezpieczenie.</p>
         </div>
 
-        <h3>Pięć etapów</h3>
+        <h3 style="text-align:center">Pięć etapów</h3>
         <div class="ux-decision-grid">
           <div class="ux-decision-box">
             <div class="ux-label">Etap 1</div>
@@ -888,7 +883,7 @@
           <div class="ux-decision-box">
             <div class="ux-label">Etap 2</div>
             <h4>Tryb EXPRESS — jednym przełącznikiem dla całego zamówienia</h4>
-            <p>Klient chce „cały zamówienie na jutro"? Jeden przełącznik dolicza +20% do każdej pozycji, suma przelicza się na żywo. Operator nie zaznacza tego przy każdej pozycji osobno.</p>
+            <p>Klient chce „całe zamówienie na jutro"? Jeden przełącznik dolicza +20% do każdej pozycji, suma przelicza się na żywo. Operator nie zaznacza tego przy każdej pozycji osobno.</p>
           </div>
           <div class="ux-decision-box">
             <div class="ux-label">Etap 3</div>
@@ -906,7 +901,7 @@
             <p>Każde wysłane zamówienie trafia jako wiersz do arkusza <code>orders</code>: data, godzina, firma, dane klienta, materiał, nakład, cena jednostkowa, suma, priorytet i flaga EXPRESS. Drukarnia ma firmowy „mini-CRM" bez kosztu utrzymania.</p>
           </div>
           <div class="ux-decision-box">
-            <div class="ux-label">Etap 5 · niezawodność</div>
+            <div class="ux-label">Niezawodność</div>
             <h4>Wysyłka z weryfikacją i obsługą błędów</h4>
             <p>Wysyłka ma timeout, status zwrotny i tryb „dry run" do testów. Jeśli wysyłka się nie powiedzie (brak sieci, błąd Apps Script), operator widzi komunikat — nie cichy fail.</p>
           </div>
@@ -936,7 +931,7 @@
           </p>
         </div>
 
-        <h3>Architektura — pięć warstw odpowiedzialności</h3>
+        <h3 style="text-align:center">Architektura — pięć warstw odpowiedzialności</h3>
         <p style="max-width:720px;margin:0 auto 1rem;color:#475569;">Każda warstwa ma jedno zadanie. Dzięki temu zmiana w jednej warstwie nie psuje pozostałych — np. zmiana ceny nie wymaga ruszania kodu, a dodanie nowej kategorii produktów nie wymaga ruszania interfejsu.</p>
         <div class="arch-layers">
           <div class="arch-layer">
@@ -988,7 +983,7 @@
           <strong>Dlaczego pięć, a nie cztery?</strong> Wydzielenie warstwy „Logiki domenowej" (koszyk, modyfikatory, walidacje, klucze wariantów) od warstwy kategorii oznacza, że ta sama logika koszyka działa dla wszystkich 22 kategorii — i będzie działała dla 23. kategorii bez zmian. To także moduły, które najłatwiej przenieść do innej branży (patrz: sekcja „Potencjał B2B").
         </p>
 
-        <h3 style="margin-top: 3rem;">Integracje ekosystemu</h3>
+        <h3 style="margin-top:3rem;text-align:center">Integracje ekosystemu</h3>
         <div class="integration-flow">
           <div class="int-card">
             <div class="int-card-icon">📄</div>
@@ -1010,7 +1005,7 @@
           </div>
         </div>
 
-        <h3 style="margin-top: 3rem;">Niezawodność — testy automatyczne</h3>
+        <h3 style="margin-top:3rem;text-align:center">Niezawodność — testy automatyczne</h3>
         <p>Każda zmiana w cenniku jest krytyczna biznesowo: błąd kropki w stawce za m² oznacza realną stratę na fakturze. Dlatego zbudowałem <strong>~50 plików testowych</strong> obejmujących nie tylko kalkulacje, ale też zachowania interfejsu i scenariusze regresji. <em style="color:#94a3b8;">Łączna liczba przypadków — wymaga weryfikacji przed publikacją (uruchom <code>npm test</code>).</em></p>
         <div class="test-grid">
           <div class="test-item">
@@ -1070,7 +1065,7 @@
           <p>Raz Dwa Druk to <strong>aplikacja dla konkretnej drukarni</strong>, ale zbudowana z modułów, które rozwiązują problem znacznie szerszy: <em>jak małej firmie usługowej dać kalkulator + koszyk + bazę zamówień bez własnej infrastruktury</em>. Większość warstw architektury można przenieść do innej branży po podmianie definicji kategorii i cennika.</p>
         </div>
 
-        <h3>Co jest specyficzne dla poligrafii</h3>
+        <h3 style="text-align:center">Co jest specyficzne dla poligrafii</h3>
         <ul style="max-width:760px;margin:0 auto 2rem;color:#475569;line-height:1.7;">
           <li>Rozpoznawanie formatu CAD (A0–A3) z uploadowanych plików</li>
           <li>Przeliczenia metr bieżący × szerokość rolki</li>
@@ -1078,7 +1073,7 @@
           <li>Modyfikatory poligraficzne: oczkowanie, składanie, satyna, dwustronnie, gramatura papieru</li>
         </ul>
 
-        <h3>Co jest uniwersalne i gotowe do przeniesienia</h3>
+        <h3 style="text-align:center">Co jest uniwersalne i gotowe do przeniesienia</h3>
         <div class="kwcs-trio">
           <article class="kwcs-card">
             <h3>Moduły do reuse</h3>
@@ -1127,7 +1122,7 @@
             <li>Ręczne wyceny w Excelu z wysokim ryzykiem błędu ludzkiego (szczególnie w plikach z roli CAD).</li>
             <li>Brak centralnej historii zamówień i brak możliwości łatwej modyfikacji cennika.</li>
             <li>Praca w warsztacie drukarni z bardzo niestabilnym internetem.</li>
-            <li>Wymóg stworzenia interfejsu, którego zespół nauczy się "bez szkolenia".</li>
+            <li>Wymóg stworzenia interfejsu, którego zespół nauczy się „bez szkolenia".</li>
           </ul>
         </article>
 
@@ -1160,7 +1155,7 @@
 
           <div class="result-lead">
             <p>
-              🚀 System <strong>Raz Dwa Druk</strong> wdrożono bez bólu na stanowiskach operacyjnych. Architektura 4-warstwowa spełniła wszystkie założenia: pracownicy samodzielnie aktualizują cenniki, zamówienia generują PDF i automatycznie zasilają firmowego Google Excela. Aplikacja PWA działa niezawodnie, skracając czas operacyjny i redukując błędy matematyczne do zera.
+              🚀 System <strong>Raz Dwa Druk</strong> wdrożono bez bólu na stanowiskach operacyjnych. Architektura 5-warstwowa spełniła wszystkie założenia: pracownicy samodzielnie aktualizują cenniki, zamówienia generują PDF i automatycznie zasilają firmowy arkusz Google Sheets. Aplikacja PWA działa niezawodnie, skracając czas operacyjny i redukując błędy matematyczne do zera.
             </p>
           </div>
 

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -489,7 +489,7 @@
           </p>
         </div>
 
-        <h3>Jak rozpoznałem problem</h3>
+        <h3 style="text-align:center">Jak rozpoznałem problem</h3>
         <div class="ux-decision-grid">
           
             <h4>Forma rozpoznania potrzeb</h4>
@@ -508,26 +508,26 @@
           </div>
         </div>
 
-        <h3 style="margin-top:3rem;">Kluczowe decyzje produktowe</h3>
+        <h3 style="margin-top:3rem;text-align:center">Kluczowe decyzje produktowe</h3>
 
         <div class="ux-decision-grid">
           <div class="ux-decision-box">
             <div class="ux-label">Decyzja 1 · Architektura</div>
             <h4>Aplikacja PWA zamiast sklepu na WooCommerce/Shoper</h4>
             <p><strong>Dlaczego:</strong> obecnie drukarnia nie sprzedaje online klientowi końcowemu — obsługuje klientów B2B fizycznie/telefonicznie/mailowo. Sklep e-commerce byłby kosztownym narzutem (hosting, wtyczki, aktualizacje), a nie rozwiązałby głównego problemu: czasu wyceny przy ladzie. PWA daje aplikację „przyklejoną" do pulpitu bez instalacji i bez kosztu utrzymania serwera.</p>
-            <p style="margin-top:0.75rem;padding:0.75rem;background:#fffbeb;border-left:3px solid #f59e0b;border-radius:4px;font-size:0.85rem;"><strong style="color:#92400e;">⚠ Pytanie do autora:</strong> Czy klient sam chciał aplikację, czy to Ty zaproponowałeś takie rozwiązanie zamiast alternatyw? Co odrzuciliście razem (Excel z makrami, sklep online, gotowy SaaS)?</p>
+            <p style="margin-top:0.75rem;padding:0.75rem;background:#fffbeb;border-left:3px solid #f59e0b;border-radius:4px;font-size:0.85rem;">Rozwiązanie zaproponowałem sam. Wiedziałem, że drukarnia potrzebuje czegoś prostego i intuicyjnego — a koszt utrzymania musiał być niski. Dla klienta to był pierwszy tego rodzaju system, więc bariera wejścia musiała być na tyle niska, żeby nie zniechęcić do wdrożenia.</p>
           </div>
           <div class="ux-decision-box">
             <div class="ux-label">Decyzja 2 · Zaplecze</div>
             <h4>Google Sheets + Apps Script zamiast własnej bazy danych</h4>
             <p><strong>Dlaczego:</strong> wybór tej technologii oznacza zero nowego narzędzia do nauki, darmowy hosting (Google), darmową kopię zapasową i pełną kontrolę po stronie klienta. Apps Script obsługuje zapis zamówień, edycję cennika i bramkę PIN — bez utrzymywania własnego API.</p>
-            <p style="margin-top:0.75rem;padding:0.75rem;background:#fffbeb;border-left:3px solid #f59e0b;border-radius:4px;font-size:0.85rem;"><strong style="color:#92400e;">⚠ Pytanie do autora:</strong> Czy klient już używał Sheetów przed projektem, czy to była Twoja propozycja? Czy rozważaliście alternatywy (Airtable, własna baza, gotowy CRM)?</p>
+            <p style="margin-top:0.75rem;padding:0.75rem;background:#fffbeb;border-left:3px solid #f59e0b;border-radius:4px;font-size:0.85rem;">Klient nie korzystał wcześniej z Google Sheets — to była moja propozycja. W drukarni funkcjonowały już drobne bazy danych, ale żadna nie łączyła prostoty z łatwością dostępu. Google Sheets okazało się naturalnym wyborem: znany interfejs, zero kosztu, pełna kontrola po stronie klienta.</p>
           </div>
           <div class="ux-decision-box">
             <div class="ux-label">Decyzja 3 · Utrzymanie</div>
             <h4>Cennik edytowalny w aplikacji zamiast „wdrażanego" przez programistę</h4>
             <p><strong>Dlaczego:</strong> ceny się zmieniają. Gdyby każda zmiana wymagała kontaktu z programistą, drukarnia szybko porzuciłaby aplikację. Panel administracyjny z bramką PIN pozwala właścicielowi zmienić cenę w 30 sekund — bez ryzyka przypadkowej zmiany przez recepcję.</p>
-            <p style="margin-top:0.75rem;padding:0.75rem;background:#fffbeb;border-left:3px solid #f59e0b;border-radius:4px;font-size:0.85rem;"><strong style="color:#92400e;">⚠ Pytanie do autora:</strong> Panel był w pierwotnym planie czy doszedł później? Bramka PIN — preventywnie czy po jakimś incydencie (np. przypadkowa zmiana ceny)?</p>
+            <p style="margin-top:0.75rem;padding:0.75rem;background:#fffbeb;border-left:3px solid #f59e0b;border-radius:4px;font-size:0.85rem;">Panel administracyjny nie był częścią pierwotnego planu — wyłonił się w trakcie iteracji, gdy rozważania nad bezpieczeństwem danych cennika wskazały na potrzebę oddzielonego dostępu dla właściciela.</p>
           </div>
           <div class="ux-decision-box">
             <div class="ux-label">Decyzja 4 · Frontend</div>
@@ -536,7 +536,7 @@
           </div>
         </div>
 
-        <h3 style="margin-top:3rem;">Co weszło do MVP, co odłożyłem na później</h3>
+        <h3 style="margin-top:3rem;text-align:center">Co weszło do MVP, co odłożyłem na później</h3>
         <div class="kwcs-trio">
           <article class="kwcs-card">
             <h3>MVP (must-have)</h3>
@@ -563,7 +563,7 @@
               <li>Parser DWG/DXF dla wektorów CAD</li>
               <li>Tryb klienta końcowego z ukrytymi marżami</li>
               <li>Integracja płatności</li>
-              <li style="color:#92400e;background:#fffbeb;padding:0.5rem;border-left:3px solid #f59e0b;border-radius:4px;"><strong>⚠ Pytanie do autora:</strong> Co świadomie wyciąłeś z zakresu, mimo że klient o to prosił lub sam chciałeś to zrobić? I dlaczego?</li>
+              <li style="color:#92400e;background:#fffbeb;padding:0.5rem;border-left:3px solid #f59e0b;border-radius:4px;">Żadnej funkcji nie wyciąłem na prośbę klienta ani z własnej inicjatywy. Ograniczyłem natomiast liczbę kategorii — powiązane typy usług zostały połączone, żeby zredukować szum i przyspieszyć nawigację do właściwej pozycji cennika.</li>
             </ul>
           </article>
         </div>
@@ -593,14 +593,7 @@
         </div>
 
         <div style="max-width:760px;margin:2rem auto 0;padding:1.25rem 1.5rem;background:#fffbeb;border:1px solid #fde68a;border-left:4px solid #f59e0b;border-radius:0.75rem;">
-          <strong style="color:#92400e;">⚠ Pytania do autora — wzmocnienie person:</strong>
-          <ul style="margin:0.75rem 0 0;color:#475569;font-size:0.9rem;line-height:1.7;">
-            <li><strong>Operator:</strong> opisz konkretną osobę (można zanonimizować) — wiek, staż, komfort z technologią, ulubione/znienawidzone narzędzia. Np. „Pani Anna, 45 lat, 8 lat w drukarni".</li>
-            <li><strong>Operator:</strong> ile osób z recepcji korzysta z aplikacji? Czy jest rotacja w zespole?</li>
-            <li><strong>Operator:</strong> typowy dzień — ile zamówień, jak długie pojedyncze zlecenie, kiedy są piki (np. poniedziałek rano)?</li>
-            <li><strong>Administrator:</strong> gdzie i jak korzysta z panelu — z biura w drukarni, z domu, z telefonu? Jak często wchodzi do panelu?</li>
-            <li><strong>Zespół:</strong> czy są osoby, dla których aplikacja jest barierą technologiczną? Jak sobie z tym poradziłeś w projekcie?</li>
-          </ul>
+          <p style="color:#475569;font-size:0.9rem;line-height:1.7;margin:0;">Główny operator to osoba po 40. roku życia, ze stażem ok. 1,5 roku w drukarni. Nowe, skomplikowane narzędzia mogą być przyjmowane z rezerwą — dlatego prostota obsługi i krótka krzywa uczenia były wymaganiem, nie tylko życzeniem.</p>
         </div>
       </div>
     </div>
@@ -783,7 +776,7 @@
           <p>Drukarnia, która musi dzwonić do programisty, żeby podnieść cenę wydruku o 10 groszy, szybko porzuci aplikację. Panel administracyjny to <strong>jedna z najważniejszych decyzji produktowych całego projektu</strong>: oddaje kontrolę nad cennikiem właścicielowi i likwiduje koszt utrzymania.</p>
         </div>
 
-        <h3>Co panel pozwala zrobić</h3>
+        <h3 style="text-align:center">Co panel pozwala zrobić</h3>
         <div class="ux-decision-grid">
           <div class="ux-decision-box">
             <div class="ux-label">Funkcja 1</div>
@@ -807,7 +800,7 @@
           </div>
         </div>
 
-        <h3 style="margin-top:3rem;">Bezpieczeństwo: bramka PIN</h3>
+        <h3 style="margin-top:3rem;text-align:center">Bezpieczeństwo: bramka PIN</h3>
         <p style="max-width:760px;margin:0 auto 1rem;color:#475569;">Cennik to wrażliwy zasób — przypadkowa edycja przez recepcjonistę kosztuje realne pieniądze. Wprowadziłem bramkę PIN, ale w sposób, który nie utrudnia codziennej pracy:</p>
         <ul style="max-width:760px;margin:0 auto;color:#475569;line-height:1.7;">
           <li><strong>PIN przechowywany po stronie Google Apps Script</strong> (PropertiesService) — nie w kodzie aplikacji, nie w przeglądarce. Zmiana PIN-u nie wymaga wdrażania nowej wersji.</li>
@@ -825,7 +818,7 @@
             <li>Ekran bramki PIN (z fallbackiem offline)</li>
             <li>Arkusz <code>cennik</code> w Google Sheets po synchronizacji</li>
           </ul>
-          <p style="margin:0.75rem 0 0;color:#92400e;font-size:0.85rem;"><strong>⚠ Pytanie do autora:</strong> Czy klient samodzielnie dodał już jakieś pozycje przez panel? Ile? Czy zgłaszał problemy z tą funkcją?</p>
+          <p style="margin:0.75rem 0 0;color:#92400e;font-size:0.85rem;">Klient nie dodał jeszcze własnych pozycji przez panel. Informacja zostanie uzupełniona po zebraniu danych.</p>
         </div>
       </div>
     </div>
@@ -839,7 +832,7 @@
           <p>W trakcie pracy z drukarnią okazało się, że <strong>nie wystarczy jeden cennik</strong>: ten sam produkt (np. wizytówki) ma kilka odmian, które klient zamawia po imieniu („Wizytówki Premium", „Wizytówki ekspresowe"). Zaprojektowałem osobny system wariantów, niezależny od cennika bazowego.</p>
         </div>
 
-        <h3>Dlaczego warianty są osobno od cennika</h3>
+        <h3 style="text-align:center">Dlaczego warianty są osobno od cennika</h3>
         <p style="max-width:760px;margin:0 auto 1.5rem;color:#475569;">Cennik bazowy odpowiada na pytanie „ile kosztuje druk koloru A4 w nakładzie 100 sztuk". Wariant odpowiada na pytanie „co dokładnie zamawia klient i pod jaką nazwą zapisać to w systemie". Rozdzielenie tych dwóch warstw oznacza, że dodanie nowego wariantu nie wymaga modyfikacji cennika, a zmiana ceny nie wymaga modyfikacji nazw wariantów.</p>
 
         <div class="ux-decision-grid">
@@ -870,7 +863,7 @@
           <ul style="margin:0.75rem 0 0;color:#475569;font-size:0.9rem;line-height:1.7;">
             <li><strong>Materiał graficzny (P0):</strong> screenshot tworzenia własnej podgrupy (np. „Wizytówki Premium") w panelu</li>
             <li><strong>Pytanie do autora:</strong> Dlaczego ta funkcja w ogóle powstała? Jakie konkretne zlecenie / rozmowa z drukarnią ją wywołały? 2–3 zdania historii.</li>
-            <li><strong>Pytanie do autora:</strong> Czy klient samodzielnie utworzył już własne warianty po wdrożeniu? Ile, jakie?</li>
+            <li>Klient nie utworzył jeszcze własnych wariantów po wdrożeniu. Informacja zostanie uzupełniona.</li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Two-pass edit of `projects/razdwa_aplikacja.html` only. No layout, color, spacing, or structural changes beyond HTML correctness fixes.

---

## Pass 1 — Replace 8 placeholder question groups with polished copy

- Groups 1–3: answered PWA origin, Google Sheets origin, and admin panel timing questions
- Group 4: replaced Backlog placeholder with scope rationale
- Group 5: replaced 5-question persona block with operator profile paragraph
- Groups 6–7: replaced two unanswered client-usage questions with status notes
- Group 8 (Pytania do autora projektu): left unchanged
- Centered 6 `h3` subheadings in the 4 affected sections

---

## Pass 2 — Consistency audit and fixes

**Critical**
- Fixed broken `ux-decision-grid` HTML: missing opening `<div class="ux-decision-box">`, bare text without `<p>` wrapper, and empty `ux-label` div removed
- Fixed factual contradiction: "Architektura 4-warstwowa" → "5-warstwowa" (page describes 5 layers)
- Fixed wrong product name: "Google Excela" → "Google Sheets"
- Fixed run-on sentence in Kontekst projektu paragraph (missing separator + missing space)

**Important**
- Fixed grammatical error: "cały zamówienie" → "całe zamówienie"
- Fixed duplicate "Etap 5" label → renamed to "Niezawodność"
- Fixed passive voice: "Zdecydowano się" → "Zdecydowałem się" (consistent with first-person narrative)
- Removed warning/question visual styling from answered Backlog list item
- Completed `h3` centering: 10 remaining section-level subtitles now consistent with the 6 already centered in Pass 1

**Polish**
- Removed double space after em dash in ecosystem node
- Removed stray `<br>` in stat label
- Fixed "Zabezpiecza" → "zabezpiecza" in image caption (mid-parenthesis cap)
- Fixed h3 title: "Logika Kalkulatora CAD w detalach" → "Logika kalkulatora CAD — szczegóły"
- Fixed straight ASCII quotes → Polish typographic quotes „…"

## Not touched
- All unanswered author-question areas (Pytania do autora projektu section)
- All graphics/materials TODO lists
- All layout, CSS, colors, spacing, components

https://claude.ai/code/session_013QtxnYFre6YuEDy6SCRQFA