### PR TITLE
fix(razdwa-rail): przywróć renderowanie chapter rail w case study RAZDWA

### DIFF
--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -226,7 +226,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function removeChapterRail() {
-    document.querySelectorAll('#razdwa-chapter-rail').forEach(el => el.remove());
+    // Usuwaj tylko rail przeniesiony do body w poprzednim cyklu —
+    // świeżo wstrzyknięty rail w #project-details-content zostaje
+    document.querySelectorAll('body > #razdwa-chapter-rail').forEach(el => el.remove());
     if (window.__razdwaRailObserver) {
       window.__razdwaRailObserver.disconnect();
       window.__razdwaRailObserver = null;

--- a/assets/js/projects.js
+++ b/assets/js/projects.js
@@ -235,14 +235,65 @@ function initWebsiteTabs() {
 // INITIALIZATION - MAIN FUNCTION
 // ========================================
 
+// ========================================
+// CHAPTER RAIL (standalone case study, np. razdwa_aplikacja.html)
+// W portfolio.html rail jest inicjalizowany przez portfolio.js
+// (z dodatkowym move-to-body, bo .project-details-container ma transform).
+// Tutaj minimalny wariant: bindowanie kliknięć + scroll-spy.
+// ========================================
+
+function initChapterRail() {
+  const rail = document.getElementById('razdwa-chapter-rail');
+  if (!rail) return;
+
+  const links = Array.from(rail.querySelectorAll('.razdwa-chapter-link'));
+  if (!links.length) return;
+
+  const getTargetId = (link) =>
+    link.dataset.railTarget || (link.getAttribute('href') || '').replace('#', '');
+
+  links.forEach(link => {
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      const id = getTargetId(link);
+      const target = document.getElementById(id);
+      if (!target) return;
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      links.forEach(l => l.classList.remove('is-active'));
+      link.classList.add('is-active');
+    });
+  });
+
+  const targets = links
+    .map(link => document.getElementById(getTargetId(link)))
+    .filter(Boolean);
+
+  if ('IntersectionObserver' in window && targets.length) {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (!entry.isIntersecting) return;
+        const id = entry.target.id;
+        links.forEach(l => {
+          l.classList.toggle('is-active', getTargetId(l) === id);
+        });
+      });
+    }, {
+      rootMargin: '-30% 0px -60% 0px',
+      threshold: 0
+    });
+    targets.forEach(t => observer.observe(t));
+  }
+}
+
 function initAllFeatures() {
   console.log('🚀 Initializing KWCS interactive features...');
-  
+
   initAccordion();
   initLightbox();
   initWebsiteTabs();
   initCarousel(); // nowa funkcja dodana tutaj
-  
+  initChapterRail();
+
   console.log('✅ All features initialized successfully');
 }
 


### PR DESCRIPTION
## Problem
Chapter rail w `projects/razdwa_aplikacja.html` **w ogóle się nie pojawiał** po merge PR #51 / #52. Diagnostyka 5-stopniowa wskazała na realny bug w `portfolio.js`.

## Root cause
`assets/js/portfolio.js:229` — `removeChapterRail()` używał globalnego selektora `#razdwa-chapter-rail`, który łapał **świeżo wstrzyknięty** rail w `#project-details-content` i usuwał go, zanim `initializeChapterRail()` zdążył go przenieść do `<body>`.

```
showProjectDetails("RazDwa")
 → content.innerHTML = doc.body.innerHTML   // rail trafia do #project-details-content
 → initializeProjectScripts()
 → initializeChapterRail()
     → removeChapterRail()                  // ⬅ USUWA rail z DOM
     → document.getElementById('razdwa-chapter-rail') === null
     → if (!rail) return;                   // ⬅ wczesny return — koniec
```

Bug wprowadzony przeze mnie w `f5567aa` przy reworkku rail-a do lewej kolumny — `removeChapterRail` był pomyślany jako sprzątanie po POPRZEDNIM projekcie, ale selektor nie odróżniał starego rail-a (już w `body`) od nowego (jeszcze w `#project-details-content`).

## Dokładnie zmienione pliki
| Plik | Zmiana |
|---|---|
| `assets/js/portfolio.js` | 1 linia — zawężenie selektora w `removeChapterRail` |
| `assets/js/projects.js` | dodanie `initChapterRail()` (~45 linii) + wpięcie do `initAllFeatures()` |
| `assets/css/projects.css` | **bez zmian** |
| `projects/razdwa_aplikacja.html` | **bez zmian** |

## Fix #1 — `portfolio.js`
```diff
 function removeChapterRail() {
-  document.querySelectorAll('#razdwa-chapter-rail').forEach(el => el.remove());
+  // Usuwaj tylko rail przeniesiony do body w poprzednim cyklu —
+  // świeżo wstrzyknięty rail w #project-details-content zostaje
+  document.querySelectorAll('body > #razdwa-chapter-rail').forEach(el => el.remove());
   if (window.__razdwaRailObserver) { ... }
 }
```

**Co naprawia:** rail w kontekście `portfolio.html` → klik karty RAZDWA → case study się ładuje → rail nie jest już niszczony, zostaje przeniesiony do `body`, dostaje listenery i scroll-spy.

## Fix #2 — `projects.js`
Nowa funkcja `initChapterRail()` w `projects.js`, wywoływana przez `initAllFeatures()`. Wariant **minimal**: bindowanie kliknięć (`scrollIntoView`) + `IntersectionObserver` scroll-spy. **Bez** „move to body" — standalone case study nie ma rodzica z `transform`, więc `position: fixed` przykleja się do viewportu bez dodatkowych zabiegów.

**Co naprawia:** bezpośrednie otwarcie `projects/razdwa_aplikacja.html` (z linka SEO, og:url, CV) → rail się rendereuje (CSS), klik w pigułkę smooth-scrolluje do sekcji, aktywna pigułka się podświetla podczas scrollowania.

## Sanity check

### Flow A — portfolio.html → RAZDWA
1. Otwórz `portfolio.html`.
2. Klik karty „Raz Dwa Druk" → case study wjeżdża w `#project-details-container`.
3. **Oczekiwane:** rail widoczny po lewej (desktop) lub jako top bar (mobile).
4. Klik dowolnej pigułki rozdziału → smooth scroll do sekcji.
5. Scrollowanie ręczne → aktywna pigułka się zmienia (scroll-spy).
6. Kliknij inną kartę portfolio → poprzedni rail zniknie z `body`, nowy projekt się pokaże bez „ducha" railu w narożniku.
7. Klik „X Zamknij" → rail wyczyszczony z `body` przez `closeProjectDetails`.

### Flow B — standalone razdwa_aplikacja.html
1. Otwórz bezpośrednio `https://kwyszynskidesign.github.io/KWdesignnew/projects/razdwa_aplikacja.html`.
2. **Oczekiwane:** rail widoczny po lewej (desktop) lub top bar (mobile) — sam CSS to gwarantuje.
3. Klik pigułki → smooth scroll do sekcji.
4. Scroll → aktywna pigułka się zmienia.
5. Brak `move to body` — rail siedzi w `<section id="case-razdwa-pelne">` i CSS-em wisi nad treścią (`position: fixed; left: 16; top: 50%`).

### Regression check
- Inne case studies (Karoma, Power of Mind, CyfraDruk, KW-Design, Sir Roger, Savage) — bez `#razdwa-chapter-rail`, `initChapterRail` zwraca wcześnie (`if (!rail) return;`). Brak regresji.
- KW-Design rail (`#kwdesign-chapter-rail`, klasa `.kwcs-chapter-rail`) — **nietknięty**. To osobna ścieżka inicjalizacji (jeśli istnieje), nie w scope tego PR.

## Konflikt z innymi pending PR
- **PR #53** (`claude/razdwa-rail-sidebar-rework`) — modyfikuje tylko `projects.css`. **Brak konfliktu**.
- **PR #52** — już zmergowany (hotfix portfolio.js syntax). Bez konfliktu.

## Czego nie ma w tym PR
- Oś kategorii — osobny task, dopiero po przywróceniu railu.
- Zmian CSS — niepotrzebne.
- Zmian HTML — niepotrzebne.
- Refaktoringu współdzielonego modułu rail-a — celowo trzymana minimalna duplikacja (~45 linii) zamiast architektury, której ten projekt nie potrzebuje.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNi6jDQsDLXyrD4mEe2weo)_