### PR TITLE
RAZDWA: summary, sticky chapter rail, deep-dive accordions, System UI

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -2231,3 +2231,525 @@ body.lightbox-open {
   .pfn-btn.pfn-prev:hover,
   .pfn-btn.pfn-next:hover { transform: translateY(-2px); }
 }
+
+/* ========================================
+   RAZDWA CASE STUDY — przeniesione z embedded <style>
+   w razdwa_aplikacja.html (DOMParser gubi style z <head>)
+   ======================================== */
+
+/* Statystyki */
+.razdwa-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.5rem;
+  max-width: 900px;
+  margin: 0 auto 2rem;
+}
+@media (max-width: 600px) {
+  .razdwa-stats { grid-template-columns: repeat(2, 1fr); }
+}
+.razdwa-stat {
+  text-align: center;
+  padding: 1.5rem 1rem;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+}
+.razdwa-stat-num {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #0284c7;
+  line-height: 1;
+  margin-bottom: 0.35rem;
+}
+.razdwa-stat-label {
+  font-size: 0.8rem;
+  color: #64748b;
+  line-height: 1.3;
+}
+
+/* Ekosystem */
+.razdwa-ecosystem { max-width: 900px; margin: 0 auto; }
+.razdwa-ecosystem-row {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.eco-node {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1rem 1.5rem;
+  text-align: center;
+}
+.eco-node-icon { font-size: 1.75rem; margin-bottom: 0.25rem; }
+.eco-node-label { font-size: 0.875rem; font-weight: 600; color: #0f172a; }
+.eco-node-sub { font-size: 0.8rem; color: #64748b; margin-top: 0.2rem; }
+.eco-arrow {
+  font-size: 1.5rem;
+  color: #06b6d4;
+  text-align: center;
+  font-weight: 700;
+}
+@media (max-width: 600px) {
+  .razdwa-ecosystem-row { grid-template-columns: 1fr; }
+  .eco-arrow { transform: rotate(90deg); }
+}
+
+/* UX Decisions */
+.ux-decision-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  max-width: 900px;
+  margin: 2rem auto;
+}
+@media (max-width: 600px) {
+  .ux-decision-grid { grid-template-columns: 1fr; }
+}
+.ux-decision-box {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-left: 4px solid #06b6d4;
+  border-radius: 0.75rem;
+  padding: 1.25rem 1.5rem;
+}
+.ux-decision-box h4 {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 0.5rem;
+}
+.ux-decision-box p {
+  font-size: 0.875rem;
+  color: #475569;
+  line-height: 1.6;
+  text-align: left !important;
+  margin: 0 0 0.5rem;
+}
+.ux-decision-box p:last-child { margin-bottom: 0; }
+.ux-decision-box .ux-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #06b6d4;
+  margin-bottom: 0.35rem;
+}
+
+/* User flow */
+.user-flow {
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
+  max-width: 960px;
+  margin: 2rem auto;
+  overflow-x: auto;
+  padding-bottom: 1rem;
+}
+.flow-step { flex: 1; min-width: 130px; text-align: center; padding: 0 0.5rem; }
+.flow-step-icon {
+  width: 52px; height: 52px; border-radius: 50%;
+  background: linear-gradient(135deg, #06b6d4, #0284c7);
+  color: #fff; font-size: 1.25rem;
+  display: flex; align-items: center; justify-content: center;
+  margin: 0 auto 0.5rem;
+}
+.flow-step-label { font-size: 0.8rem; font-weight: 600; color: #0f172a; margin-bottom: 0.25rem; }
+.flow-step-sub { font-size: 0.75rem; color: #64748b; line-height: 1.3; }
+.flow-arrow {
+  flex-shrink: 0;
+  display: flex; align-items: center; justify-content: center;
+  padding-top: 14px;
+  color: #06b6d4; font-size: 1.25rem; font-weight: 700;
+}
+@media (max-width: 768px) {
+  .user-flow { flex-wrap: wrap; }
+  .flow-arrow { display: none; }
+}
+
+/* Architektura warstw */
+.arch-layers {
+  max-width: 720px;
+  margin: 2rem auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.arch-layer {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  align-items: stretch;
+  border: 1px solid #e2e8f0;
+  border-bottom: none;
+}
+.arch-layer:first-child { border-radius: 0.75rem 0.75rem 0 0; }
+.arch-layer:last-child { border-bottom: 1px solid #e2e8f0; border-radius: 0 0 0.75rem 0.75rem; }
+.arch-layer-label {
+  background: linear-gradient(135deg, #06b6d4, #0284c7);
+  color: #fff;
+  display: flex; align-items: center; justify-content: center;
+  padding: 0.875rem 1rem;
+  font-size: 0.8125rem; font-weight: 700; text-align: center;
+  line-height: 1.3; letter-spacing: 0.03em;
+}
+.arch-layer-content {
+  background: #fff;
+  padding: 0.875rem 1.25rem;
+  display: flex; align-items: center; flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.arch-tag {
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.375rem;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.8125rem;
+  font-family: 'Courier New', monospace;
+  color: #0f172a; font-weight: 500;
+}
+.arch-tag.highlight { background: #eff6ff; border-color: #bfdbfe; color: #1d4ed8; }
+
+/* Integration flow */
+.integration-flow {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  max-width: 960px;
+  margin: 2rem auto;
+}
+@media (max-width: 700px) {
+  .integration-flow { grid-template-columns: 1fr; }
+}
+.int-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  text-align: center;
+}
+.int-card-icon { font-size: 2rem; margin-bottom: 0.5rem; }
+.int-card-title { font-weight: 700; font-size: 1rem; color: #0f172a; margin-bottom: 0.5rem; }
+.int-card-desc { font-size: 0.875rem; color: #475569; line-height: 1.5; }
+.int-card-code {
+  font-family: 'Courier New', monospace;
+  font-size: 0.8rem;
+  color: #1d4ed8;
+  background: #eff6ff;
+  border-radius: 0.375rem;
+  padding: 0.25rem 0.5rem;
+  margin-top: 0.5rem;
+  display: inline-block;
+}
+
+/* Pokrycie testami */
+.test-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+  max-width: 900px;
+  margin: 2rem auto;
+}
+.test-item {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-left: 3px solid #10b981;
+  border-radius: 0.5rem;
+  padding: 0.875rem 1rem;
+}
+.test-item-name {
+  font-size: 0.8125rem;
+  font-family: 'Courier New', monospace;
+  color: #0f172a; font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+.test-item-count { font-size: 0.875rem; color: #10b981; font-weight: 700; }
+.test-item-sub { font-size: 0.75rem; color: #64748b; }
+
+/* Section divider — z anchorem; scroll-margin pod sticky rail */
+.section-divider {
+  text-align: center;
+  margin: 4rem 0 2rem;
+  font-family: 'Playfair Display', serif;
+  font-size: 2.5rem;
+  color: #0f172a;
+  position: relative;
+  scroll-margin-top: 80px;
+}
+.section-divider::after {
+  content: '';
+  display: block;
+  width: 60px;
+  height: 4px;
+  background: #06b6d4;
+  margin: 1rem auto 0;
+  border-radius: 2px;
+}
+
+/* Sekcje z id też dostają scroll-margin */
+[id^="razdwa-"] { scroll-margin-top: 80px; }
+
+/* ========================================
+   RAZDWA — Executive summary po hero
+   ======================================== */
+.razdwa-summary {
+  background: linear-gradient(180deg, #f0f9ff 0%, #ffffff 100%);
+  border-top: 1px solid #e0f2fe;
+  border-bottom: 1px solid #e0f2fe;
+  padding: 3rem 1rem;
+}
+.razdwa-summary .wrap { max-width: 1100px; margin: 0 auto; }
+.razdwa-summary h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.75rem;
+  color: #0f172a;
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+.razdwa-summary-lead {
+  max-width: 760px;
+  margin: 0 auto 2rem;
+  text-align: center;
+  color: #475569;
+  font-size: 1.0625rem;
+  line-height: 1.7;
+}
+.razdwa-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+.razdwa-summary-cell {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1rem 1.1rem;
+}
+.razdwa-summary-cell .label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #06b6d4;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+.razdwa-summary-cell .value {
+  font-size: 0.95rem;
+  color: #0f172a;
+  font-weight: 600;
+  line-height: 1.4;
+}
+@media (max-width: 900px) {
+  .razdwa-summary-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 500px) {
+  .razdwa-summary-grid { grid-template-columns: 1fr; }
+}
+
+/* ========================================
+   RAZDWA — Chapter rail (sticky TOC)
+   ======================================== */
+.razdwa-chapter-rail {
+  position: sticky;
+  top: 16px;
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.85rem;
+  margin: 1.25rem auto 2rem;
+  max-width: 1100px;
+  box-shadow: 0 8px 24px -12px rgba(15, 23, 42, 0.12);
+}
+.razdwa-chapter-rail-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #06b6d4;
+  font-weight: 700;
+  padding: 0.1rem 0.25rem;
+  margin-bottom: 0.4rem;
+}
+.razdwa-chapter-rail-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.razdwa-chapter-rail-list li { margin: 0; }
+.razdwa-chapter-rail-list li::before { content: none !important; }
+.razdwa-chapter-link {
+  display: inline-block;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  color: #0f172a;
+  font-size: 0.8rem;
+  font-weight: 500;
+  padding: 0.3rem 0.7rem;
+  border-radius: 9999px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+.razdwa-chapter-link:hover {
+  background: #06b6d4;
+  border-color: #06b6d4;
+  color: #fff;
+}
+.razdwa-chapter-link.is-active {
+  background: #0284c7;
+  border-color: #0284c7;
+  color: #fff;
+}
+@media (max-width: 600px) {
+  .razdwa-chapter-rail {
+    border-radius: 0.5rem;
+    padding: 0.5rem 0.6rem;
+    margin: 1rem 0.5rem 1.5rem;
+  }
+  .razdwa-chapter-rail-list { flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  .razdwa-chapter-link { white-space: nowrap; }
+}
+
+/* ========================================
+   RAZDWA — Contribution grid
+   ======================================== */
+.contribution-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+  max-width: 1100px;
+  margin: 2rem auto;
+}
+.contribution-cell {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  padding: 1.25rem 1.4rem;
+  border-top: 4px solid #06b6d4;
+}
+.contribution-cell.contribution-cell--solo { border-top-color: #0284c7; }
+.contribution-cell.contribution-cell--shared { border-top-color: #10b981; }
+.contribution-cell.contribution-cell--external { border-top-color: #f59e0b; }
+.contribution-cell h4 {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0 0 0.6rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.contribution-cell h4 .dot {
+  display: inline-block;
+  width: 8px; height: 8px; border-radius: 50%;
+  background: currentColor;
+}
+.contribution-cell--solo h4 { color: #0284c7; }
+.contribution-cell--shared h4 { color: #10b981; }
+.contribution-cell--external h4 { color: #f59e0b; }
+.contribution-cell ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  list-style: disc;
+}
+.contribution-cell li {
+  font-size: 0.875rem;
+  color: #475569;
+  line-height: 1.55;
+  margin-bottom: 0.35rem;
+}
+.contribution-cell li::before { content: none !important; }
+@media (max-width: 900px) {
+  .contribution-grid { grid-template-columns: 1fr; }
+}
+
+/* ========================================
+   RAZDWA — System UI (design tokens projektu)
+   ======================================== */
+.razdwa-systemui {
+  max-width: 1100px;
+  margin: 2rem auto;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+@media (max-width: 900px) {
+  .razdwa-systemui { grid-template-columns: 1fr; }
+}
+.systemui-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  padding: 1.25rem 1.4rem;
+}
+.systemui-card h4 {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0 0 0.85rem;
+}
+.systemui-swatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+.systemui-swatch {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 0.3rem 0.6rem 0.3rem 0.35rem;
+}
+.systemui-swatch-color {
+  width: 28px; height: 28px;
+  border-radius: 0.375rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  flex-shrink: 0;
+}
+.systemui-swatch-meta { line-height: 1.2; }
+.systemui-swatch-name { font-size: 0.75rem; color: #0f172a; font-weight: 600; }
+.systemui-swatch-code {
+  font-family: 'Courier New', monospace;
+  font-size: 0.7rem;
+  color: #64748b;
+}
+.systemui-typo {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+.systemui-typo-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.4rem 0.6rem;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+}
+.systemui-typo-sample { color: #0f172a; min-width: 90px; }
+.systemui-typo-sample.is-display { font-family: 'Playfair Display', serif; font-size: 1.4rem; font-weight: 700; }
+.systemui-typo-sample.is-heading { font-family: 'Inter', sans-serif; font-size: 1.05rem; font-weight: 700; }
+.systemui-typo-sample.is-body { font-family: 'Inter', sans-serif; font-size: 0.9rem; font-weight: 400; }
+.systemui-typo-sample.is-mono { font-family: 'Courier New', monospace; font-size: 0.85rem; color: #1d4ed8; }
+.systemui-typo-meta {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+.systemui-components {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.systemui-components .arch-tag { font-size: 0.75rem; }

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -195,6 +195,8 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
 
+    initializeChapterRail();
+
     const accordionHeaders = document.querySelectorAll('.kwcs-header');
     if (accordionHeaders.length > 0) {
       accordionHeaders.forEach(header => {
@@ -220,6 +222,50 @@ document.addEventListener('DOMContentLoaded', () => {
           }
         });
       });
+    }
+  }
+
+  function initializeChapterRail() {
+    const rail = document.getElementById('razdwa-chapter-rail');
+    if (!rail) return;
+
+    const links = Array.from(rail.querySelectorAll('.razdwa-chapter-link'));
+    if (!links.length) return;
+
+    const detailsContainer = document.getElementById('project-details-container');
+
+    links.forEach(link => {
+      link.addEventListener('click', (e) => {
+        e.preventDefault();
+        const id = link.dataset.railTarget || link.getAttribute('href').replace('#', '');
+        const target = document.getElementById(id);
+        if (!target) return;
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        links.forEach(l => l.classList.remove('is-active'));
+        link.classList.add('is-active');
+      });
+    });
+
+    const targets = links
+      .map(link => document.getElementById(link.dataset.railTarget || link.getAttribute('href').replace('#', '')))
+      .filter(Boolean);
+
+    if ('IntersectionObserver' in window && targets.length) {
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (!entry.isIntersecting) return;
+          const id = entry.target.id;
+          links.forEach(l => {
+            const targetId = l.dataset.railTarget || l.getAttribute('href').replace('#', '');
+            l.classList.toggle('is-active', targetId === id);
+          });
+        });
+      }, {
+        root: detailsContainer && detailsContainer.style.overflow === 'auto' ? detailsContainer : null,
+        rootMargin: '-30% 0px -60% 0px',
+        threshold: 0
+      });
+      targets.forEach(t => observer.observe(t));
     }
   }
 

--- a/portfolio.html
+++ b/portfolio.html
@@ -321,25 +321,25 @@
                 <div class="portfolio-new-card" data-project="RazDwa">
                     <div class="card-image-wrapper">
                         <img src="assets/images/strona startowa_RAZDWA.webp"
-                             alt="Raz Dwa – kalkulator druku, aplikacja B2B i strona internetowa"
+                             alt="Raz Dwa Druk — aplikacja PWA z kalkulatorem wycen B2B"
                              loading="lazy" />
                     </div>
                     <div class="card-content">
-                        <span class="card-category">APLIKACJA B2B + PWA + STRONA</span>
+                        <span class="card-category">APLIKACJA B2B · PWA · DRUKARNIA</span>
                         <h4 class="card-title">Raz Dwa Druk</h4>
-                        <p class="card-description">Kompleksowy system cyfrowy dla drukarni: kalkulator wycen, PWA offline i strona internetowa.</p>
+                        <p class="card-description">Aplikacja PWA z kalkulatorem wycen, koszykiem i integracją Google Sheets — wycena skrócona z ok. godziny do ok. 5 minut.</p>
                         <div class="card-features">
                             <span class="feature-item">
                                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
                                     <path d="M13.5 3.5L6 11L2.5 7.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                 </svg>
-                                Dynamiczny cennik, szybkie dodawanie produktów
+                                22 kategorie cennika, panel admina z PIN
                             </span>
                             <span class="feature-item">
                                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
                                     <path d="M13.5 3.5L6 11L2.5 7.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                 </svg>
-                                21 kategorii, generowanie raportów zamówienia 
+                                Offline PWA, eksport PDF + Google Sheets
                             </span>
                         </div>
                         <div class="card-cta">

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -34,302 +34,6 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
-
-  <style>
-    /* ── Połączone style z wszystkich podstron ─────────────────────────── */
-    
-    /* Główne statystyki (z razdwa.html) */
-    .razdwa-stats {
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      gap: 1.5rem;
-      max-width: 900px;
-      margin: 0 auto 2rem;
-    }
-    @media (max-width: 600px) {
-      .razdwa-stats { grid-template-columns: repeat(2, 1fr); }
-    }
-    .razdwa-stat {
-      text-align: center;
-      padding: 1.5rem 1rem;
-      background: #fff;
-      border: 1px solid #e2e8f0;
-      border-radius: 1rem;
-    }
-    .razdwa-stat-num {
-      font-size: 2rem;
-      font-weight: 700;
-      color: #0284c7;
-      line-height: 1;
-      margin-bottom: 0.35rem;
-    }
-    .razdwa-stat-label {
-      font-size: 0.8rem;
-      color: #64748b;
-      line-height: 1.3;
-    }
-
-    /* Ekosystem (z razdwa.html) */
-    .razdwa-ecosystem {
-      max-width: 900px;
-      margin: 0 auto;
-    }
-    .razdwa-ecosystem-row {
-      display: grid;
-      grid-template-columns: 1fr auto 1fr;
-      align-items: center;
-      gap: 1rem;
-      margin-bottom: 1rem;
-    }
-    .eco-node {
-      background: #fff;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.75rem;
-      padding: 1rem 1.5rem;
-      text-align: center;
-    }
-    .eco-node-icon { font-size: 1.75rem; margin-bottom: 0.25rem; }
-    .eco-node-label { font-size: 0.875rem; font-weight: 600; color: #0f172a; }
-    .eco-node-sub { font-size: 0.8rem; color: #64748b; margin-top: 0.2rem; }
-    .eco-arrow {
-      font-size: 1.5rem;
-      color: #06b6d4;
-      text-align: center;
-      font-weight: 700;
-    }
-    @media (max-width: 600px) {
-      .razdwa-ecosystem-row { grid-template-columns: 1fr; }
-      .eco-arrow { transform: rotate(90deg); }
-    }
-
-    /* UX Decisions (z razdwa-strona.html) */
-    .ux-decision-grid {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-      gap: 1.5rem;
-      max-width: 900px;
-      margin: 2rem auto;
-    }
-    @media (max-width: 600px) {
-      .ux-decision-grid { grid-template-columns: 1fr; }
-    }
-    .ux-decision-box {
-      background: #fff;
-      border: 1px solid #e2e8f0;
-      border-left: 4px solid #06b6d4;
-      border-radius: 0.75rem;
-      padding: 1.25rem 1.5rem;
-    }
-    .ux-decision-box h4 {
-      font-size: 0.9375rem;
-      font-weight: 700;
-      color: #0f172a;
-      margin-bottom: 0.5rem;
-    }
-    .ux-decision-box p {
-      font-size: 0.875rem;
-      color: #475569;
-      line-height: 1.6;
-      text-align: left !important;
-      margin: 0;
-    }
-    .ux-decision-box .ux-label {
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      color: #06b6d4;
-      margin-bottom: 0.35rem;
-    }
-
-    /* User Flow (z razdwa-strona.html) */
-    .user-flow {
-      display: flex;
-      align-items: flex-start;
-      gap: 0;
-      max-width: 960px;
-      margin: 2rem auto;
-      overflow-x: auto;
-      padding-bottom: 1rem;
-    }
-    .flow-step {
-      flex: 1;
-      min-width: 130px;
-      text-align: center;
-      padding: 0 0.5rem;
-    }
-    .flow-step-icon {
-      width: 52px;
-      height: 52px;
-      border-radius: 50%;
-      background: linear-gradient(135deg, #06b6d4, #0284c7);
-      color: #fff;
-      font-size: 1.25rem;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      margin: 0 auto 0.5rem;
-    }
-    .flow-step-label {
-      font-size: 0.8rem;
-      font-weight: 600;
-      color: #0f172a;
-      margin-bottom: 0.25rem;
-    }
-    .flow-step-sub {
-      font-size: 0.75rem;
-      color: #64748b;
-      line-height: 1.3;
-    }
-    .flow-arrow {
-      flex-shrink: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding-top: 14px;
-      color: #06b6d4;
-      font-size: 1.25rem;
-      font-weight: 700;
-    }
-    @media (max-width: 768px) {
-      .user-flow { flex-wrap: wrap; }
-      .flow-arrow { display: none; }
-    }
-
-    /* Architektura (z razdwa-aplikacja.html) */
-    .arch-layers {
-      max-width: 720px;
-      margin: 2rem auto;
-      display: flex;
-      flex-direction: column;
-      gap: 0;
-    }
-    .arch-layer {
-      display: grid;
-      grid-template-columns: 140px 1fr;
-      align-items: stretch;
-      border: 1px solid #e2e8f0;
-      border-bottom: none;
-    }
-    .arch-layer:first-child { border-radius: 0.75rem 0.75rem 0 0; }
-    .arch-layer:last-child { border-bottom: 1px solid #e2e8f0; border-radius: 0 0 0.75rem 0.75rem; }
-    .arch-layer-label {
-      background: linear-gradient(135deg, #06b6d4, #0284c7);
-      color: #fff;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 0.875rem 1rem;
-      font-size: 0.8125rem;
-      font-weight: 700;
-      text-align: center;
-      line-height: 1.3;
-      letter-spacing: 0.03em;
-    }
-    .arch-layer-content {
-      background: #fff;
-      padding: 0.875rem 1.25rem;
-      display: flex;
-      align-items: center;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-    }
-    .arch-tag {
-      background: #f1f5f9;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.375rem;
-      padding: 0.2rem 0.6rem;
-      font-size: 0.8125rem;
-      font-family: 'Courier New', monospace;
-      color: #0f172a;
-      font-weight: 500;
-    }
-    .arch-tag.highlight {
-      background: #eff6ff;
-      border-color: #bfdbfe;
-      color: #1d4ed8;
-    }
-
-    /* Integration flow (z razdwa-aplikacja.html) */
-    .integration-flow {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 1.5rem;
-      max-width: 960px;
-      margin: 2rem auto;
-    }
-    @media (max-width: 700px) {
-      .integration-flow { grid-template-columns: 1fr; }
-    }
-    .int-card {
-      background: #fff;
-      border: 1px solid #e2e8f0;
-      border-radius: 1rem;
-      padding: 1.5rem;
-      text-align: center;
-    }
-    .int-card-icon { font-size: 2rem; margin-bottom: 0.5rem; }
-    .int-card-title { font-weight: 700; font-size: 1rem; color: #0f172a; margin-bottom: 0.5rem; }
-    .int-card-desc { font-size: 0.875rem; color: #475569; line-height: 1.5; }
-    .int-card-code {
-      font-family: 'Courier New', monospace;
-      font-size: 0.8rem;
-      color: #1d4ed8;
-      background: #eff6ff;
-      border-radius: 0.375rem;
-      padding: 0.25rem 0.5rem;
-      margin-top: 0.5rem;
-      display: inline-block;
-    }
-
-    /* Pokrycie testami (z razdwa-aplikacja.html) */
-    .test-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-      gap: 1rem;
-      max-width: 900px;
-      margin: 2rem auto;
-    }
-    .test-item {
-      background: #fff;
-      border: 1px solid #e2e8f0;
-      border-left: 3px solid #10b981;
-      border-radius: 0.5rem;
-      padding: 0.875rem 1rem;
-    }
-    .test-item-name {
-      font-size: 0.8125rem;
-      font-family: 'Courier New', monospace;
-      color: #0f172a;
-      font-weight: 600;
-      margin-bottom: 0.25rem;
-    }
-    .test-item-count {
-      font-size: 0.875rem;
-      color: #10b981;
-      font-weight: 700;
-    }
-    .test-item-sub { font-size: 0.75rem; color: #64748b; }
-
-    /* Dekoracyjne oddzielenie sekcji */
-    .section-divider {
-      text-align: center;
-      margin: 4rem 0 2rem;
-      font-family: 'Playfair Display', serif;
-      font-size: 2.5rem;
-      color: #0f172a;
-      position: relative;
-    }
-    .section-divider::after {
-      content: '';
-      display: block;
-      width: 60px;
-      height: 4px;
-      background: #06b6d4;
-      margin: 1rem auto 0;
-      border-radius: 2px;
-    }
-  </style>
 </head>
 
 <body>
@@ -399,7 +103,60 @@
       </div>
     </div>
 
-    <div class="kwcs-sec kwcs-context-section">
+    <!-- ============================================================
+         Executive summary po hero
+    ============================================================ -->
+    <div class="razdwa-summary" id="razdwa-summary">
+      <div class="wrap">
+        <h2>W skrócie</h2>
+        <p class="razdwa-summary-lead">
+          Aplikacja PWA dla drukarni Raz Dwa, zastąpiła ręczne wyceny w Excelu i papierowy cennik. Operator wycenia zlecenie w ok. 5 minut, właściciel sam aktualizuje ceny przez panel, a zamówienia trafiają do PDF i Google Sheets bez własnego serwera.
+        </p>
+        <div class="razdwa-summary-grid">
+          <div class="razdwa-summary-cell">
+            <div class="label">Problem</div>
+            <div class="value">Ręczne wyceny zajmowały do godziny, błędy wracały jako poprawione faktury.</div>
+          </div>
+          <div class="razdwa-summary-cell">
+            <div class="label">Moja rola</div>
+            <div class="value">Digital Product Designer — analiza, projekt, kod, testy, wdrożenie.</div>
+          </div>
+          <div class="razdwa-summary-cell">
+            <div class="label">Co dostarczyłem</div>
+            <div class="value">Kalkulator 22 kategorii, koszyk, panel admina, PWA offline, integracja z Google Sheets.</div>
+          </div>
+          <div class="razdwa-summary-cell">
+            <div class="label">Wynik</div>
+            <div class="value">~5 min zamiast godziny (ok. −90%), zero IT w utrzymaniu, ~50 testów automatycznych.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================
+         Chapter rail — sticky TOC z internal anchors
+    ============================================================ -->
+    <nav class="razdwa-chapter-rail" id="razdwa-chapter-rail" aria-label="Spis treści case study">
+      <div class="razdwa-chapter-rail-label">Spis treści</div>
+      <ul class="razdwa-chapter-rail-list">
+        <li><a class="razdwa-chapter-link" href="#razdwa-summary" data-rail-target="razdwa-summary">W skrócie</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-kontekst" data-rail-target="razdwa-kontekst">Kontekst</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-decyzje" data-rail-target="razdwa-decyzje">Decyzje produktowe</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-role" data-rail-target="razdwa-role">Role i persony</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-ux" data-rail-target="razdwa-ux">Interfejs i UX</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-cad" data-rail-target="razdwa-cad">Kalkulator CAD</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-panel" data-rail-target="razdwa-panel">Panel admina</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-warianty" data-rail-target="razdwa-warianty">Warianty</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-droga" data-rail-target="razdwa-droga">Droga zamówienia</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-architektura" data-rail-target="razdwa-architektura">Architektura</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-systemui" data-rail-target="razdwa-systemui">System UI</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-contribution" data-rail-target="razdwa-contribution">Moja rola</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-potencjal" data-rail-target="razdwa-potencjal">Potencjał B2B</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-rezultat" data-rail-target="razdwa-rezultat">Rezultat</a></li>
+      </ul>
+    </nav>
+
+    <div class="kwcs-sec kwcs-context-section" id="razdwa-kontekst">
       <div class="wrap">
         <h2>Kontekst projektu</h2>
 
@@ -478,7 +235,7 @@
     </div>
 
 
-    <h2 class="section-divider">Decyzje produktowe</h2>
+    <h2 class="section-divider" id="razdwa-decyzje">Decyzje produktowe</h2>
 
     <div class="kwcs-sec">
       <div class="wrap">
@@ -567,7 +324,7 @@
     </div>
 
 
-    <h2 class="section-divider">Role i persony</h2>
+    <h2 class="section-divider" id="razdwa-role">Role i persony</h2>
 
     <div class="kwcs-sec" style="background:#f8fafc;">
       <div class="wrap">
@@ -595,7 +352,7 @@
     </div>
 
 
-    <h2 class="section-divider">Część 1: Interfejs i UX</h2>
+    <h2 class="section-divider" id="razdwa-ux">Część 1: Interfejs i UX</h2>
     
     <div class="kwcs-sec">
       <div class="wrap">
@@ -697,7 +454,7 @@
     </div>
 
 
-    <h2 class="section-divider">Część 2: Kalkulator Druku CAD</h2>
+    <h2 class="section-divider" id="razdwa-cad">Część 2: Kalkulator Druku CAD</h2>
 
     <div class="kwcs-sec">
       <div class="wrap">
@@ -756,7 +513,7 @@
     </div>
 
 
-    <h2 class="section-divider">Część 3: Panel administracyjny cen</h2>
+    <h2 class="section-divider" id="razdwa-panel">Część 3: Panel administracyjny cen</h2>
 
     <div class="kwcs-sec">
       <div class="wrap">
@@ -815,7 +572,7 @@
     </div>
 
 
-    <h2 class="section-divider">Część 4: Warianty produktów</h2>
+    <h2 class="section-divider" id="razdwa-warianty">Część 4: Warianty produktów</h2>
 
     <div class="kwcs-sec" style="background:#f8fafc;">
       <div class="wrap">
@@ -864,7 +621,7 @@
     </div>
 
 
-    <h2 class="section-divider">Część 5: Droga zamówienia</h2>
+    <h2 class="section-divider" id="razdwa-droga">Część 5: Droga zamówienia</h2>
 
     <div class="kwcs-sec">
       <div class="wrap">
@@ -925,7 +682,7 @@
     </div>
 
 
-    <h2 class="section-divider">Część 6: Architektura i Integracje</h2>
+    <h2 class="section-divider" id="razdwa-architektura">Część 6: Architektura i Integracje</h2>
 
     <div class="kwcs-sec">
       <div class="wrap">
@@ -935,8 +692,15 @@
           </p>
         </div>
 
-        <h3 style="text-align:center">Architektura — pięć warstw odpowiedzialności</h3>
-        <p style="max-width:720px;margin:0 auto 1rem;color:#475569;">Każda warstwa ma jedno zadanie. Dzięki temu zmiana w jednej warstwie nie psuje pozostałych — np. zmiana ceny nie wymaga ruszania kodu, a dodanie nowej kategorii produktów nie wymaga ruszania interfejsu.</p>
+        <h3 style="text-align:center" id="razdwa-architektura-warstwy">Architektura — pięć warstw odpowiedzialności</h3>
+        <p style="max-width:720px;margin:0 auto 1rem;color:#475569;">Każda warstwa ma jedno zadanie. Dzięki temu zmiana w jednej warstwie nie psuje pozostałych — np. zmiana ceny nie wymaga ruszania kodu, a dodanie nowej kategorii produktów nie wymaga ruszania interfejsu. Szczegółowy opis odpowiedzialności jest poniżej, domyślnie zwinięty.</p>
+        <div class="kwcs-accordion">
+          <div class="kwcs-item">
+            <button class="kwcs-header" aria-expanded="false" aria-controls="content-arch-warstwy" id="header-arch-warstwy" type="button">
+              <span class="num">▸</span> Deep dive — pięć warstw architektury aplikacji
+              <span class="icon" aria-hidden="true">+</span>
+            </button>
+            <div class="kwcs-content" id="content-arch-warstwy" role="region" aria-labelledby="header-arch-warstwy">
         <div class="arch-layers">
           <div class="arch-layer">
             <div class="arch-layer-label">Interfejs<br>Warstwa 1</div>
@@ -986,8 +750,19 @@
         <p style="max-width:720px;margin:1rem auto 0;color:#64748b;font-size:0.875rem;">
           <strong>Dlaczego pięć, a nie cztery?</strong> Wydzielenie warstwy „Logiki domenowej" (koszyk, modyfikatory, walidacje, klucze wariantów) od warstwy kategorii oznacza, że ta sama logika koszyka działa dla wszystkich 22 kategorii — i będzie działała dla 23. kategorii bez zmian. To także moduły, które najłatwiej przenieść do innej branży (patrz: sekcja „Potencjał B2B").
         </p>
+            </div>
+          </div>
+        </div>
 
-        <h3 style="margin-top:3rem;text-align:center">Integracje ekosystemu</h3>
+        <h3 style="margin-top:3rem;text-align:center" id="razdwa-architektura-integracje">Integracje ekosystemu</h3>
+        <p style="max-width:720px;margin:0 auto 1rem;color:#475569;text-align:center;">Trzy zewnętrzne komponenty zastępują własny backend. Lista i opisy zwinięte poniżej.</p>
+        <div class="kwcs-accordion">
+          <div class="kwcs-item">
+            <button class="kwcs-header" aria-expanded="false" aria-controls="content-arch-integ" id="header-arch-integ" type="button">
+              <span class="num">▸</span> Deep dive — pdf-lib, Google Apps Script, panel cennika
+              <span class="icon" aria-hidden="true">+</span>
+            </button>
+            <div class="kwcs-content" id="content-arch-integ" role="region" aria-labelledby="header-arch-integ">
         <div class="integration-flow">
           <div class="int-card">
             <div class="int-card-icon">📄</div>
@@ -1008,9 +783,19 @@
             <div class="int-card-code">StorageEvent Broadcast</div>
           </div>
         </div>
+            </div>
+          </div>
+        </div>
 
-        <h3 style="margin-top:3rem;text-align:center">Niezawodność — testy automatyczne</h3>
-        <p>Każda zmiana w cenniku jest krytyczna biznesowo: błąd kropki w stawce za m² oznacza realną stratę na fakturze. Dlatego zbudowałem <strong>~50 plików testowych</strong> obejmujących nie tylko kalkulacje, ale też zachowania interfejsu i scenariusze regresji.</p>
+        <h3 style="margin-top:3rem;text-align:center" id="razdwa-architektura-testy">Niezawodność — testy automatyczne</h3>
+        <p>Każda zmiana w cenniku jest krytyczna biznesowo: błąd kropki w stawce za m² oznacza realną stratę na fakturze. Dlatego zbudowałem <strong>~50 plików testowych</strong> obejmujących nie tylko kalkulacje, ale też zachowania interfejsu i scenariusze regresji. Pełna mapa pokrycia jest zwinięta poniżej.</p>
+        <div class="kwcs-accordion">
+          <div class="kwcs-item">
+            <button class="kwcs-header" aria-expanded="false" aria-controls="content-arch-testy" id="header-arch-testy" type="button">
+              <span class="num">▸</span> Deep dive — mapa pokrycia testami (8 obszarów)
+              <span class="icon" aria-hidden="true">+</span>
+            </button>
+            <div class="kwcs-content" id="content-arch-testy" role="region" aria-labelledby="header-arch-testy">
         <div class="test-grid">
           <div class="test-item">
             <div class="test-item-name">Kalkulacje per kategoria</div>
@@ -1056,12 +841,165 @@
         <p style="max-width:720px;margin:1rem auto 0;color:#64748b;font-size:0.875rem;">
           <strong>Decyzja PM:</strong> testy regresji UI (nawigacja, dostępność panelu, walidacje) wprowadziłem po doświadczeniach z wcześniejszych iteracji, kiedy refaktoring jednego widoku potrafił przypadkiem zepsuć inny. Koszt utrzymania zwraca się przy każdej zmianie cennika.
         </p>
+            </div>
+          </div>
+        </div>
 
       </div>
     </div>
 
+    <!-- ============================================================
+         System UI projektu
+    ============================================================ -->
+    <h2 class="section-divider" id="razdwa-systemui">System UI projektu</h2>
 
-    <h2 class="section-divider">Potencjał poza poligrafią</h2>
+    <div class="kwcs-sec" style="background:#f8fafc;">
+      <div class="wrap">
+        <div class="context-intro">
+          <p>Aplikacja używa wąskiego, świadomego zestawu tokenów: jeden akcent (cyan), neutralna paleta slate, dwie rodziny pisma i kilka powtarzalnych komponentów. Dzięki temu każda nowa kategoria cennikowa wygląda spójnie bez dodatkowej decyzji wizualnej.</p>
+        </div>
+
+        <div class="razdwa-systemui">
+          <div class="systemui-card">
+            <h4>Kolory</h4>
+            <div class="systemui-swatches">
+              <div class="systemui-swatch">
+                <div class="systemui-swatch-color" style="background:#06b6d4"></div>
+                <div class="systemui-swatch-meta">
+                  <div class="systemui-swatch-name">Akcent</div>
+                  <div class="systemui-swatch-code">#06b6d4</div>
+                </div>
+              </div>
+              <div class="systemui-swatch">
+                <div class="systemui-swatch-color" style="background:#0284c7"></div>
+                <div class="systemui-swatch-meta">
+                  <div class="systemui-swatch-name">Akcent ciemny</div>
+                  <div class="systemui-swatch-code">#0284c7</div>
+                </div>
+              </div>
+              <div class="systemui-swatch">
+                <div class="systemui-swatch-color" style="background:#0f172a"></div>
+                <div class="systemui-swatch-meta">
+                  <div class="systemui-swatch-name">Tekst</div>
+                  <div class="systemui-swatch-code">#0f172a</div>
+                </div>
+              </div>
+              <div class="systemui-swatch">
+                <div class="systemui-swatch-color" style="background:#475569"></div>
+                <div class="systemui-swatch-meta">
+                  <div class="systemui-swatch-name">Tekst pomocniczy</div>
+                  <div class="systemui-swatch-code">#475569</div>
+                </div>
+              </div>
+              <div class="systemui-swatch">
+                <div class="systemui-swatch-color" style="background:#f8fafc;border-color:#e2e8f0"></div>
+                <div class="systemui-swatch-meta">
+                  <div class="systemui-swatch-name">Tło sekcji</div>
+                  <div class="systemui-swatch-code">#f8fafc</div>
+                </div>
+              </div>
+              <div class="systemui-swatch">
+                <div class="systemui-swatch-color" style="background:#10b981"></div>
+                <div class="systemui-swatch-meta">
+                  <div class="systemui-swatch-name">Sukces</div>
+                  <div class="systemui-swatch-code">#10b981</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="systemui-card">
+            <h4>Typografia</h4>
+            <div class="systemui-typo">
+              <div class="systemui-typo-row">
+                <span class="systemui-typo-sample is-display">Aa</span>
+                <span class="systemui-typo-meta">Playfair Display 700 — nagłówki sekcji</span>
+              </div>
+              <div class="systemui-typo-row">
+                <span class="systemui-typo-sample is-heading">Aa</span>
+                <span class="systemui-typo-meta">Inter 700 — h3, etykiety kart</span>
+              </div>
+              <div class="systemui-typo-row">
+                <span class="systemui-typo-sample is-body">Aa</span>
+                <span class="systemui-typo-meta">Inter 400 — tekst ciągły</span>
+              </div>
+              <div class="systemui-typo-row">
+                <span class="systemui-typo-sample is-mono">Aa</span>
+                <span class="systemui-typo-meta">Courier — tagi techniczne, klucze cennika</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="systemui-card" style="grid-column: 1 / -1;">
+            <h4>Powtarzalne komponenty</h4>
+            <div class="systemui-components">
+              <span class="arch-tag">.razdwa-stat</span>
+              <span class="arch-tag">.eco-node</span>
+              <span class="arch-tag">.ux-decision-box</span>
+              <span class="arch-tag">.kwcs-card</span>
+              <span class="arch-tag">.arch-layer / .arch-tag</span>
+              <span class="arch-tag">.int-card</span>
+              <span class="arch-tag">.test-item</span>
+              <span class="arch-tag">.kwcs-accordion / .kwcs-item</span>
+              <span class="arch-tag">.razdwa-summary-cell</span>
+              <span class="arch-tag">.contribution-cell</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================
+         Contribution grid — co robiłem ja, co podzielone, co poza zakresem
+    ============================================================ -->
+    <h2 class="section-divider" id="razdwa-contribution">Moja rola w projekcie</h2>
+
+    <div class="kwcs-sec">
+      <div class="wrap">
+        <div class="context-intro">
+          <p>Aplikację zaprojektowałem i zbudowałem samodzielnie — od analizy procesu po wdrożenie. Poniższa siatka rozdziela to, co było wyłącznie moją odpowiedzialnością, od tego, co konsultowałem z właścicielką drukarni, i od zasobów, które wniosła sama firma.</p>
+        </div>
+
+        <div class="contribution-grid">
+          <div class="contribution-cell contribution-cell--solo">
+            <h4><span class="dot"></span>Solo — ja</h4>
+            <ul>
+              <li>Analiza procesu wyceny w warsztacie</li>
+              <li>Architektura aplikacji (5 warstw)</li>
+              <li>Projekt UX/UI wszystkich ekranów</li>
+              <li>TypeScript: kalkulatory, koszyk, panel admina</li>
+              <li>System wariantów i slugifikacja PL → klucze</li>
+              <li>Integracja Google Apps Script + PIN</li>
+              <li>~50 plików testów (Vitest)</li>
+              <li>PWA, Service Worker, eksport PDF (pdf-lib)</li>
+              <li>Wdrożenie produkcyjne i dokumentacja</li>
+            </ul>
+          </div>
+          <div class="contribution-cell contribution-cell--shared">
+            <h4><span class="dot"></span>Wspólnie z klientem</h4>
+            <ul>
+              <li>Mapa 22 kategorii cennikowych</li>
+              <li>Reguły dopłat (składanie, skanowanie, EXPRESS)</li>
+              <li>Walidacja kalkulatora CAD na rzeczywistych plikach</li>
+              <li>Test akceptacyjny: samodzielna aktualizacja cennika</li>
+              <li>Decyzja o panelu admina i bramce PIN</li>
+            </ul>
+          </div>
+          <div class="contribution-cell contribution-cell--external">
+            <h4><span class="dot"></span>Zasoby drukarni</h4>
+            <ul>
+              <li>Konto Google + arkusze (orders / cennik / variants)</li>
+              <li>Stary cennik papierowy jako źródło danych</li>
+              <li>Komputer warsztatowy do testów PWA offline</li>
+              <li>Zdjęcia i materiały do strony Raz Dwa</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+
+
+    <h2 class="section-divider" id="razdwa-potencjal">Potencjał poza poligrafią</h2>
 
     <div class="kwcs-sec">
       <div class="wrap">
@@ -1116,7 +1054,7 @@
     </div>
 
 
-    <h2 class="section-divider">Podsumowanie Projektu</h2>
+    <h2 class="section-divider" id="razdwa-rezultat">Podsumowanie Projektu</h2>
 
     <div class="kwcs-sec" id="zakres">
       <div class="wrap kwcs-trio">


### PR DESCRIPTION
## Cel

Pierwszy krok standaryzacji portfolio — pełna porządkowa runda na case studie **RAZDWA**. Pozostałe projekty pozostają nietknięte (standaryzacja kolejnymi PR-ami).

## Co się zmieniło

### `projects/razdwa_aplikacja.html`
- **Usunięto embedded `<style>`** z `<head>`. To było realne bug: `portfolio.js` wczytuje plik przez `fetch` + `DOMParser` i bierze tylko `doc.body.innerHTML`, więc style w `<head>` były ciche dropowane podczas otwierania case study z poziomu portfolio. CSS przeniesiony do `assets/css/projects.css`.
- **Executive summary po hero** (`#razdwa-summary`) — 4 komórki: problem / rola / co dostarczyłem / wynik.
- **Sticky chapter rail** (`#razdwa-chapter-rail`) — 14 anchorów do głównych sekcji, na mobile zamienia się w przewijany pasek pigułek.
- **Internal anchors** (`id="razdwa-*"`) na każdym `section-divider` i kluczowych `h3` (warstwy / integracje / testy).
- **Deep-dive accordions** na trzech najdłuższych blokach technicznych: pięć warstw architektury, integracje (pdf-lib / Apps Script / panel cennika), mapa pokrycia testami. Domyślnie zamknięte.
- **System UI projektu** (`#razdwa-systemui`) — kolory, typografia, lista powtarzalnych komponentów aplikacji.
- **Contribution grid** (`#razdwa-contribution`) — solo / wspólnie z klientem / zasoby drukarni.

### `assets/css/projects.css`
- Dodano sekcję „RAZDWA case study” z przeniesionymi stylami i nowymi komponentami: `.razdwa-summary*`, `.razdwa-chapter-rail*`, `.contribution-*`, `.razdwa-systemui` + `.systemui-*`.
- `scroll-margin-top` na `.section-divider` i `[id^="razdwa-"]` dla sticky rail.

### `assets/js/portfolio.js`
- Nowa funkcja `initializeChapterRail()` w obrębie `initializeProjectScripts`. Klik na rail przewija przez `scrollIntoView` (bez ruszania URL hash, żeby nie kolidować z routingiem `projectPages[hash]`). `IntersectionObserver` podświetla aktywną pigułkę.

### `portfolio.html`
- Doprecyzowano opis karty Raz Dwa (kategoria, opis, dwa konkretne featury) dla skanowalności. Reszta sekcji bez zmian.

## Czego **nie** ruszałem
- `razdwa.html` (hub), `karoma`, `power-of-mind`, `cyfradruk`, `KW-Design`, `sir-roger`, `savage`, `voucher-salon-magdy`, `wizualizacje`, `kontakt`, `omnie`, `uslugi`, `index`.
- Treść merytoryczna RAZDWA pozostała — same zmiany strukturalne/nawigacyjne.

## Test plan
- [ ] Otwórz `portfolio.html`, kliknij kartę „Raz Dwa Druk” — case study się ładuje.
- [ ] Sticky rail jest widoczny, kliknięcia smooth-scrollują do sekcji w obrębie kontenera szczegółów.
- [ ] Aktywna pigułka rail się podświetla podczas scrolla.
- [ ] Trzy deep-dive accordiony otwierają się i zamykają (warstwy, integracje, testy).
- [ ] Bezpośrednie otwarcie `projects/razdwa_aplikacja.html` (standalone) — style działają z `projects.css`, nie z embedded `<style>`.
- [ ] Mobile (≤600px) — rail pokazuje się jako horizontal scroll bar.
- [ ] Brak regresji na pozostałych projektach (powinno być zero — CSS jest namespacowany pod RAZDWA).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNi6jDQsDLXyrD4mEe2weo)_