### PR TITLE
RAZDWA: chapter rail jako pełnowymiarowy timeline (fix urywania w połowie)

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -2551,33 +2551,27 @@ body.lightbox-open {
 }
 
 /* ========================================
-   RAZDWA — Sticky chapter rail (boczny)
-   Desktop >= 1280px: pełna lista rozdziałów po lewej.
-   Poniżej 1280px: slim pasek z kropkami przy lewej krawędzi.
-   Nigdy nie wraca do "TOC na górze".
+   RAZDWA — Chapter rail jako pełnej długości timeline
+   - Fixed, top:0 / bottom:0 → linia biegnie przez cały viewport
+   - Kropki rozłożone równomiernie wzdłuż linii (justify-content: space-between)
+   - Desktop >= 1280px: pełne etykiety rozdziałów obok kropek
+   - Poniżej 1280px: slim timeline z samymi kropkami przy lewej krawędzi
+   - Zawsze widoczny przy scrollu — to persistent navigation case study
    ======================================== */
 .razdwa-chapter-rail {
   position: fixed;
   left: 0.5rem;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 0;
+  bottom: 0;
   z-index: 25;
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border: 1px solid #e2e8f0;
-  border-radius: 0.85rem;
-  box-shadow: 0 10px 30px -15px rgba(15, 23, 42, 0.25);
-  padding: 0.5rem 0.4rem;
+  display: flex;
+  flex-direction: column;
+  padding: 5rem 0.3rem 4rem;
   margin: 0;
-  max-width: 2.4rem;
-  max-height: 80vh;
-  overflow-y: auto;
-  overflow-x: hidden;
-  scrollbar-width: thin;
+  max-width: 2.2rem;
+  pointer-events: none;
+  background: transparent;
 }
-.razdwa-chapter-rail::-webkit-scrollbar { width: 4px; }
-.razdwa-chapter-rail::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 2px; }
 
 .razdwa-chapter-rail-label {
   display: none;
@@ -2586,95 +2580,146 @@ body.lightbox-open {
   letter-spacing: 0.1em;
   color: #06b6d4;
   font-weight: 700;
-  padding: 0.1rem 0.6rem;
+  padding: 0 0.6rem;
   margin-bottom: 0.5rem;
+  pointer-events: auto;
 }
 
 .razdwa-chapter-rail-list {
+  position: relative;
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
-  gap: 0.2rem;
+  justify-content: space-between;
+  flex: 1 1 auto;
+  gap: 0;
   list-style: none;
   padding: 0;
   margin: 0;
+  pointer-events: auto;
 }
-.razdwa-chapter-rail-list li { margin: 0; }
+
+/* Pionowa linia timeline biegnąca przez całą wysokość */
+.razdwa-chapter-rail-list::before {
+  content: '';
+  position: absolute;
+  left: 0.55rem;
+  top: 0.5rem;
+  bottom: 0.5rem;
+  width: 2px;
+  background: linear-gradient(
+    180deg,
+    rgba(6, 182, 212, 0.0) 0%,
+    rgba(6, 182, 212, 0.35) 8%,
+    rgba(6, 182, 212, 0.45) 50%,
+    rgba(6, 182, 212, 0.35) 92%,
+    rgba(6, 182, 212, 0.0) 100%
+  );
+  border-radius: 2px;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.razdwa-chapter-rail-list li {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  display: flex;
+}
 .razdwa-chapter-rail-list li::before { content: none !important; }
 
 .razdwa-chapter-link {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.6rem;
   background: transparent;
   border: 1px solid transparent;
   color: #475569;
   font-size: 0;
   line-height: 1.2;
   font-weight: 500;
-  padding: 0.45rem;
-  border-radius: 0.5rem;
+  padding: 0.15rem 0.35rem;
+  border-radius: 9999px;
   text-decoration: none;
   cursor: pointer;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: 100%;
   transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
 }
+
+/* Kropka-marker na linii */
 .razdwa-chapter-link::before {
   content: '';
   flex-shrink: 0;
   display: block;
-  width: 8px;
-  height: 8px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
-  background: #cbd5e1;
-  transition: background 0.18s ease, transform 0.18s ease;
+  background: #ffffff;
+  border: 2px solid #cbd5e1;
+  box-shadow: 0 0 0 4px rgba(248, 250, 252, 0.92);
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
-.razdwa-chapter-link:hover {
-  background: #f0f9ff;
-  color: #0f172a;
-  border-color: #e0f2fe;
+
+.razdwa-chapter-link:hover { color: #0f172a; }
+.razdwa-chapter-link:hover::before {
+  border-color: #06b6d4;
+  background: #ecfeff;
 }
-.razdwa-chapter-link:hover::before { background: #06b6d4; }
 .razdwa-chapter-link:focus-visible {
   outline: 2px solid #06b6d4;
   outline-offset: 2px;
 }
+
 .razdwa-chapter-link.is-active {
-  background: #ecfeff;
   color: #0f172a;
-  border-color: #a5f3fc;
-  font-weight: 600;
+  font-weight: 700;
 }
 .razdwa-chapter-link.is-active::before {
   background: #06b6d4;
-  transform: scale(1.4);
+  border-color: #06b6d4;
+  transform: scale(1.25);
+  box-shadow: 0 0 0 5px rgba(6, 182, 212, 0.18);
 }
 
-/* Desktop: pełna lista rozdziałów z etykietami */
+/* Desktop: pełne etykiety obok kropek, więcej oddechu */
 @media (min-width: 1280px) {
   .razdwa-chapter-rail {
     left: max(0.85rem, calc(50vw - 820px));
-    max-width: 230px;
-    width: 230px;
-    padding: 0.85rem 0.7rem;
+    max-width: 240px;
+    width: 240px;
+    padding: 5.5rem 0.5rem 4rem;
   }
   .razdwa-chapter-rail-label { display: block; }
+  .razdwa-chapter-rail-list::before { left: 0.7rem; }
   .razdwa-chapter-link {
     font-size: 0.82rem;
-    padding: 0.42rem 0.7rem;
+    padding: 0.25rem 0.6rem 0.25rem 0.3rem;
+    background: rgba(255, 255, 255, 0.6);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+  }
+  .razdwa-chapter-link.is-active {
+    background: rgba(236, 254, 255, 0.95);
+    border-color: #a5f3fc;
   }
 }
 
-/* Bardzo małe ekrany — przyklejony do krawędzi, nieco mniejszy */
+/* Bardzo małe ekrany — przyklejony do krawędzi */
 @media (max-width: 480px) {
   .razdwa-chapter-rail {
-    left: 0.35rem;
-    padding: 0.4rem 0.3rem;
-    max-height: 70vh;
+    left: 0.3rem;
+    padding: 4rem 0.25rem 3.5rem;
   }
-  .razdwa-chapter-link { padding: 0.4rem; }
+}
+
+/* Bardzo niskie viewporty — żeby 14 kropek się nie nachodziło, pozwól na scroll */
+@media (max-height: 560px) {
+  .razdwa-chapter-rail { overflow-y: auto; }
+  .razdwa-chapter-rail-list { justify-content: flex-start; gap: 0.4rem; }
+  .razdwa-chapter-rail-list::before { bottom: auto; height: 100%; }
 }
 
 /* Przy aktywnym lightboxie chowamy rail, żeby nie zasłaniał zdjęcia */


### PR DESCRIPTION
## Summary

Korekta po feedbacku: chapter rail miał `max-height: 80vh` i był wycentrowany pionowo, więc wyglądał jak floating box urywający się w połowie strony. Teraz rail biegnie przez cały viewport jako pełny timeline.

### Zmiany w `.razdwa-chapter-rail`

- `top: 0; bottom: 0` zamiast `top: 50%; transform: translateY(-50%); max-height: 80vh` — rail wypełnia wysokość okna.
- Pionowa linia timeline jako gradient na `::before` listy (ginie miękko na końcach, nie urywa się ostro).
- `justify-content: space-between` na liście — 14 kropek rozłożonych równomiernie wzdłuż linii.
- Kropki-markery zamiast pełnych pigułek: białe wnętrze, szare obramowanie, "halo" w kolorze tła. Active state: wypełniona cyjanowa kropka, scale 1.25, podświetlone halo.
- Desktop ≥1280px: pełne etykiety obok kropek z subtelnym backdrop-blur za nimi.
- <1280px: slim timeline (~36px szer.) z samymi kropkami — nie zasłania treści.
- Fallback dla viewportów <560px wys.: scroll w railu (żeby 14 kropek się nie nachodziło).

Wynik: stała pionowa nawigacja od góry do dołu, widoczna przez cały scroll case study, z aktywnym markerem synchronizowanym z `IntersectionObserver` (logika z poprzedniego PR).

## Test plan

- [ ] Otwórz `portfolio.html`, kliknij kartę "Raz Dwa Druk"
- [ ] Desktop (≥1280px): widać pionową linię z 14 kropkami i etykietami; linia sięga od góry do dołu, nie urywa się w połowie
- [ ] Scroll przez całe case study: linia + kropki cały czas widoczne, aktywna kropka się przesuwa wraz z aktualną sekcją
- [ ] Tablet/mobile (<1280px): slim timeline z samymi kropkami przy lewej krawędzi, tap scrolluje do sekcji
- [ ] Wysoki viewport: kropki rozłożone z dużym odstępem; niski viewport (<560px wys.): rail się scrolluje
- [ ] Lightbox aktywny → rail znika
- [ ] Zamknij case study → rail znika razem z treścią

https://claude.ai/code/session_01AFtYsPhvWLnoMFwGErnot7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFtYsPhvWLnoMFwGErnot7)_