### PR TITLE
RAZDWA: górny TOC → sticky boczny chapter rail

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -2551,73 +2551,134 @@ body.lightbox-open {
 }
 
 /* ========================================
-   RAZDWA — Chapter rail (sticky TOC)
+   RAZDWA — Sticky chapter rail (boczny)
+   Desktop >= 1280px: pełna lista rozdziałów po lewej.
+   Poniżej 1280px: slim pasek z kropkami przy lewej krawędzi.
+   Nigdy nie wraca do "TOC na górze".
    ======================================== */
 .razdwa-chapter-rail {
-  position: sticky;
-  top: 16px;
-  z-index: 10;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  position: fixed;
+  left: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 25;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   border: 1px solid #e2e8f0;
-  border-radius: 0.75rem;
-  padding: 0.6rem 0.85rem;
-  margin: 1.25rem auto 2rem;
-  max-width: 1100px;
-  box-shadow: 0 8px 24px -12px rgba(15, 23, 42, 0.12);
+  border-radius: 0.85rem;
+  box-shadow: 0 10px 30px -15px rgba(15, 23, 42, 0.25);
+  padding: 0.5rem 0.4rem;
+  margin: 0;
+  max-width: 2.4rem;
+  max-height: 80vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: thin;
 }
+.razdwa-chapter-rail::-webkit-scrollbar { width: 4px; }
+.razdwa-chapter-rail::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 2px; }
+
 .razdwa-chapter-rail-label {
+  display: none;
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: #06b6d4;
   font-weight: 700;
-  padding: 0.1rem 0.25rem;
-  margin-bottom: 0.4rem;
+  padding: 0.1rem 0.6rem;
+  margin-bottom: 0.5rem;
 }
+
 .razdwa-chapter-rail-list {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  gap: 0.2rem;
   list-style: none;
   padding: 0;
   margin: 0;
 }
 .razdwa-chapter-rail-list li { margin: 0; }
 .razdwa-chapter-rail-list li::before { content: none !important; }
+
 .razdwa-chapter-link {
-  display: inline-block;
-  background: #f1f5f9;
-  border: 1px solid #e2e8f0;
-  color: #0f172a;
-  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  background: transparent;
+  border: 1px solid transparent;
+  color: #475569;
+  font-size: 0;
+  line-height: 1.2;
   font-weight: 500;
-  padding: 0.3rem 0.7rem;
-  border-radius: 9999px;
+  padding: 0.45rem;
+  border-radius: 0.5rem;
   text-decoration: none;
   cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
 }
