### PR TITLE
RAZDWA: chapter rail jako lewa sticky kolumna (fixed) na desktopie

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -2551,35 +2551,46 @@ body.lightbox-open {
 }
 
 /* ========================================
-   RAZDWA — Chapter rail (sticky TOC)
+   RAZDWA — Chapter rail (fixed sidebar / top bar)
+
+   UWAGA: rail jest przenoszony JS-em do <body>,
+   bo .project-details-container ma transform i
+   tworzy containing block dla position: fixed.
    ======================================== */
 .razdwa-chapter-rail {
-  position: sticky;
-  top: 16px;
-  z-index: 10;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  position: fixed;
+  left: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 50;
+  background: rgba(255, 255, 255, 0.96);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   border: 1px solid #e2e8f0;
-  border-radius: 0.75rem;
-  padding: 0.6rem 0.85rem;
-  margin: 1.25rem auto 2rem;
-  max-width: 1100px;
-  box-shadow: 0 8px 24px -12px rgba(15, 23, 42, 0.12);
+  border-radius: 0.85rem;
+  padding: 0.7rem 0.6rem;
+  margin: 0;
+  width: 220px;
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  box-shadow: 0 18px 48px -16px rgba(15, 23, 42, 0.22);
 }
 .razdwa-chapter-rail-label {
-  font-size: 0.7rem;
+  font-size: 0.65rem;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.12em;
   color: #06b6d4;
   font-weight: 700;
-  padding: 0.1rem 0.25rem;
-  margin-bottom: 0.4rem;
+  padding: 0.15rem 0.45rem 0.5rem;
+  margin: 0 0 0.4rem;
+  border-bottom: 1px solid #f1f5f9;
 }
 .razdwa-chapter-rail-list {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  gap: 0.15rem;
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2587,36 +2598,67 @@ body.lightbox-open {
 .razdwa-chapter-rail-list li { margin: 0; }
 .razdwa-chapter-rail-list li::before { content: none !important; }
 .razdwa-chapter-link {
-  display: inline-block;
-  background: #f1f5f9;
-  border: 1px solid #e2e8f0;
-  color: #0f172a;
+  display: block;
+  background: transparent;
+  border: 1px solid transparent;
+  color: #475569;
   font-size: 0.8rem;
   font-weight: 500;
-  padding: 0.3rem 0.7rem;
-  border-radius: 9999px;
+  line-height: 1.35;
+  padding: 0.4rem 0.65rem;
+  border-radius: 0.5rem;
   text-decoration: none;
   cursor: pointer;
-  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+  text-align: left;
+  white-space: normal;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
 .razdwa-chapter-link:hover {
-  background: #06b6d4;
-  border-color: #06b6d4;
-  color: #fff;
+  background: #f1f5f9;
+  color: #0f172a;
 }
 .razdwa-chapter-link.is-active {
   background: #0284c7;
   border-color: #0284c7;
   color: #fff;
 }
-@media (max-width: 600px) {
+
+/* Tablet i mobile — fixed top bar z poziomym scrollem pigułek */
+@media (max-width: 1100px) {
   .razdwa-chapter-rail {
-    border-radius: 0.5rem;
-    padding: 0.5rem 0.6rem;
-    margin: 1rem 0.5rem 1.5rem;
+    left: 12px;
+    right: 12px;
+    top: 12px;
+    transform: none;
+    width: auto;
+    max-width: none;
+    max-height: none;
+    padding: 0.55rem 0.7rem;
+    border-radius: 0.7rem;
   }
-  .razdwa-chapter-rail-list { flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch; }
-  .razdwa-chapter-link { white-space: nowrap; }
+  .razdwa-chapter-rail-label { display: none; }
+  .razdwa-chapter-rail-list {
+    flex-direction: row;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    gap: 0.35rem;
+  }
+  .razdwa-chapter-link {
+    flex-shrink: 0;
+    white-space: nowrap;
+    background: #f1f5f9;
+    border: 1px solid #e2e8f0;
+    border-radius: 9999px;
+    padding: 0.3rem 0.7rem;
+    font-size: 0.78rem;
+    color: #0f172a;
+  }
+  .razdwa-chapter-link:hover {
+    background: #06b6d4;
+    border-color: #06b6d4;
+    color: #fff;
+  }
 }
 
 /* ========================================

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -225,19 +225,36 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  function removeChapterRail() {
+    document.querySelectorAll('#razdwa-chapter-rail').forEach(el => el.remove());
+    if (window.__razdwaRailObserver) {
+      window.__razdwaRailObserver.disconnect();
+      window.__razdwaRailObserver = null;
+    }
+  }
+
   function initializeChapterRail() {
+    // Sprzątanie po poprzednim projekcie / przeładowaniu
+    removeChapterRail();
+
     const rail = document.getElementById('razdwa-chapter-rail');
     if (!rail) return;
+
+    // .project-details-container ma transform → tworzy containing block
+    // dla position:fixed. Przenosimy rail do body, żeby pozostał przyklejony
+    // do viewportu podczas scrollowania całego case study.
+    document.body.appendChild(rail);
 
     const links = Array.from(rail.querySelectorAll('.razdwa-chapter-link'));
     if (!links.length) return;
 
-    const detailsContainer = document.getElementById('project-details-container');
+    const getTargetId = (link) =>
+      link.dataset.railTarget || (link.getAttribute('href') || '').replace('#', '');
 
     links.forEach(link => {
       link.addEventListener('click', (e) => {
         e.preventDefault();
-        const id = link.dataset.railTarget || link.getAttribute('href').replace('#', '');
+        const id = getTargetId(link);
         const target = document.getElementById(id);
         if (!target) return;
         target.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -247,7 +264,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     const targets = links
-      .map(link => document.getElementById(link.dataset.railTarget || link.getAttribute('href').replace('#', '')))
+      .map(link => document.getElementById(getTargetId(link)))
       .filter(Boolean);
 
     if ('IntersectionObserver' in window && targets.length) {
@@ -256,16 +273,15 @@ document.addEventListener('DOMContentLoaded', () => {
           if (!entry.isIntersecting) return;
           const id = entry.target.id;
           links.forEach(l => {
-            const targetId = l.dataset.railTarget || l.getAttribute('href').replace('#', '');
-            l.classList.toggle('is-active', targetId === id);
+            l.classList.toggle('is-active', getTargetId(l) === id);
           });
         });
       }, {
-        root: detailsContainer && detailsContainer.style.overflow === 'auto' ? detailsContainer : null,
         rootMargin: '-30% 0px -60% 0px',
         threshold: 0
       });
       targets.forEach(t => observer.observe(t));
+      window.__razdwaRailObserver = observer;
     }
   }
 
@@ -291,6 +307,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Usuń pływającą nawigację
     removeProjectNavigation();
+
+    // Usuń sticky chapter rail (przeniesiony do body w initializeChapterRail)
+    removeChapterRail();
 
     history.pushState('', document.title, window.location.pathname);
   };


### PR DESCRIPTION
- Rail przeniesiony JS-em do <body> w initializeChapterRail, bo .project-details-container ma transform i tworzy containing block dla position:fixed (fixed przykleiłby rail do kontenera).
- Desktop ≥1101px: pionowa kolumna fixed, left:16px, top:50%, width:220px, max-height calc(100vh - 32px) z overflow:auto.
- Tablet/mobile ≤1100px: fixed top bar (left/right:12px) z poziomym scrollem pigułek; bez kolizji z close button (sticky, top:80px) ani z floating prev/next nav (bottom na mobile).
- Smooth scroll i scroll spy (IntersectionObserver) zachowane.
- Sprzątanie rail w closeProjectDetails oraz przy przełączaniu projektów (init wywołuje removeChapterRail na starcie).