### PR TITLE
hotfix(portfolio.js): napraw SyntaxError blokujący otwieranie projektów

### DIFF
--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -261,6 +261,7 @@ document.addEventListener('DOMContentLoaded', () => {
         links.forEach(l => l.classList.remove('is-active'));
         link.classList.add('is-active');
       });
+    });
 
     const targets = links
       .map(link => document.getElementById(getTargetId(link)))
@@ -274,10 +275,6 @@ document.addEventListener('DOMContentLoaded', () => {
           links.forEach(l => {
             l.classList.toggle('is-active', getTargetId(l) === id);
           });
-        }, {
-          root: detailsContainer && detailsContainer.style.overflow === 'auto' ? detailsContainer : null,
-          rootMargin: '-25% 0px -65% 0px',
-          threshold: 0
         });
       }, {
         rootMargin: '-30% 0px -60% 0px',


### PR DESCRIPTION
## Hotfix — przywrócenie otwierania project details

### Problem
Po zmergowaniu PR #50 (KW-Design chapter rail) i PR #51 (RAZDWA chapter rail) automatyczny merge zostawił w `assets/js/portfolio.js` pozostałości obu wersji `initializeChapterRail()`. Plik nie parsował się jako JavaScript:

```
Uncaught SyntaxError: missing ) after argument list
    at portfolio.js:289
```

Skutek produkcyjny: cały handler `DOMContentLoaded` wywalał się przed bindowaniem listenerów na kartach portfolio, więc **żaden projekt nie dawał się otworzyć**.

### Root cause — trzy ślady w `initializeChapterRail()`
1. `links.forEach(link => { ... })` bez zamykającego `});` — bezpośrednia przyczyna SyntaxError.
2. Dwa scalone bloki `options` dla `IntersectionObserver` (stara wersja z `root: detailsContainer`, nowa z samym `rootMargin`).
3. Odwołanie do niezadeklarowanej zmiennej `detailsContainer` (zostało z wersji sprzed `f5567aa`).

### Fix — chirurgicznie minimalny
**+1 / -4 linie** w jednym pliku (`assets/js/portfolio.js`):

```diff
       });
+    });

     const targets = links
       .map(link => document.getElementById(getTargetId(link)))
@@ ...
           });
-        }, {
-          root: detailsContainer && detailsContainer.style.overflow === 'auto' ? detailsContainer : null,
-          rootMargin: '-25% 0px -65% 0px',
-          threshold: 0
         });
       }, {
         rootMargin: '-30% 0px -60% 0px',
```

### Co świadomie wycięte z zakresu
- Brak nowych feature changes.
- Brak zmian wizualnych ani UX.
- Brak ruszania KW-Design rail (`#kwdesign-chapter-rail` nadal nie jest inicjalizowany przez `initializeChapterRail` — to osobny temat, ale **nie** blokuje otwierania project details).
- Zero modyfikacji CSS i HTML.

### Weryfikacja
- `node --check assets/js/portfolio.js` → OK
- Espree (parser ESLint, ten sam co Babel/VSCode) → OK, `body nodes: 1`
- `new Function(code)` (V8 strict) → OK

### Test plan
- [ ] Otwórz `portfolio.html` → DevTools Console: brak `SyntaxError`.
- [ ] Klik karty **Raz Dwa Druk** → case study się ładuje, chapter rail się pojawia.
- [ ] Klik karty **Karoma / Power of Mind / CyfraDruk / KW-Design / Sir Roger / Savage** → wszystkie projekty się otwierają.
- [ ] `Escape` zamyka project details.
- [ ] Klawiatura `Enter / Space` na karcie też otwiera.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNi6jDQsDLXyrD4mEe2weo)_