+.razdwa-chapter-link::before {
+  content: '';
+  flex-shrink: 0;
+  display: block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #cbd5e1;
+  transition: background 0.18s ease, transform 0.18s ease;
+}
 .razdwa-chapter-link:hover {
-  background: #06b6d4;
-  border-color: #06b6d4;
-  color: #fff;
+  background: #f0f9ff;
+  color: #0f172a;
+  border-color: #e0f2fe;
+}
+.razdwa-chapter-link:hover::before { background: #06b6d4; }
+.razdwa-chapter-link:focus-visible {
+  outline: 2px solid #06b6d4;
+  outline-offset: 2px;
 }
 .razdwa-chapter-link.is-active {
-  background: #0284c7;
-  border-color: #0284c7;
-  color: #fff;
+  background: #ecfeff;
+  color: #0f172a;
+  border-color: #a5f3fc;
+  font-weight: 600;
 }
-@media (max-width: 600px) {
+.razdwa-chapter-link.is-active::before {
+  background: #06b6d4;
+  transform: scale(1.4);
+}
+
+/* Desktop: pełna lista rozdziałów z etykietami */
+@media (min-width: 1280px) {
   .razdwa-chapter-rail {
-    border-radius: 0.5rem;
-    padding: 0.5rem 0.6rem;
-    margin: 1rem 0.5rem 1.5rem;
+    left: max(0.85rem, calc(50vw - 820px));
+    max-width: 230px;
+    width: 230px;
+    padding: 0.85rem 0.7rem;
   }
-  .razdwa-chapter-rail-list { flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch; }
-  .razdwa-chapter-link { white-space: nowrap; }
+  .razdwa-chapter-rail-label { display: block; }
+  .razdwa-chapter-link {
+    font-size: 0.82rem;
+    padding: 0.42rem 0.7rem;
+  }
 }
+
+/* Bardzo małe ekrany — przyklejony do krawędzi, nieco mniejszy */
+@media (max-width: 480px) {
+  .razdwa-chapter-rail {
+    left: 0.35rem;
+    padding: 0.4rem 0.3rem;
+    max-height: 70vh;
+  }
+  .razdwa-chapter-link { padding: 0.4rem; }
+}
+
+/* Przy aktywnym lightboxie chowamy rail, żeby nie zasłaniał zdjęcia */
+body.lightbox-open .razdwa-chapter-rail { display: none; }
 
 /* ========================================
    RAZDWA — Contribution grid

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -234,6 +234,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const detailsContainer = document.getElementById('project-details-container');
 
+    const setActive = (activeLink) => {
+      links.forEach(l => {
+        const isActive = l === activeLink;
+        l.classList.toggle('is-active', isActive);
+        if (isActive) {
+          l.setAttribute('aria-current', 'true');
+        } else {
+          l.removeAttribute('aria-current');
+        }
+      });
+    };
+
     links.forEach(link => {
       link.addEventListener('click', (e) => {
         e.preventDefault();
@@ -241,8 +253,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const target = document.getElementById(id);
         if (!target) return;
         target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        links.forEach(l => l.classList.remove('is-active'));
-        link.classList.add('is-active');
+        setActive(link);
       });
     });
 
@@ -255,14 +266,12 @@ document.addEventListener('DOMContentLoaded', () => {
         entries.forEach(entry => {
           if (!entry.isIntersecting) return;
           const id = entry.target.id;
-          links.forEach(l => {
-            const targetId = l.dataset.railTarget || l.getAttribute('href').replace('#', '');
-            l.classList.toggle('is-active', targetId === id);
-          });
+          const match = links.find(l => (l.dataset.railTarget || l.getAttribute('href').replace('#', '')) === id);
+          if (match) setActive(match);
         });
       }, {
         root: detailsContainer && detailsContainer.style.overflow === 'auto' ? detailsContainer : null,
-        rootMargin: '-30% 0px -60% 0px',
+        rootMargin: '-25% 0px -65% 0px',
         threshold: 0
       });
       targets.forEach(t => observer.observe(t));

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -137,22 +137,22 @@
          Chapter rail — sticky TOC z internal anchors
     ============================================================ -->
     <nav class="razdwa-chapter-rail" id="razdwa-chapter-rail" aria-label="Spis treści case study">
-      <div class="razdwa-chapter-rail-label">Spis treści</div>
+      <div class="razdwa-chapter-rail-label">Rozdziały</div>
       <ul class="razdwa-chapter-rail-list">
-        <li><a class="razdwa-chapter-link" href="#razdwa-summary" data-rail-target="razdwa-summary">W skrócie</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-kontekst" data-rail-target="razdwa-kontekst">Kontekst</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-decyzje" data-rail-target="razdwa-decyzje">Decyzje produktowe</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-role" data-rail-target="razdwa-role">Role i persony</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-ux" data-rail-target="razdwa-ux">Interfejs i UX</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-cad" data-rail-target="razdwa-cad">Kalkulator CAD</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-panel" data-rail-target="razdwa-panel">Panel admina</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-warianty" data-rail-target="razdwa-warianty">Warianty</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-droga" data-rail-target="razdwa-droga">Droga zamówienia</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-architektura" data-rail-target="razdwa-architektura">Architektura</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-systemui" data-rail-target="razdwa-systemui">System UI</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-contribution" data-rail-target="razdwa-contribution">Moja rola</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-potencjal" data-rail-target="razdwa-potencjal">Potencjał B2B</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-rezultat" data-rail-target="razdwa-rezultat">Rezultat</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-summary" data-rail-target="razdwa-summary" title="W skrócie" aria-label="W skrócie">W skrócie</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-kontekst" data-rail-target="razdwa-kontekst" title="Kontekst" aria-label="Kontekst">Kontekst</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-decyzje" data-rail-target="razdwa-decyzje" title="Decyzje produktowe" aria-label="Decyzje produktowe">Decyzje produktowe</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-role" data-rail-target="razdwa-role" title="Role i persony" aria-label="Role i persony">Role i persony</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-ux" data-rail-target="razdwa-ux" title="Interfejs i UX" aria-label="Interfejs i UX">Interfejs i UX</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-cad" data-rail-target="razdwa-cad" title="Kalkulator CAD" aria-label="Kalkulator CAD">Kalkulator CAD</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-panel" data-rail-target="razdwa-panel" title="Panel admina" aria-label="Panel admina">Panel admina</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-warianty" data-rail-target="razdwa-warianty" title="Warianty" aria-label="Warianty">Warianty</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-droga" data-rail-target="razdwa-droga" title="Droga zamówienia" aria-label="Droga zamówienia">Droga zamówienia</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-architektura" data-rail-target="razdwa-architektura" title="Architektura" aria-label="Architektura">Architektura</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-systemui" data-rail-target="razdwa-systemui" title="System UI" aria-label="System UI">System UI</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-contribution" data-rail-target="razdwa-contribution" title="Moja rola" aria-label="Moja rola">Moja rola</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-potencjal" data-rail-target="razdwa-potencjal" title="Potencjał B2B" aria-label="Potencjał B2B">Potencjał B2B</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-rezultat" data-rail-target="razdwa-rezultat" title="Rezultat" aria-label="Rezultat">Rezultat</a></li>
       </ul>
     </nav>
 


### PR DESCRIPTION
## Summary

Pierwszy krok standaryzacji portfolio — zmiana nawigacji w case study RAZDWA.

Górny sticky TOC (poziome pigułki na górze sekcji) został przekształcony w boczny sticky chapter rail. Pozostałe elementy targetu (summary po hero, anchors, accordion deep-dive, contribution grid, System UI projektu, brak embedded `<style>` w `razdwa_aplikacja.html`) były już wprowadzone w poprzedniej iteracji — w tym PR nadrabiamy ostatni brakujący punkt: rail nie jest już TOC na górze.

### Zmiany

- **`assets/css/projects.css`** — przebudowa `.razdwa-chapter-rail` z `position: sticky` (top, horizontal) na `position: fixed` (lewa krawędź, vertical). Desktop ≥ 1280px: pełne etykiety rozdziałów w panelu 230px szer. Poniżej 1280px: slim 36px pasek z animowaną kropką per rozdział — widoczny stale, nie blokuje treści, nie wraca do TOC na górze. Auto-hide gdy aktywny lightbox.
- **`projects/razdwa_aplikacja.html`** — `title` i `aria-label` na każdym linku rail (tooltip + a11y w widoku slim, gdy etykiety są wizualnie ukryte).
- **`assets/js/portfolio.js`** — `setActive()` ustawia `aria-current="true"` na aktywnym linku; tighter `rootMargin` w IntersectionObserver dla nowego layoutu.

### Poza scope tego PR

- `razdwa.html` (hub-page) — pozostaje bez zmian, jego embedded `<style>` nie był w zakresie ticketu.
- Inne case studies — zgodnie z instrukcją "tylko RAZDWA jako pierwszy krok".

## Test plan

- [ ] Otwórz `portfolio.html`, kliknij kartę "Raz Dwa Druk" — rail pojawia się przy lewej krawędzi
- [ ] Desktop (≥1280px): rail pokazuje pełne nazwy rozdziałów, klik scrolluje do sekcji, aktywny rozdział się podświetla
- [ ] Tablet/mobile (<1280px): rail to slim pasek z kropkami, tap na kropce scrolluje do sekcji
- [ ] Aktywny rozdział aktualizuje się przy scrollu (IntersectionObserver)
- [ ] Lightbox: po kliknięciu obrazka rail znika i nie zasłania powiększenia
- [ ] Brak górnego pasma TOC po sekcji "W skrócie"
- [ ] `aria-current="true"` na aktywnym linku (DevTools)

https://claude.ai/code/session_01AFtYsPhvWLnoMFwGErnot7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFtYsPhvWLnoMFwGErnot7)_