### PR TITLE
KW-Design: chapter rail timeline + uniwersalna .kwcs-chapter-rail

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -2551,14 +2551,17 @@ body.lightbox-open {
 }
 
 /* ========================================
-   RAZDWA — Chapter rail jako pełnej długości timeline
+   CHAPTER RAIL — uniwersalny sticky timeline dla case studies
+   - Klasa .kwcs-chapter-rail (uniwersalna) + .razdwa-chapter-rail
+     (alias zachowany dla istniejącego RAZDWA case study)
    - Fixed, top:0 / bottom:0 → linia biegnie przez cały viewport
    - Kropki rozłożone równomiernie wzdłuż linii (justify-content: space-between)
    - Desktop >= 1280px: pełne etykiety rozdziałów obok kropek
    - Poniżej 1280px: slim timeline z samymi kropkami przy lewej krawędzi
    - Zawsze widoczny przy scrollu — to persistent navigation case study
    ======================================== */
-.razdwa-chapter-rail {
+.razdwa-chapter-rail,
+.kwcs-chapter-rail {
   position: fixed;
   left: 0.5rem;
   top: 0;
@@ -2573,7 +2576,8 @@ body.lightbox-open {
   background: transparent;
 }
 
-.razdwa-chapter-rail-label {
+.razdwa-chapter-rail-label,
+.kwcs-chapter-rail-label {
   display: none;
   font-size: 0.7rem;
   text-transform: uppercase;
@@ -2585,7 +2589,8 @@ body.lightbox-open {
   pointer-events: auto;
 }
 
-.razdwa-chapter-rail-list {
+.razdwa-chapter-rail-list,
+.kwcs-chapter-rail-list {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -2600,7 +2605,8 @@ body.lightbox-open {
 }
 
 /* Pionowa linia timeline biegnąca przez całą wysokość */
-.razdwa-chapter-rail-list::before {
+.razdwa-chapter-rail-list::before,
+.kwcs-chapter-rail-list::before {
   content: '';
   position: absolute;
   left: 0.55rem;
@@ -2620,15 +2626,18 @@ body.lightbox-open {
   pointer-events: none;
 }
 
-.razdwa-chapter-rail-list li {
+.razdwa-chapter-rail-list li,
+.kwcs-chapter-rail-list li {
   position: relative;
   z-index: 1;
   margin: 0;
   display: flex;
 }
-.razdwa-chapter-rail-list li::before { content: none !important; }
+.razdwa-chapter-rail-list li::before,
+.kwcs-chapter-rail-list li::before { content: none !important; }
 
-.razdwa-chapter-link {
+.razdwa-chapter-link,
+.kwcs-chapter-link {
   display: inline-flex;
   align-items: center;
   gap: 0.6rem;
@@ -2650,7 +2659,8 @@ body.lightbox-open {
 }
 
 /* Kropka-marker na linii */
-.razdwa-chapter-link::before {
+.razdwa-chapter-link::before,
+.kwcs-chapter-link::before {
   content: '';
   flex-shrink: 0;
   display: block;
@@ -2663,21 +2673,26 @@ body.lightbox-open {
   transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.razdwa-chapter-link:hover { color: #0f172a; }
-.razdwa-chapter-link:hover::before {
+.razdwa-chapter-link:hover,
+.kwcs-chapter-link:hover { color: #0f172a; }
+.razdwa-chapter-link:hover::before,
+.kwcs-chapter-link:hover::before {
   border-color: #06b6d4;
   background: #ecfeff;
 }
-.razdwa-chapter-link:focus-visible {
+.razdwa-chapter-link:focus-visible,
+.kwcs-chapter-link:focus-visible {
   outline: 2px solid #06b6d4;
   outline-offset: 2px;
 }
 
-.razdwa-chapter-link.is-active {
+.razdwa-chapter-link.is-active,
+.kwcs-chapter-link.is-active {
   color: #0f172a;
   font-weight: 700;
 }
-.razdwa-chapter-link.is-active::before {
+.razdwa-chapter-link.is-active::before,
+.kwcs-chapter-link.is-active::before {
   background: #06b6d4;
   border-color: #06b6d4;
   transform: scale(1.25);
@@ -2686,22 +2701,27 @@ body.lightbox-open {
 
 /* Desktop: pełne etykiety obok kropek, więcej oddechu */
 @media (min-width: 1280px) {
-  .razdwa-chapter-rail {
+  .razdwa-chapter-rail,
+  .kwcs-chapter-rail {
     left: max(0.85rem, calc(50vw - 820px));
     max-width: 240px;
     width: 240px;
     padding: 5.5rem 0.5rem 4rem;
   }
-  .razdwa-chapter-rail-label { display: block; }
-  .razdwa-chapter-rail-list::before { left: 0.7rem; }
-  .razdwa-chapter-link {
+  .razdwa-chapter-rail-label,
+  .kwcs-chapter-rail-label { display: block; }
+  .razdwa-chapter-rail-list::before,
+  .kwcs-chapter-rail-list::before { left: 0.7rem; }
+  .razdwa-chapter-link,
+  .kwcs-chapter-link {
     font-size: 0.82rem;
     padding: 0.25rem 0.6rem 0.25rem 0.3rem;
     background: rgba(255, 255, 255, 0.6);
     backdrop-filter: blur(6px);
     -webkit-backdrop-filter: blur(6px);
   }
-  .razdwa-chapter-link.is-active {
+  .razdwa-chapter-link.is-active,
+  .kwcs-chapter-link.is-active {
     background: rgba(236, 254, 255, 0.95);
     border-color: #a5f3fc;
   }
@@ -2709,21 +2729,26 @@ body.lightbox-open {
 
 /* Bardzo małe ekrany — przyklejony do krawędzi */
 @media (max-width: 480px) {
-  .razdwa-chapter-rail {
+  .razdwa-chapter-rail,
+  .kwcs-chapter-rail {
     left: 0.3rem;
     padding: 4rem 0.25rem 3.5rem;
   }
 }
 
-/* Bardzo niskie viewporty — żeby 14 kropek się nie nachodziło, pozwól na scroll */
+/* Bardzo niskie viewporty — żeby kropki się nie nachodziły, pozwól na scroll */
 @media (max-height: 560px) {
-  .razdwa-chapter-rail { overflow-y: auto; }
-  .razdwa-chapter-rail-list { justify-content: flex-start; gap: 0.4rem; }
-  .razdwa-chapter-rail-list::before { bottom: auto; height: 100%; }
+  .razdwa-chapter-rail,
+  .kwcs-chapter-rail { overflow-y: auto; }
+  .razdwa-chapter-rail-list,
+  .kwcs-chapter-rail-list { justify-content: flex-start; gap: 0.4rem; }
+  .razdwa-chapter-rail-list::before,
+  .kwcs-chapter-rail-list::before { bottom: auto; height: 100%; }
 }
 
 /* Przy aktywnym lightboxie chowamy rail, żeby nie zasłaniał zdjęcia */
-body.lightbox-open .razdwa-chapter-rail { display: none; }
+body.lightbox-open .razdwa-chapter-rail,
+body.lightbox-open .kwcs-chapter-rail { display: none; }
 
 /* ========================================
    RAZDWA — Contribution grid

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -226,56 +226,60 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function initializeChapterRail() {
-    const rail = document.getElementById('razdwa-chapter-rail');
-    if (!rail) return;
-
-    const links = Array.from(rail.querySelectorAll('.razdwa-chapter-link'));
-    if (!links.length) return;
+    // Uniwersalny handler — obsługuje zarówno .razdwa-chapter-rail (legacy)
+    // jak i .kwcs-chapter-rail (nowy standard dla wszystkich case studies).
+    const rails = document.querySelectorAll('.kwcs-chapter-rail, .razdwa-chapter-rail');
+    if (!rails.length) return;
 
     const detailsContainer = document.getElementById('project-details-container');
 
-    const setActive = (activeLink) => {
-      links.forEach(l => {
-        const isActive = l === activeLink;
-        l.classList.toggle('is-active', isActive);
-        if (isActive) {
-          l.setAttribute('aria-current', 'true');
-        } else {
-          l.removeAttribute('aria-current');
-        }
-      });
-    };
+    rails.forEach(rail => {
+      const links = Array.from(rail.querySelectorAll('.kwcs-chapter-link, .razdwa-chapter-link'));
+      if (!links.length) return;
 
-    links.forEach(link => {
-      link.addEventListener('click', (e) => {
-        e.preventDefault();
-        const id = link.dataset.railTarget || link.getAttribute('href').replace('#', '');
-        const target = document.getElementById(id);
-        if (!target) return;
-        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        setActive(link);
-      });
-    });
-
-    const targets = links
-      .map(link => document.getElementById(link.dataset.railTarget || link.getAttribute('href').replace('#', '')))
-      .filter(Boolean);
-
-    if ('IntersectionObserver' in window && targets.length) {
-      const observer = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-          if (!entry.isIntersecting) return;
-          const id = entry.target.id;
-          const match = links.find(l => (l.dataset.railTarget || l.getAttribute('href').replace('#', '')) === id);
-          if (match) setActive(match);
+      const setActive = (activeLink) => {
+        links.forEach(l => {
+          const isActive = l === activeLink;
+          l.classList.toggle('is-active', isActive);
+          if (isActive) {
+            l.setAttribute('aria-current', 'true');
+          } else {
+            l.removeAttribute('aria-current');
+          }
         });
-      }, {
-        root: detailsContainer && detailsContainer.style.overflow === 'auto' ? detailsContainer : null,
-        rootMargin: '-25% 0px -65% 0px',
-        threshold: 0
+      };
+
+      links.forEach(link => {
+        link.addEventListener('click', (e) => {
+          e.preventDefault();
+          const id = link.dataset.railTarget || link.getAttribute('href').replace('#', '');
+          const target = document.getElementById(id);
+          if (!target) return;
+          target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          setActive(link);
+        });
       });
-      targets.forEach(t => observer.observe(t));
-    }
+
+      const targets = links
+        .map(link => document.getElementById(link.dataset.railTarget || link.getAttribute('href').replace('#', '')))
+        .filter(Boolean);
+
+      if ('IntersectionObserver' in window && targets.length) {
+        const observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if (!entry.isIntersecting) return;
+            const id = entry.target.id;
+            const match = links.find(l => (l.dataset.railTarget || l.getAttribute('href').replace('#', '')) === id);
+            if (match) setActive(match);
+          });
+        }, {
+          root: detailsContainer && detailsContainer.style.overflow === 'auto' ? detailsContainer : null,
+          rootMargin: '-25% 0px -65% 0px',
+          threshold: 0
+        });
+        targets.forEach(t => observer.observe(t));
+      }
+    });
   }
 
   window.closeProjectDetails = function() {

--- a/projects/KW-Design.html
+++ b/projects/KW-Design.html
@@ -69,6 +69,23 @@
     </div>
 
     <!-- ============================================================
+         Sticky chapter rail — persistent timeline navigation
+    ============================================================ -->
+    <nav class="kwcs-chapter-rail" id="kwdesign-chapter-rail" aria-label="Spis treści case study">
+      <div class="kwcs-chapter-rail-label">Rozdziały</div>
+      <ul class="kwcs-chapter-rail-list">
+        <li><a class="kwcs-chapter-link" href="#kwdesign-summary" data-rail-target="kwdesign-summary" title="W skrócie" aria-label="W skrócie">W skrócie</a></li>
+        <li><a class="kwcs-chapter-link" href="#kwdesign-kontekst" data-rail-target="kwdesign-kontekst" title="Kontekst" aria-label="Kontekst">Kontekst</a></li>
+        <li><a class="kwcs-chapter-link" href="#kwdesign-decyzje" data-rail-target="kwdesign-decyzje" title="Decyzje brandingowe" aria-label="Decyzje brandingowe">Decyzje brandingowe</a></li>
+        <li><a class="kwcs-chapter-link" href="#kwdesign-proces" data-rail-target="kwdesign-proces" title="Proces" aria-label="Proces">Proces</a></li>
+        <li><a class="kwcs-chapter-link" href="#kwdesign-ewolucja" data-rail-target="kwdesign-ewolucja" title="Ewolucja" aria-label="Ewolucja">Ewolucja</a></li>
+        <li><a class="kwcs-chapter-link" href="#kwdesign-contribution" data-rail-target="kwdesign-contribution" title="Moja rola" aria-label="Moja rola">Moja rola</a></li>
+        <li><a class="kwcs-chapter-link" href="#kwdesign-potencjal" data-rail-target="kwdesign-potencjal" title="Potencjał reuse" aria-label="Potencjał reuse">Potencjał reuse</a></li>
+        <li><a class="kwcs-chapter-link" href="#kwdesign-rezultat" data-rail-target="kwdesign-rezultat" title="Rezultat" aria-label="Rezultat">Rezultat</a></li>
+      </ul>
+    </nav>
+
+    <!-- ============================================================
          Executive summary po hero
     ============================================================ -->
     <div class="kwcs-summary" id="kwdesign-summary">


### PR DESCRIPTION
## Summary

Krok pośredni standaryzacji KW-Design **po merge'u Fazy 1**. Nie jest to ani Faza 2 (treść/copy), ani Faza 3 w pełni (zostaje lightbox-trigger + data-caption), ani Faza 4 — tylko **dokończenie struktury nawigacji**: chapter rail timeline na bazie uniwersalnej klasy `.kwcs-chapter-rail`.

### Zakres wdrożony

1. **Uniwersalna klasa `.kwcs-chapter-rail`** w `projects.css` jako alias do `.razdwa-chapter-rail` (group selectors w każdej regule). Jedna implementacja stylów, dwie nazwy klas — RAZDWA dalej działa, KW-Design (i kolejne case studies) używają nowej, neutralnej nazwy.
2. **JS handler `initializeChapterRail()`** uogólniony — iteruje po wszystkich elementach pasujących do `.kwcs-chapter-rail, .razdwa-chapter-rail`. Każdy rail ma własny `IntersectionObserver` i `aria-current`.
3. **`<nav class="kwcs-chapter-rail" id="kwdesign-chapter-rail">`** dodany do KW-Design.html z 8 linkami do anchorów ustawionych w Fazie 1:
   - W skrócie / Kontekst / Decyzje brandingowe / Proces / Ewolucja / Moja rola / Potencjał reuse / Rezultat
4. **A11y**: `title` + `aria-label` na każdym linku (czytelne w slim-mode poniżej 1280px); `aria-label` na `<nav>`.

### Czego NIE ruszono (zgodnie z constraint)

- **System UI** — wymaga brakującego `marka-d-brand-guide.png`, pominięty zgodnie z wcześniejszą decyzją.
- **Treść / copy** (Faza 2) — bez zmian.
- **Lightbox-trigger + data-caption na galeriach** (Faza 3) — bez zmian; bloki `.asset-missing` zostają.
- **Polish / a11y** (Faza 4) — bez zmian.

### Pliki

| Plik | Zmiana |
|---|---|
| `assets/css/projects.css` | +75 / −0: aliasy `.kwcs-chapter-*` w group selectors |
| `assets/js/portfolio.js` | refactor: handler iteruje wiele railów (z aria-current i IO bez zmian) |
| `projects/KW-Design.html` | +17: `<nav class="kwcs-chapter-rail">` po hero-body |

## Test plan

- [ ] Otwórz `portfolio.html`, kliknij kartę "KW Design"
- [ ] Desktop ≥1280px: timeline z 8 kropkami i etykietami widoczny od góry do dołu po lewej stronie
- [ ] Tablet/mobile <1280px: slim timeline z samymi kropkami przy lewej krawędzi
- [ ] Klik w rozdział scrolluje do właściwej sekcji (8 anchorów: summary→rezultat)
- [ ] Aktywna kropka aktualizuje się podczas scrolla (IntersectionObserver)
- [ ] `aria-current="true"` na aktywnym linku (DevTools)
- [ ] RAZDWA dalej działa bez regresji (`.razdwa-chapter-rail` w aliasach)

https://claude.ai/code/session_01AFtYsPhvWLnoMFwGErnot7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFtYsPhvWLnoMFwGErnot7)_