### PR TITLE
KW-Design Faza 1: struktura i hierarchia treści

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -2859,3 +2859,122 @@ body.lightbox-open .razdwa-chapter-rail { display: none; }
   gap: 0.5rem;
 }
 .systemui-components .arch-tag { font-size: 0.75rem; }
+
+/* ========================================
+   ASSET MISSING — placeholder dla brakujących obrazów
+   Pokazuje nazwę pliku zamiast szarego rectangle.
+   ======================================== */
+.asset-missing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  min-height: 200px;
+  background: repeating-linear-gradient(
+    45deg,
+    #fef3c7,
+    #fef3c7 10px,
+    #fde68a 10px,
+    #fde68a 20px
+  );
+  border: 2px dashed #d97706;
+  border-radius: 0.75rem;
+  padding: 1.5rem 1rem;
+  text-align: center;
+  color: #78350f;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+.asset-missing-icon { font-size: 2rem; line-height: 1; }
+.asset-missing-label {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.7rem;
+}
+.asset-missing-filename {
+  display: inline-block;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #d97706;
+  padding: 0.3rem 0.7rem;
+  border-radius: 0.4rem;
+  font-family: 'Courier New', Courier, monospace;
+  color: #78350f;
+  font-weight: 700;
+  font-size: 0.85rem;
+  word-break: break-all;
+  max-width: 100%;
+}
+
+/* ========================================
+   KWCS-SUMMARY — uniwersalne klasy executive summary
+   (paralela do .razdwa-summary; do reuse dla każdego case study)
+   ======================================== */
+.kwcs-summary {
+  background: linear-gradient(180deg, #f0f9ff 0%, #ffffff 100%);
+  border-top: 1px solid #e0f2fe;
+  border-bottom: 1px solid #e0f2fe;
+  padding: 3rem 1rem;
+}
+.kwcs-summary .wrap { max-width: 1100px; margin: 0 auto; }
+.kwcs-summary h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.75rem;
+  color: #0f172a;
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+.kwcs-summary-lead {
+  max-width: 760px;
+  margin: 0 auto 2rem;
+  text-align: center;
+  color: #475569;
+  font-size: 1.0625rem;
+  line-height: 1.7;
+}
+.kwcs-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+.kwcs-summary-cell {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1rem 1.1rem;
+}
+.kwcs-summary-cell .label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #06b6d4;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+.kwcs-summary-cell .value {
+  font-size: 0.95rem;
+  color: #0f172a;
+  font-weight: 600;
+  line-height: 1.4;
+}
+@media (max-width: 900px) {
+  .kwcs-summary-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 500px) {
+  .kwcs-summary-grid { grid-template-columns: 1fr; }
+}
+
+/* Dodatkowa klasa pomocnicza dla "Kontekst decyzji" pod główną decyzją */
+.ux-decision-box .ux-context {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  background: #f8fafc;
+  border-left: 3px solid #06b6d4;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  color: #475569;
+}
+.ux-decision-box .ux-context strong { color: #0f172a; }

--- a/projects/KW-Design.html
+++ b/projects/KW-Design.html
@@ -68,17 +68,49 @@
       </div>
     </div>
 
-    <!-- KONTEKST PROJEKTU (nowa sekcja jak w Karoma) -->
-    <div class="kwcs-sec kwcs-context-section">
+    <!-- ============================================================
+         Executive summary po hero
+    ============================================================ -->
+    <div class="kwcs-summary" id="kwdesign-summary">
+      <div class="wrap">
+        <h2>W skrócie</h2>
+        <p class="kwcs-summary-lead">
+          KW Design to identyfikacja wizualna mojej własnej marki projektanta cyfrowego. Sygnet i logotyp zaprojektowane z myślą o pracy w faviconie, w stopce maila, na stronie i w materiałach drukowanych — wszystko z jednego źródła, bez zewnętrznych dostawców.
+        </p>
+        <div class="kwcs-summary-grid">
+          <div class="kwcs-summary-cell">
+            <div class="label">Problem</div>
+            <div class="value">Brak spójnej identyfikacji własnej marki ograniczał wiarygodność komunikacji z klientami.</div>
+          </div>
+          <div class="kwcs-summary-cell">
+            <div class="label">Moja rola</div>
+            <div class="value">Digital Product Designer — analiza, koncepcja, finalne pliki i księga znaku w jednych rękach.</div>
+          </div>
+          <div class="kwcs-summary-cell">
+            <div class="label">Co dostarczyłem</div>
+            <div class="value">Logo i sygnet, księga znaku, paczka plików wektorowych i rastrowych, mockupy zastosowań.</div>
+          </div>
+          <div class="kwcs-summary-cell">
+            <div class="label">Wynik</div>
+            <div class="value">Spójna identyfikacja gotowa do natychmiastowego wdrożenia w kanałach digital i print.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================
+         KONTEKST PROJEKTU
+    ============================================================ -->
+    <div class="kwcs-sec kwcs-context-section" id="kwdesign-kontekst">
       <div class="wrap">
         <h2>Kontekst projektu</h2>
 
         <div class="context-intro">
           <p>
-            Projekt dotyczył stworzenia <strong>unikalnej identyfikacji wizualnej</strong> dla klienta z branży kreatywnej. Celem było zaprojektowanie znaku, który <strong>zapada w pamięć</strong>, będzie spójny z charakterem marki oraz łatwy do wdrożenia w różnych kanałach komunikacji.
+            KW Design to <strong>moja autorska marka projektanta produktów cyfrowych</strong>. Case study pokazuje, jak prowadziłem proces brandingu od strony klienta i projektanta jednocześnie: bez pośredników, na żywym własnym brandzie.
           </p>
           <p>
-            Kluczowe wyzwanie polegało na połączeniu <strong>minimalizmu</strong> z silnym charakterem wizualnym, tak aby logo dobrze działało zarówno w formie <strong>samodzielnego sygnetu</strong>, jak i pełnego logotypu w otoczeniu treści.
+            Wyzwaniem było połączenie <strong>minimalizmu</strong> ze znakiem, który <strong>działa w faviconie 16×16</strong> i jednocześnie czyta się czysto na materiałach prezentacyjnych. Sygnet musiał być rozpoznawalny solo, logotyp — pełnić rolę pełnej sygnatury w stopkach, ofertach i podpisach maili.
           </p>
         </div>
 
@@ -108,14 +140,58 @@
       </div>
     </div>
 
-    <!-- PROCES LOGO – używamy Twoich treści z „Proces w 3 etapach” -->
-    <div class="kwcs-sec kwcs-logo-section">
+    <!-- ============================================================
+         DECYZJE BRANDINGOWE
+    ============================================================ -->
+    <h2 class="section-divider" id="kwdesign-decyzje">Decyzje brandingowe</h2>
+
+    <div class="kwcs-sec">
+      <div class="wrap">
+        <div class="context-intro">
+          <p>
+            Zanim powstała pierwsza wersja znaku, ustaliłem cztery zasady, które kierowały całym procesem. Każda decyzja miała wymierną konsekwencję — w formie znaku, w paczce plików i w sposobie wdrożenia.
+          </p>
+        </div>
+
+        <div class="ux-decision-grid">
+          <div class="ux-decision-box">
+            <div class="ux-label">Decyzja 1 · Forma znaku</div>
+            <h4>Logotyp + sygnet jako dwie spójne wersje</h4>
+            <p><strong>Dlaczego:</strong> sam logotyp jest za szeroki na favicon i avatar w social media; sam sygnet — za mało rozpoznawalny w kontekście długich materiałów (oferta, prezentacja). Zaprojektowałem oba jako warianty jednego systemu — ze wspólną typografią i siatką.</p>
+            <p class="ux-context"><strong>Kontekst decyzji:</strong> w praktyce projektanta cyfrowego najczęstszy kontakt z marką ma postać avatara — favicon, profil LinkedIn, podpis maila. Sygnet musi działać samodzielnie, bez logotypu obok.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">Decyzja 2 · Paleta</div>
+            <h4>Monochromatyczna baza + niebieskie akcenty jako drugi poziom</h4>
+            <p><strong>Dlaczego:</strong> projektant cyfrowy pracuje na bardzo różnych tłach (ciemny tryb IDE, jasna prezentacja klienta, druk). Baza w czerni i bieli gwarantuje czytelność wszędzie. Niebieskie akcenty pełnią rolę sygnałową — używane oszczędnie, tam, gdzie mają wzmacniać CTA lub kluczowy element.</p>
+            <p class="ux-context"><strong>Kontekst decyzji:</strong> drugi poziom palety (niebieskie akcenty) jest opisany w księdze znaku jako element do wdrożenia w kolejnym etapie. Case study dokumentuje docelowy system, a nie tylko stan na dzień zakończenia projektu logo.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">Decyzja 3 · Typografia</div>
+            <h4>Jeden krój nośny, hierarchia przez wagi i interlinię</h4>
+            <p><strong>Dlaczego:</strong> system z 2–3 krojami komplikuje wdrożenie (licencje, fallbacki webowe, sprawdzanie kerningu w każdym nowym materiale). Wybrałem jeden krój i zbudowałem hierarchię na wagach i interlinii — mniejsza powierzchnia decyzyjna dla każdego nowego artefaktu marki.</p>
+            <p class="ux-context"><strong>Kontekst decyzji:</strong> docelowy krój i hierarchia są opisane w księdze znaku jako sztywne zasady, nie sugestie — ma to ograniczyć rozjazd stylu między materiałami tworzonymi w różnym czasie.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">Decyzja 4 · Format dostawy</div>
+            <h4>Paczka plików gotowa do wdrożenia bez pytania o szczegóły</h4>
+            <p><strong>Dlaczego:</strong> w wielu projektach klient dostaje samo logo w PNG i utyka przy pierwszym materiale wymagającym wektora. Zaprojektowałem komplet: AI/EPS/SVG na wektor, PNG w kilku rozmiarach z przezroczystością na raster, plus księga znaku jako PDF — żeby każdy nowy materiał można było wykonać bez kontaktu z projektantem.</p>
+            <p class="ux-context"><strong>Kontekst decyzji:</strong> ten sam format dostawy zamierzam stosować dla każdego kolejnego brandingu klienckiego. KW Design był testem polowym tego standardu na własnej marce.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================
+         PROCES POWSTAWANIA LOGO
+    ============================================================ -->
+    <div class="kwcs-sec kwcs-logo-section" id="kwdesign-proces">
       <div class="wrap">
         <h2>Proces powstawania logo</h2>
 
         <div class="logo-intro">
           <p>
-            Proces został podzielony na <strong>3 etapy</strong> — od analizy i koncepcji, przez iteracje projektowe, aż po przekazanie kompletnej paczki plików i księgi znaku. Każdy etap był konsultowany z klientem, co pozwoliło precyzyjnie dopasować znak do wizji marki.
+            Proces został podzielony na <strong>3 etapy</strong> — od analizy i koncepcji, przez iteracje projektowe, aż po przekazanie kompletnej paczki plików i księgi znaku. Każdy etap był konsultowany (w przypadku własnej marki — z samym sobą, ale w roli klienta), co pozwoliło precyzyjnie dopasować znak do wizji marki.
           </p>
         </div>
 
@@ -136,11 +212,11 @@
               id="content-marka-d-1"
               role="region"
               aria-labelledby="header-marka-d-1">
-              <p><strong>Research i strategia:</strong> Zrozumienie branży kreatywnej, wartości klienta i grupy docelowej. Analiza konkurencji, identyfikacja luk rynkowych oraz trendów w logo design.</p>
+              <p><strong>Research i strategia:</strong> Zrozumienie branży kreatywnej, wartości marki KW Design i grupy docelowej (klienci szukający projektanta cyfrowego). Analiza konkurencji, identyfikacja luk i konwencji w logo design dla freelancerów i małych studiów.</p>
               <ul>
-                <li>Wywiad z klientem – poznanie wizji, wartości marki, oczekiwań wobec znaku.</li>
-                <li>Moodboardy i inspiracje – referencje typograficzne, kolorystyczne i stylistyczne.</li>
-                <li>Wstępne szkice – 5–7 kierunków projektowych (od minimalistycznego po odważniejszy).</li>
+                <li>Definicja wartości marki — czego nie pokazuje sam portfolio.</li>
+                <li>Moodboardy i inspiracje — referencje typograficzne, kolorystyczne i stylistyczne.</li>
+                <li>Wstępne szkice — 5–7 kierunków projektowych (od minimalistycznego po odważniejszy).</li>
               </ul>
             </div>
           </div>
@@ -161,12 +237,12 @@
               id="content-marka-d-2"
               role="region"
               aria-labelledby="header-marka-d-2">
-              <p><strong>Finalizacja koncepcji:</strong> Po wyborze kierunku przez klienta powstała precyzyjna wersja wektorowa w Adobe Illustrator, testowana w różnych rozmiarach i kontekstach.</p>
+              <p><strong>Finalizacja koncepcji:</strong> Po wyborze kierunku powstała precyzyjna wersja wektorowa w Adobe Illustrator, testowana w różnych rozmiarach i kontekstach.</p>
               <ul>
-                <li>Praca nad detalami typografii – kerning, spacing, balans optyczny.</li>
-                <li>Paleta kolorów – wersja kolorowa, monochromatyczna i odwrócona.</li>
-                <li>Testowanie skalowania – od faviconu po duże formaty outdoor.</li>
-                <li>Mockupy – wizytówki, papier firmowy, social media, strona WWW.</li>
+                <li>Praca nad detalami typografii — kerning, spacing, balans optyczny.</li>
+                <li>Paleta kolorów — wersja kolorowa, monochromatyczna i odwrócona.</li>
+                <li>Testowanie skalowania — od faviconu po duże formaty outdoor.</li>
+                <li>Mockupy — wizytówki, papier firmowy, social media, strona WWW.</li>
               </ul>
             </div>
           </div>
@@ -198,27 +274,53 @@
           </div>
         </div>
 
-        <!-- Galeria iteracji jak w Twoim oryginale -->
-        <h2>Ewolucja projektu</h2>
-        <p>
-          Logo przeszło przez <strong>kilka iteracji</strong>, aby osiągnąć balans między charakterem a uniwersalnością. Każdy etap był konsultowany z klientem, co pozwoliło precyzyjnie dopasować znak do wizji marki.
-        </p>
+      </div>
+    </div>
+
+    <!-- ============================================================
+         EWOLUCJA PROJEKTU
+    ============================================================ -->
+    <h2 class="section-divider" id="kwdesign-ewolucja">Ewolucja projektu</h2>
+
+    <div class="kwcs-sec">
+      <div class="wrap">
+        <div class="context-intro">
+          <p>
+            Logo przeszło przez <strong>kilka iteracji</strong>, aby osiągnąć balans między charakterem a uniwersalnością. Każdy etap był testowany w docelowych kontekstach — favicon, social media avatar, stopka maila, duży format prezentacyjny.
+          </p>
+        </div>
 
         <div class="kwcs-gallery-grid">
           <div class="gallery-item">
-            <img src="/KWdesignnew/assets/images/marka-d-v1.png" alt="Iteracja 1 - szkice koncepcyjne" loading="lazy">
+            <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-v1.png">
+              <span class="asset-missing-icon" aria-hidden="true">📁</span>
+              <span class="asset-missing-label">Brakujący asset</span>
+              <code class="asset-missing-filename">marka-d-v1.png</code>
+            </div>
             <p class="img-desc">Wstępne szkice i kierunki</p>
           </div>
           <div class="gallery-item">
-            <img src="/KWdesignnew/assets/images/marka-d-v2.png" alt="Iteracja 2 - dopracowanie typografii" loading="lazy">
+            <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-v2.png">
+              <span class="asset-missing-icon" aria-hidden="true">📁</span>
+              <span class="asset-missing-label">Brakujący asset</span>
+              <code class="asset-missing-filename">marka-d-v2.png</code>
+            </div>
             <p class="img-desc">Dopracowanie kerningu i balansu</p>
           </div>
           <div class="gallery-item">
-            <img src="/KWdesignnew/assets/images/marka-d-v3.png" alt="Iteracja 3 - wersje kolorystyczne" loading="lazy">
+            <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-v3.png">
+              <span class="asset-missing-icon" aria-hidden="true">📁</span>
+              <span class="asset-missing-label">Brakujący asset</span>
+              <code class="asset-missing-filename">marka-d-v3.png</code>
+            </div>
             <p class="img-desc">Testy palety kolorów</p>
           </div>
           <div class="gallery-item">
-            <img src="/KWdesignnew/assets/images/marka-d-final.png" alt="Finalna wersja logo" loading="lazy">
+            <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-final.png">
+              <span class="asset-missing-icon" aria-hidden="true">📁</span>
+              <span class="asset-missing-label">Brakujący asset</span>
+              <code class="asset-missing-filename">marka-d-final.png</code>
+            </div>
             <p class="img-desc">Wersja finalna – ready to use</p>
           </div>
         </div>
@@ -227,7 +329,7 @@
           Finalny znak ma <strong>wysoką czytelność</strong> w małych rozmiarach oraz <strong>wyrazisty charakter wizualny</strong>, który wyróżnia markę w branży kreatywnej.
         </p>
 
-        <!-- KSIĘGA ZNAKU / ZASTOSOWANIA w strukturze „mockups” jak w Karoma -->
+        <!-- KSIĘGA ZNAKU / ZASTOSOWANIA -->
         <div class="kwcs-mockups-section">
           <h3>Księga znaku i zastosowania</h3>
           <p>
@@ -236,39 +338,171 @@
 
           <div class="kwcs-gallery-grid">
             <div class="gallery-item">
-              <img src="/KWdesignnew/assets/images/marka-d-brand-guide.png" alt="Księga znaku - paleta i typografia" loading="lazy">
+              <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-brand-guide.png">
+                <span class="asset-missing-icon" aria-hidden="true">📁</span>
+                <span class="asset-missing-label">Brakujący asset</span>
+                <code class="asset-missing-filename">marka-d-brand-guide.png</code>
+              </div>
               <p class="img-desc">Księga znaku: paleta i typografia</p>
             </div>
             <div class="gallery-item">
-              <img src="/KWdesignnew/assets/images/marka-d-safe-zone.png" alt="Safe zone i minimalne rozmiary" loading="lazy">
+              <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-safe-zone.png">
+                <span class="asset-missing-icon" aria-hidden="true">📁</span>
+                <span class="asset-missing-label">Brakujący asset</span>
+                <code class="asset-missing-filename">marka-d-safe-zone.png</code>
+              </div>
               <p class="img-desc">Safe zone i skalowanie</p>
             </div>
             <div class="gallery-item">
-              <img src="/KWdesignnew/assets/images/marka-d-business-card.png" alt="Mockup wizytówek" loading="lazy">
+              <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-business-card.png">
+                <span class="asset-missing-icon" aria-hidden="true">📁</span>
+                <span class="asset-missing-label">Brakujący asset</span>
+                <code class="asset-missing-filename">marka-d-business-card.png</code>
+              </div>
               <p class="img-desc">Wizytówki</p>
             </div>
             <div class="gallery-item">
-              <img src="/KWdesignnew/assets/images/marka-d-social.png" alt="Mockup social media" loading="lazy">
+              <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-social.png">
+                <span class="asset-missing-icon" aria-hidden="true">📁</span>
+                <span class="asset-missing-label">Brakujący asset</span>
+                <code class="asset-missing-filename">marka-d-social.png</code>
+              </div>
               <p class="img-desc">Szablony social media</p>
             </div>
             <div class="gallery-item">
-              <img src="/KWdesignnew/assets/images/marka-d-stationery.png" alt="Mockup papeterii firmowej" loading="lazy">
+              <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-stationery.png">
+                <span class="asset-missing-icon" aria-hidden="true">📁</span>
+                <span class="asset-missing-label">Brakujący asset</span>
+                <code class="asset-missing-filename">marka-d-stationery.png</code>
+              </div>
               <p class="img-desc">Papeteria firmowa</p>
             </div>
             <div class="gallery-item">
-              <img src="/KWdesignnew/assets/images/marka-d-web.png" alt="Logo na stronie internetowej" loading="lazy">
+              <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-web.png">
+                <span class="asset-missing-icon" aria-hidden="true">📁</span>
+                <span class="asset-missing-label">Brakujący asset</span>
+                <code class="asset-missing-filename">marka-d-web.png</code>
+              </div>
               <p class="img-desc">Implementacja na stronie WWW</p>
             </div>
           </div>
         </div>
+      </div>
+    </div>
 
-        <!-- REZULTAT w stylu kart jak w Karoma -->
-        <div class="kwcs-result" id="dostarczone">
-          <h2>Rezultat</h2>
+    <!-- ============================================================
+         MOJA ROLA W PROJEKCIE
+    ============================================================ -->
+    <h2 class="section-divider" id="kwdesign-contribution">Moja rola w projekcie</h2>
+
+    <div class="kwcs-sec">
+      <div class="wrap">
+        <div class="context-intro">
+          <p>
+            KW Design to projekt mojej własnej marki — rola klienta i projektanta są połączone w jednej osobie. Projekt zrealizowałem w całości <strong>solo</strong>, bez zewnętrznych współpracowników i bez zewnętrznych zasobów.
+          </p>
+        </div>
+
+        <div class="contribution-grid">
+          <div class="contribution-cell contribution-cell--solo">
+            <h4><span class="dot"></span>Solo — ja</h4>
+            <ul>
+              <li>Strategia marki i analiza branży kreatywnej</li>
+              <li>Koncepcje znaku i iteracje wektorowe</li>
+              <li>Dobór typografii i palety</li>
+              <li>Testowanie znaku w docelowych kontekstach</li>
+              <li>Mockupy zastosowań (wizytówki, social, papeteria, WWW)</li>
+              <li>Księga znaku (PDF)</li>
+              <li>Paczka plików dostawcza (AI / EPS / SVG / PNG)</li>
+              <li>Wdrożenie na stronę portfolio</li>
+            </ul>
+          </div>
+          <div class="contribution-cell contribution-cell--shared">
+            <h4><span class="dot"></span>Wspólnie z klientem</h4>
+            <ul>
+              <li>Nie dotyczy — klient i projektant to ta sama osoba.</li>
+            </ul>
+          </div>
+          <div class="contribution-cell contribution-cell--external">
+            <h4><span class="dot"></span>Zasoby klienta</h4>
+            <ul>
+              <li>Brak zasobów zewnętrznych — projekt w pełni in-house.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================
+         POTENCJAŁ POZA PROJEKTEM (reuse)
+    ============================================================ -->
+    <h2 class="section-divider" id="kwdesign-potencjal">Potencjał poza projektem</h2>
+
+    <div class="kwcs-sec">
+      <div class="wrap">
+        <div class="context-intro">
+          <p>
+            KW Design to identyfikacja jednej, konkretnej marki — ale <strong>proces</strong> i <strong>format dostawy</strong> są uniwersalne. Większość warstw projektu da się zastosować do każdego brandingu klienckiego po podmianie pola wartości marki i wstępnych założeń estetycznych.
+          </p>
+        </div>
+
+        <h3 style="text-align:center">Co jest specyficzne dla KW Design</h3>
+        <ul style="max-width:760px;margin:0 auto 2rem;color:#475569;line-height:1.7;">
+          <li>Sygnet zbudowany wokół inicjałów <strong>K</strong> i <strong>W</strong></li>
+          <li>Niebieski akcent powiązany z dyscypliną digital design</li>
+          <li>Monochromatyczna baza wynikająca z wielokontekstowego użycia w portfolio i materiałach prezentacyjnych projektanta</li>
+        </ul>
+
+        <h3 style="text-align:center">Co jest uniwersalne i gotowe do reuse</h3>
+        <div class="kwcs-trio">
+          <article class="kwcs-card">
+            <h3>Proces</h3>
+            <ul>
+              <li>Analiza marki i wywiad z klientem (lub własną wizją)</li>
+              <li>Moodboard + 5–7 kierunków wstępnych</li>
+              <li>3–4 cykle iteracji wektorowych</li>
+              <li>Testowanie w docelowych kontekstach (favicon, social, druk)</li>
+              <li>Księga znaku jako PDF z zasadami użycia</li>
+            </ul>
+          </article>
+          <article class="kwcs-card">
+            <h3>Format dostawy</h3>
+            <ul>
+              <li>AI / EPS / SVG — wektory do druku i webu</li>
+              <li>PNG w 3 rozmiarach z przezroczystością</li>
+              <li>Księga znaku PDF: safe zone, minimalne rozmiary, paleta, przykłady złego użycia</li>
+              <li>Wsparcie 30 dni przy wdrożeniu</li>
+            </ul>
+          </article>
+          <article class="kwcs-card">
+            <h3>Branże, w których ma sens</h3>
+            <ul>
+              <li>Marki osobiste freelancerów (designerzy, konsultanci, copywriterzy)</li>
+              <li>Małe studia kreatywne potrzebujące jasnej księgi znaku</li>
+              <li>B2B SaaS we wczesnej fazie — gdy księga znaku wzmacnia wiarygodność u inwestorów</li>
+              <li>Marki lokalne (kawiarnie, gabinety, butiki) szukające jednego źródła identyfikacji</li>
+            </ul>
+          </article>
+        </div>
+
+        <p style="max-width:760px;margin:2rem auto 0;color:#475569;font-style:italic;text-align:center;">
+          Wzorzec procesu i paczki dostawczej nie jest hipotezą — wynika z tego, że na własnej marce sprawdziłem każdy krok, zanim zacznę proponować ten standard klientom.
+        </p>
+      </div>
+    </div>
+
+    <!-- ============================================================
+         REZULTAT
+    ============================================================ -->
+    <h2 class="section-divider" id="kwdesign-rezultat">Rezultat</h2>
+
+    <div class="kwcs-sec">
+      <div class="wrap">
+        <div class="kwcs-result">
 
           <div class="result-lead">
             <p>
-              🚀 Klient otrzymał <strong>unikalne, profesjonalne logo</strong> z kompletną księgą znaku, gotowe do zastosowania na wszystkich nośnikach – od druku po digital. Marka wyróżnia się dzięki <strong>nowoczesnej typografii</strong> i <strong>spójnej identyfikacji wizualnej</strong>.
+              🚀 Marka KW Design ma <strong>unikalne, profesjonalne logo</strong> z kompletną księgą znaku, gotowe do zastosowania na wszystkich nośnikach – od druku po digital. Identyfikacja jest spójna dzięki <strong>nowoczesnej typografii</strong> i konsekwentnemu zastosowaniu palety i siatki.
             </p>
           </div>
 
@@ -285,8 +519,8 @@
             </div>
             <div class="result-card">
               <div class="result-icon">🤝</div>
-              <h3>Wsparcie po projekcie</h3>
-              <p>30 dni wsparcia przy implementacji i adaptacji identyfikacji.</p>
+              <h3>Standard do reuse</h3>
+              <p>Proces i paczka plików przetestowane na własnej marce — gotowe do zastosowania u klientów.</p>
             </div>
           </div>
 
@@ -300,11 +534,10 @@
           <div class="result-next">
             <h3>Co dalej?</h3>
             <p>
-              Kolejny krok to <strong>strona docelowa</strong> lub mini brand system: szablony prezentacji, ofert i materiałów social media, aby jeszcze mocniej wykorzystać potencjał nowego logo.
+              Kolejny krok to <strong>mini brand system</strong>: szablony prezentacji, ofert i materiałów social media, oraz wdrożenie drugiego poziomu palety (niebieskie akcenty) w komunikacji marki — żeby jeszcze mocniej wykorzystać potencjał nowego logo.
             </p>
           </div>
         </div>
-
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

Pierwszy etap standaryzacji case study **KW-Design** — tylko **Faza 1 (struktura i hierarchia treści)**, zgodnie z planem czterofazowym (struktura → treść → UX/nav → polish/a11y).

Faza 2 (copy polish), Faza 3 (chapter rail + lightbox + data-caption + JS handler) i Faza 4 (polish/a11y) — w kolejnych iteracjach. Nie tknięto innych case studies.

### Co zostało zmienione strukturalnie

- **id na każdej głównej sekcji**: `kwdesign-summary`, `-kontekst`, `-decyzje`, `-proces`, `-ewolucja`, `-contribution`, `-potencjal`, `-rezultat` — przygotowane pod chapter rail w Fazie 3.
- **`section-divider`** class na h2 podsekcjach (Decyzje, Ewolucja, Contribution, Potencjał, Rezultat) — wzorzec z RAZDWA.
- **Executive summary po hero** (Problem / Moja rola / Co dostarczyłem / Wynik) jako **`.kwcs-summary`** — nowa, uniwersalna klasa do reuse w kolejnych projektach (dodana do `projects.css` jako paralela do `.razdwa-summary`).
- **Sekcja Decyzje brandingowe** z 4 decyzjami (Forma znaku / Paleta / Typografia / Format dostawy) — każda z "Dlaczego" i "Kontekst decyzji". Treść oparta na inputu autora.
- **Contribution grid** Solo / Wspólnie / Zasoby — projekt w 100% solo (własna marka).
- **Sekcja Potencjał poza projektem** — co specyficzne dla KW Design vs co uniwersalne i gotowe do reuse u klientów.

### Brakujące assety

10 obrazów `marka-d-*.png` referowanych w HTML **nie istnieje** w `assets/images/`. Zgodnie z decyzją autora **nie używamy `placeholder.jpg`** — każdy brakujący obraz zastąpiony jest blokiem `.asset-missing` z **widoczną nazwą pliku**:

```
📁 Brakujący asset
[marka-d-v1.png]
```

Stylowane na żółto z dashed-borderem (`.asset-missing` w `projects.css`) — widać z poziomu przeglądarki dokładnie czego brakuje. System UI **pominięty** w tej iteracji (zależy od `marka-d-brand-guide.png`).

### Pliki

| Plik | Zmiana |
|---|---|
| `projects/KW-Design.html` | Restrukturyzacja z 311 → 544 linii (dodane sekcje + asset-missing bloki) |
| `assets/css/projects.css` | +119 linii: `.asset-missing*`, `.kwcs-summary*`, `.ux-context` |

## Test plan

- [ ] Otwórz `portfolio.html`, kliknij kartę "KW Design"
- [ ] Hero, summary, kontekst, decyzje, proces, ewolucja, moja rola, potencjał, rezultat — wszystkie w prawidłowej kolejności
- [ ] 10 bloków `.asset-missing` widocznych jako żółte placeholders z nazwami plików (nie szare obrazki)
- [ ] Wszystkie nowe sekcje mają `id` (DevTools: każda h2 z `section-divider` ma `id="kwdesign-*"`)
- [ ] Brak regresji w RAZDWA (klasa `.razdwa-summary` działa równolegle z nową `.kwcs-summary`)
- [ ] Brak jeszcze chapter rail (Faza 3 — nie wdrażane)

https://claude.ai/code/session_01AFtYsPhvWLnoMFwGErnot7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFtYsPhvWLnoMFwGErnot7)_