### PR TITLE
RAZDWA: chapter rail jako prawdziwa lewa sticky sidebar (gold standard)

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -2551,11 +2551,21 @@ body.lightbox-open {
 }
 
 /* ========================================
-   RAZDWA — Chapter rail (fixed sidebar / top bar)
+   RAZDWA — Chapter rail (lewa sticky sidebar)
 
    UWAGA: rail jest przenoszony JS-em do <body>,
    bo .project-details-container ma transform i
    tworzy containing block dla position: fixed.
+
+   Założenia (gold standard):
+   - desktop: pełna lista 14 rozdziałów widoczna od razu,
+     pełne etykiety (bez timeline-kropki), bez scrollowania
+     wewnątrz railu w typowym viewport,
+   - klik dowolnego rozdziału, w tym środkowego, działa od razu
+     (scrollIntoView na targecie w body),
+   - rail nie nachodzi na content (sekcja RAZDWA dostaje
+     padding-left na ≥1280px) ani na floating prev/next nav po prawej,
+   - mobile (≤1100px) — fixed top bar z poziomym scrollem pigułek.
    ======================================== */
 .razdwa-chapter-rail {
   position: fixed;
@@ -2568,15 +2578,17 @@ body.lightbox-open {
   -webkit-backdrop-filter: blur(10px);
   border: 1px solid #e2e8f0;
   border-radius: 0.85rem;
-  padding: 0.7rem 0.6rem;
+  padding: 0.75rem 0.7rem;
   margin: 0;
   width: 220px;
   max-height: calc(100vh - 32px);
   overflow-y: auto;
   overscroll-behavior: contain;
   box-shadow: 0 18px 48px -16px rgba(15, 23, 42, 0.22);
+  pointer-events: auto;
 }
 .razdwa-chapter-rail-label {
+  display: block;
   font-size: 0.65rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
@@ -2586,21 +2598,20 @@ body.lightbox-open {
   margin: 0 0 0.4rem;
   border-bottom: 1px solid #f1f5f9;
 }
-
-.razdwa-chapter-rail-list,
-.kwcs-chapter-rail-list {
+.razdwa-chapter-rail-list {
   position: relative;
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
-  gap: 0.15rem;
+  gap: 0.1rem;
   list-style: none;
   padding: 0;
   margin: 0;
-  pointer-events: auto;
 }
 .razdwa-chapter-rail-list li { margin: 0; }
 .razdwa-chapter-rail-list li::before { content: none !important; }
+/* Reset timeline pseudo-elementu z poprzedniej iteracji */
+.razdwa-chapter-rail-list::before { content: none !important; }
 .razdwa-chapter-link {
   display: block;
   background: transparent;
@@ -2617,40 +2628,52 @@ body.lightbox-open {
   white-space: normal;
   transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
+/* Reset kropki-markera z poprzedniej iteracji timeline */
+.razdwa-chapter-link::before { content: none !important; }
 .razdwa-chapter-link:hover {
   background: #f1f5f9;
   color: #0f172a;
 }
-
-/* Desktop: pełne etykiety obok kropek, więcej oddechu */
-@media (min-width: 1280px) {
-  .razdwa-chapter-rail,
-  .kwcs-chapter-rail {
-    left: max(0.85rem, calc(50vw - 820px));
-    max-width: 240px;
-    width: 240px;
-    padding: 5.5rem 0.5rem 4rem;
-  }
-  .razdwa-chapter-rail-label,
-  .kwcs-chapter-rail-label { display: block; }
-  .razdwa-chapter-rail-list::before,
-  .kwcs-chapter-rail-list::before { left: 0.7rem; }
-  .razdwa-chapter-link,
-  .kwcs-chapter-link {
-    font-size: 0.82rem;
-    padding: 0.25rem 0.6rem 0.25rem 0.3rem;
-    background: rgba(255, 255, 255, 0.6);
-    backdrop-filter: blur(6px);
-    -webkit-backdrop-filter: blur(6px);
-  }
-  .razdwa-chapter-link.is-active,
-  .kwcs-chapter-link.is-active {
-    background: rgba(236, 254, 255, 0.95);
-    border-color: #a5f3fc;
-  }
+.razdwa-chapter-link:focus-visible {
+  outline: 2px solid #06b6d4;
+  outline-offset: 2px;
+}
+.razdwa-chapter-link.is-active {
+  background: #0284c7;
+  border-color: #0284c7;
+  color: #fff;
+  font-weight: 600;
 }
 
-/* Tablet i mobile — fixed top bar z poziomym scrollem pigułek */
+/* Desktop ≥1280px — szerszy rail, content RAZDWA odsunięty w prawo,
+   żeby rail nie nachodził na sekcje przy max-width 1200 wycentrowanych */
+@media (min-width: 1280px) {
+  .razdwa-chapter-rail {
+    width: 240px;
+    padding: 0.85rem 0.75rem;
+  }
+  .razdwa-chapter-link {
+    font-size: 0.82rem;
+    padding: 0.45rem 0.7rem;
+  }
+  /* Wypchnij content RAZDWA w prawo, żeby rail (16 + 240 + ~24 gap) nie nachodził */
+  #case-razdwa-pelne { padding-left: 280px; }
+}
+
+/* Laptop 1101-1279px — węższy rail, mniejszy margin contentu */
+@media (min-width: 1101px) and (max-width: 1279px) {
+  .razdwa-chapter-rail {
+    width: 196px;
+    padding: 0.65rem 0.6rem;
+  }
+  .razdwa-chapter-link {
+    font-size: 0.76rem;
+    padding: 0.35rem 0.55rem;
+  }
+  #case-razdwa-pelne { padding-left: 232px; }
+}
+
+/* Tablet i mobile ≤1100px — fixed top bar z poziomym scrollem pigułek */
 @media (max-width: 1100px) {
   .razdwa-chapter-rail {
     left: 12px;
@@ -2686,19 +2709,62 @@ body.lightbox-open {
     border-color: #06b6d4;
     color: #fff;
   }
+  /* Mobile top bar nie wymaga marginesu sekcji */
+  #case-razdwa-pelne { padding-left: 0; }
 }
 
-/* Bardzo niskie viewporty — żeby kropki się nie nachodziły, pozwól na scroll */
+/* Bardzo niskie wysokości viewportu — pełny pion + scroll wewnątrz railu */
+@media (min-width: 1101px) and (max-height: 720px) {
+  .razdwa-chapter-rail {
+    top: 12px;
+    bottom: 12px;
+    transform: none;
+    max-height: calc(100vh - 24px);
+  }
+}
+
+/* ========================================
+   KW-Design — chapter rail timeline (zachowane bez zmian z PR #50)
+   ======================================== */
+.kwcs-chapter-rail-list {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  gap: 0.15rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  pointer-events: auto;
+}
+@media (min-width: 1280px) {
+  .kwcs-chapter-rail {
+    left: max(0.85rem, calc(50vw - 820px));
+    max-width: 240px;
+    width: 240px;
+    padding: 5.5rem 0.5rem 4rem;
+  }
+  .kwcs-chapter-rail-label { display: block; }
+  .kwcs-chapter-rail-list::before { left: 0.7rem; }
+  .kwcs-chapter-link {
+    font-size: 0.82rem;
+    padding: 0.25rem 0.6rem 0.25rem 0.3rem;
+    background: rgba(255, 255, 255, 0.6);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+  }
+  .kwcs-chapter-link.is-active {
+    background: rgba(236, 254, 255, 0.95);
+    border-color: #a5f3fc;
+  }
+}
 @media (max-height: 560px) {
-  .razdwa-chapter-rail,
   .kwcs-chapter-rail { overflow-y: auto; }
-  .razdwa-chapter-rail-list,
   .kwcs-chapter-rail-list { justify-content: flex-start; gap: 0.4rem; }
-  .razdwa-chapter-rail-list::before,
   .kwcs-chapter-rail-list::before { bottom: auto; height: 100%; }
 }
 
-/* Przy aktywnym lightboxie chowamy rail, żeby nie zasłaniał zdjęcia */
+/* Lightbox aktywny — chowamy oba raile, żeby nie zasłaniały zdjęcia */
 body.lightbox-open .razdwa-chapter-rail,
 body.lightbox-open .kwcs-chapter-rail { display: none; }
 


### PR DESCRIPTION
## Cel
Powrót do prawdziwego sidebara dla RAZDWA chapter rail — pełna lista 14 rozdziałów po lewej, widoczna od razu, bez timeline-gimmicku.

> Bazuje na hotfix branch `claude/hotfix-portfolio-js-syntax` (PR #52), więc diff pokazuje **tylko zmiany CSS railu**. Po zmergowaniu hotfixu można rebase na `main`.

## Root cause poprzedniej wersji (commit `ff99811`)
1. `font-size: 0` na `.razdwa-chapter-link` w base — etykiety całkowicie ukryte poniżej 1280px; tekst pojawiał się dopiero w `@media (min-width: 1280px)`.
2. `justify-content: space-between` + `top:0/bottom:0` + `padding: 5.5rem 0.5rem 4rem` rozrzucało 14 kropek równomiernie na cały viewport — klik środkowego rozdziału = celowanie w pojedynczy 12px marker.
3. `pointer-events: none` na `.razdwa-chapter-rail` (zostawione po timeline) blokowało interakcję z całym kontenerem.
4. Współdzielony selektor `.razdwa-chapter-rail, .kwcs-chapter-rail { left: max(...); padding: 5.5rem ... }` utrudniał osobne strojenie RAZDWA i KW-Design.

## Rozwiązanie
**`assets/css/projects.css`** — przepisany blok rail (+99 / -33 linii):

- Reset `font-size: 0` i kropek (`::before` na linkach i liście).
- `position: fixed; left: 16; top: 50%; transform: translateY(-50%)` — prosty wertykalny sidebar.
- `width: 220–240px`, `max-height: calc(100vh - 32px)`, `overflow-y: auto` (fallback dla niskich monitorów ≤720px wys.).
- 14 rozdziałów × ~30px = ~420px — mieści się w 100vh w pełni, klik dowolnego rozdziału (także środkowego) działa od razu.
- `#case-razdwa-pelne { padding-left: 280px }` na ≥1280px (i `232px` na 1101–1279px) — content RAZDWA odsunięty w prawo, rail nie nachodzi na wycentrowane `.wrap`.
- Mobile ≤1100px **bez zmian** — fixed top bar z poziomym scrollem pigułek (zostawiłem konfigurację z poprzedniej iteracji, działała OK).
- `.kwcs-chapter-rail*` (KW-Design) **wydzielony do osobnego bloku** i nietknięty — KW-Design rail dalej działa jak wcześniej (osobny PR, gdy ktoś go będzie poprawiał).

## Co zachowane bez zmian
- `assets/js/portfolio.js` — `initializeChapterRail` z hotfixu (przenoszenie railu do `body`, `scrollIntoView`, IntersectionObserver scroll spy) zostaje identyczne.
- `projects/razdwa_aplikacja.html` — anchory, struktura sekcji, treść case study — wszystko bez ruchu.
- Wszystkie pozostałe case studies — nietknięte.

## Test plan
- [ ] Desktop ≥1280px: rail po lewej z pełną listą 14 rozdziałów, content odsunięty w prawo, brak nachodzenia.
- [ ] Klik na **dowolny** rozdział (np. „Panel admina", „Architektura") natychmiast smooth-scrolluje bez wcześniejszego scrollowania w railu.
- [ ] IntersectionObserver podświetla aktywny rozdział podczas scrollowania case study.
- [ ] Laptop 1101–1279px: węższy rail (196px), content z mniejszym `padding-left` (232px).
- [ ] Mobile ≤1100px: top bar z pigułkami, poziomy scroll.
- [ ] Floating prev/next nav po prawej nie koliduje z railem.
- [ ] Otwarcie lightboxa chowa rail (klasa `.lightbox-open` na body).
- [ ] URL hash nie zmienia się przy klikaniu (brak kolizji z `projectPages[hash]` routingiem).
- [ ] Inne case studies otwierają się normalnie, KW-Design rail bez regresji.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNi6jDQsDLXyrD4mEe2weo)_