### PR TITLE
RAZDWA P0: kompletny rail desktop — 15 L1 + 15 L2 z hierarchią

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -2645,6 +2645,42 @@ body.lightbox-open {
   font-weight: 600;
 }
 
+/* ── L2 (podsekcje) — wcięcie, mniejszy font, kropka-marker, lżejszy akcent ── */
+.razdwa-chapter-link[data-rail-level="2"] {
+  padding-left: 1.5rem;
+  font-size: 0.72rem;
+  font-weight: 400;
+  color: #64748b;
+  position: relative;
+}
+/* Kropka-marker — override globalnego resetu content: none !important */
+.razdwa-chapter-link[data-rail-level="2"]::before {
+  content: "" !important;
+  position: absolute;
+  left: 0.7rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #cbd5e1;
+  transition: background 0.15s ease;
+}
+.razdwa-chapter-link[data-rail-level="2"]:hover {
+  background: #f1f5f9;
+  color: #0f172a;
+}
+.razdwa-chapter-link[data-rail-level="2"]:hover::before { background: #06b6d4; }
+/* L2 aktywny — sam akcent koloru, bez wypełnienia tła
+   (żeby L1 aktywny zawsze miał silniejszy sygnał wizualny niż L2) */
+.razdwa-chapter-link[data-rail-level="2"].is-active {
+  background: transparent;
+  border-color: transparent;
+  color: #0284c7;
+  font-weight: 600;
+}
+.razdwa-chapter-link[data-rail-level="2"].is-active::before { background: #0284c7; }
+
 /* Desktop ≥1280px — szerszy rail, content RAZDWA odsunięty w prawo,
    żeby rail nie nachodził na sekcje przy max-width 1200 wycentrowanych */
 @media (min-width: 1280px) {
@@ -2708,6 +2744,20 @@ body.lightbox-open {
     background: #06b6d4;
     border-color: #06b6d4;
     color: #fff;
+  }
+  /* Mobile L2 — mniejsza pigułka, słabszy kontrast (bez wcięcia, bo top bar
+     jest horyzontalny — wcięcie nie ma sensu, hierarchia przez rozmiar) */
+  .razdwa-chapter-link[data-rail-level="2"] {
+    padding: 0.2rem 0.55rem;
+    font-size: 0.7rem;
+    background: #f8fafc;
+    color: #64748b;
+  }
+  .razdwa-chapter-link[data-rail-level="2"]::before { content: none !important; }
+  .razdwa-chapter-link[data-rail-level="2"].is-active {
+    background: #e0f2fe;
+    color: #0284c7;
+    border-color: #bae6fd;
   }
   /* Mobile top bar nie wymaga marginesu sekcji */
   #case-razdwa-pelne { padding-left: 0; }

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -141,18 +141,34 @@
       <ul class="razdwa-chapter-rail-list">
         <li><a class="razdwa-chapter-link" href="#razdwa-summary" data-rail-target="razdwa-summary" title="W skrócie" aria-label="W skrócie">W skrócie</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-kontekst" data-rail-target="razdwa-kontekst" title="Kontekst" aria-label="Kontekst">Kontekst</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-architektura-ekosystem" data-rail-target="razdwa-architektura-ekosystem" title="Architektura ekosystemu" aria-label="Architektura ekosystemu">Architektura ekosystemu</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-decyzje" data-rail-target="razdwa-decyzje" title="Decyzje produktowe" aria-label="Decyzje produktowe">Decyzje produktowe</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-decyzje-problem" data-rail-target="razdwa-decyzje-problem" title="Jak rozpoznałem problem" aria-label="Jak rozpoznałem problem">Jak rozpoznałem problem</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-decyzje-kluczowe" data-rail-target="razdwa-decyzje-kluczowe" title="Kluczowe decyzje produktowe" aria-label="Kluczowe decyzje produktowe">Kluczowe decyzje produktowe</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-decyzje-zakres" data-rail-target="razdwa-decyzje-zakres" title="Zakres dostarczony" aria-label="Zakres dostarczony">Zakres dostarczony</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-role" data-rail-target="razdwa-role" title="Role i persony" aria-label="Role i persony">Role i persony</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-ux" data-rail-target="razdwa-ux" title="Interfejs i UX" aria-label="Interfejs i UX">Interfejs i UX</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-cad" data-rail-target="razdwa-cad" title="Kalkulator CAD" aria-label="Kalkulator CAD">Kalkulator CAD</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-panel" data-rail-target="razdwa-panel" title="Panel admina" aria-label="Panel admina">Panel admina</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-warianty" data-rail-target="razdwa-warianty" title="Warianty" aria-label="Warianty">Warianty</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-droga" data-rail-target="razdwa-droga" title="Droga zamówienia" aria-label="Droga zamówienia">Droga zamówienia</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-architektura" data-rail-target="razdwa-architektura" title="Architektura" aria-label="Architektura">Architektura</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-ux" data-rail-target="razdwa-ux" title="Część 1: Interfejs i UX" aria-label="Część 1: Interfejs i UX">Część 1 · Interfejs i UX</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-ux-decyzje" data-rail-target="razdwa-ux-decyzje" title="Kluczowe decyzje UX" aria-label="Kluczowe decyzje UX">Kluczowe decyzje UX</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-cad" data-rail-target="razdwa-cad" title="Część 2: Kalkulator CAD" aria-label="Część 2: Kalkulator CAD">Część 2 · Kalkulator CAD</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-cad-logika" data-rail-target="razdwa-cad-logika" title="Logika CAD (deep dive)" aria-label="Logika CAD (deep dive)">Logika CAD (deep dive)</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-panel" data-rail-target="razdwa-panel" title="Część 3: Panel administracyjny" aria-label="Część 3: Panel administracyjny">Część 3 · Panel administracyjny</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-panel-funkcje" data-rail-target="razdwa-panel-funkcje" title="Co panel pozwala zrobić" aria-label="Co panel pozwala zrobić">Co panel pozwala zrobić</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-panel-pin" data-rail-target="razdwa-panel-pin" title="Bramka PIN" aria-label="Bramka PIN">Bramka PIN</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-warianty" data-rail-target="razdwa-warianty" title="Część 4: Warianty produktów" aria-label="Część 4: Warianty produktów">Część 4 · Warianty produktów</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-warianty-osobno" data-rail-target="razdwa-warianty-osobno" title="Dlaczego osobno od cennika" aria-label="Dlaczego osobno od cennika">Dlaczego osobno od cennika</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-droga" data-rail-target="razdwa-droga" title="Część 5: Droga zamówienia" aria-label="Część 5: Droga zamówienia">Część 5 · Droga zamówienia</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-droga-etapy" data-rail-target="razdwa-droga-etapy" title="Pięć etapów" aria-label="Pięć etapów">Pięć etapów</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-architektura" data-rail-target="razdwa-architektura" title="Część 6: Architektura i Integracje" aria-label="Część 6: Architektura i Integracje">Część 6 · Architektura i Integracje</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-warstwy" data-rail-target="razdwa-architektura-warstwy" title="Pięć warstw" aria-label="Pięć warstw">Pięć warstw</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-integracje" data-rail-target="razdwa-architektura-integracje" title="Integracje" aria-label="Integracje">Integracje</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-testy" data-rail-target="razdwa-architektura-testy" title="Testy automatyczne" aria-label="Testy automatyczne">Testy automatyczne</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-systemui" data-rail-target="razdwa-systemui" title="System UI" aria-label="System UI">System UI</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-contribution" data-rail-target="razdwa-contribution" title="Moja rola" aria-label="Moja rola">Moja rola</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-potencjal" data-rail-target="razdwa-potencjal" title="Potencjał B2B" aria-label="Potencjał B2B">Potencjał B2B</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-potencjal-poligrafia" data-rail-target="razdwa-potencjal-poligrafia" title="Specyficzne dla poligrafii" aria-label="Specyficzne dla poligrafii">Specyficzne dla poligrafii</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-potencjal-uniwersalne" data-rail-target="razdwa-potencjal-uniwersalne" title="Uniwersalne moduły" aria-label="Uniwersalne moduły">Uniwersalne moduły</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-rezultat" data-rail-target="razdwa-rezultat" title="Rezultat" aria-label="Rezultat">Rezultat</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-rezultat-dalej" data-rail-target="razdwa-rezultat-dalej" title="Co dalej z projektem" aria-label="Co dalej z projektem">Co dalej z projektem</a></li>
       </ul>
     </nav>
 
@@ -191,7 +207,7 @@
       </div>
     </div>
 
-    <div class="kwcs-sec" style="background: #f8fafc;">
+    <div class="kwcs-sec" style="background: #f8fafc;" id="razdwa-architektura-ekosystem">
       <div class="wrap">
         <h2>Architektura ekosystemu</h2>
         <p>Aplikacja łączy w sobie wiele funkcjonalności, które zastąpiły ręczne przepływy pracy w drukarni:</p>
@@ -246,7 +262,7 @@
           </p>
         </div>
 
-        <h3 style="text-align:center">Jak rozpoznałem problem</h3>
+        <h3 style="text-align:center" id="razdwa-decyzje-problem">Jak rozpoznałem problem</h3>
         <div class="ux-decision-grid">
           <div class="ux-decision-box">
             <h4>Forma rozpoznania potrzeb</h4>
@@ -260,7 +276,7 @@
           </div>
         </div>
 
-        <h3 style="margin-top:3rem;text-align:center">Kluczowe decyzje produktowe</h3>
+        <h3 style="margin-top:3rem;text-align:center" id="razdwa-decyzje-kluczowe">Kluczowe decyzje produktowe</h3>
 
         <div class="ux-decision-grid">
           <div class="ux-decision-box">
@@ -288,7 +304,7 @@
           </div>
         </div>
 
-        <h3 style="margin-top:3rem;">Zakres dostarczony: od MVP po dzisiejszy stan produktu</h3>
+        <h3 style="margin-top:3rem;" id="razdwa-decyzje-zakres">Zakres dostarczony: od MVP po dzisiejszy stan produktu</h3>
         <p style="max-width:760px;margin:0 auto 1.5rem;color:#475569;">Projekt nie zatrzymał się na minimalnej wersji — aplikacja jest dziś w pełni wdrożonym produktem. Poniższy podział pokazuje, w jakiej kolejności powstawały kolejne warstwy funkcjonalne.</p>
         <div class="kwcs-trio">
           <article class="kwcs-card">
@@ -427,7 +443,7 @@
           </div>
         </div>
 
-        <h3 style="text-align:center">Kluczowe decyzje UX</h3>
+        <h3 style="text-align:center" id="razdwa-ux-decyzje">Kluczowe decyzje UX</h3>
         <div class="ux-decision-grid">
           <div class="ux-decision-box">
             <div class="ux-label">Problem → Rozwiązanie</div>
@@ -478,7 +494,7 @@
 
     <div class="kwcs-sec" style="background: #f8fafc;">
       <div class="wrap">
-        <h3 style="text-align:center">Logika kalkulatora CAD — szczegóły</h3>
+        <h3 style="text-align:center" id="razdwa-cad-logika">Logika kalkulatora CAD — szczegóły</h3>
         <div class="kwcs-accordion">
           <div class="kwcs-item">
             <button class="kwcs-header" aria-expanded="false" aria-controls="content-cad-3" id="header-cad-3" type="button">
@@ -528,7 +544,7 @@
           </div>
         </div>
 
-        <h3 style="text-align:center">Co panel pozwala zrobić</h3>
+        <h3 style="text-align:center" id="razdwa-panel-funkcje">Co panel pozwala zrobić</h3>
         <div class="ux-decision-grid">
           <div class="ux-decision-box">
             <div class="ux-label">Funkcja 1</div>
@@ -552,7 +568,7 @@
           </div>
         </div>
 
-        <h3 style="margin-top:3rem;text-align:center">Bezpieczeństwo: bramka PIN</h3>
+        <h3 style="margin-top:3rem;text-align:center" id="razdwa-panel-pin">Bezpieczeństwo: bramka PIN</h3>
         <p style="max-width:760px;margin:0 auto 1.5rem;color:#475569;">Cennik to wrażliwy zasób — przypadkowa edycja przez recepcjonistę kosztuje realne pieniądze. Wprowadziłem bramkę PIN, ale w sposób, który nie utrudnia codziennej pracy:</p>
 
         <div class="kwcs-gallery-grid" style="margin-bottom:2rem;">
@@ -580,7 +596,7 @@
           <p>W trakcie pracy z drukarnią okazało się, że <strong>nie wystarczy jeden cennik</strong>: ten sam produkt (np. wizytówki) ma kilka odmian, które klient zamawia po imieniu („Wizytówki Premium", „Wizytówki ekspresowe"). Zaprojektowałem osobny system wariantów, niezależny od cennika bazowego.</p>
         </div>
 
-        <h3 style="text-align:center">Dlaczego warianty są osobno od cennika</h3>
+        <h3 style="text-align:center" id="razdwa-warianty-osobno">Dlaczego warianty są osobno od cennika</h3>
         <p style="max-width:760px;margin:0 auto 1.5rem;color:#475569;">Cennik bazowy odpowiada na pytanie „ile kosztuje druk koloru A4 w nakładzie 100 sztuk". Wariant odpowiada na pytanie „co dokładnie zamawia klient i pod jaką nazwą zapisać to w systemie". Rozdzielenie tych dwóch warstw oznacza, że dodanie nowego wariantu nie wymaga modyfikacji cennika, a zmiana ceny nie wymaga modyfikacji nazw wariantów.</p>
 
         <div class="ux-decision-grid">
@@ -629,7 +645,7 @@
           <p>Od momentu, gdy operator dodaje pierwszą pozycję do koszyka, do momentu, gdy zamówienie ląduje w bazie firmy — przepływ został podzielony na etapy, w których trudno popełnić błąd. Każdy etap ma jeden cel i jedno zabezpieczenie.</p>
         </div>
 
-        <h3 style="text-align:center">Pięć etapów</h3>
+        <h3 style="text-align:center" id="razdwa-droga-etapy">Pięć etapów</h3>
         <div class="ux-decision-grid">
           <div class="ux-decision-box">
             <div class="ux-label">Etap 1</div>
@@ -1007,7 +1023,7 @@
           <p>Raz Dwa Druk to <strong>aplikacja dla konkretnej drukarni</strong>, ale zbudowana z modułów, które rozwiązują problem znacznie szerszy: <em>jak małej firmie usługowej dać kalkulator + koszyk + bazę zamówień bez własnej infrastruktury</em>. Większość warstw architektury można przenieść do innej branży po podmianie definicji kategorii i cennika.</p>
         </div>
 
-        <h3 style="text-align:center">Co jest specyficzne dla poligrafii</h3>
+        <h3 style="text-align:center" id="razdwa-potencjal-poligrafia">Co jest specyficzne dla poligrafii</h3>
         <ul style="max-width:760px;margin:0 auto 2rem;color:#475569;line-height:1.7;">
           <li>Rozpoznawanie formatu CAD (A0–A3) z uploadowanych plików</li>
           <li>Przeliczenia metr bieżący × szerokość rolki</li>
@@ -1015,7 +1031,7 @@
           <li>Modyfikatory poligraficzne: oczkowanie, składanie, satyna, dwustronnie, gramatura papieru</li>
         </ul>
 
-        <h3 style="text-align:center">Co jest uniwersalne i gotowe do przeniesienia</h3>
+        <h3 style="text-align:center" id="razdwa-potencjal-uniwersalne">Co jest uniwersalne i gotowe do przeniesienia</h3>
         <div class="kwcs-trio">
           <article class="kwcs-card">
             <h3>Moduły do reuse</h3>
@@ -1127,7 +1143,7 @@
           </a>
 
           <div class="result-next">
-            <h3>Co dalej z projektem?</h3>
+            <h3 id="razdwa-rezultat-dalej">Co dalej z projektem?</h3>
             <p>Pracuję nad integracją parsera DWG/DXF, aby czytać rzeczywiste wektory z plików architektonicznych bez generowania podglądów rastrowych. W planach jest też tryb klienta końcowego ukrywający marże, z bezpośrednią integracją płatności.</p>
           </div>
         </div>


### PR DESCRIPTION
## P0 — kompletny chapter rail RAZDWA (desktop)

Pierwszy z dwóch PR-ów. P1 (mobile bar + bottom sheet) idzie osobno.

## Root cause / co było brakujące
Audyt struktury nagłówków `projects/razdwa_aplikacja.html` wykazał trzy luki:

1. **Brakujący L1 „Architektura ekosystemu"** (linia 196) — pełna sekcja `<h2>` w `kwcs-sec` bez `id` i bez wpisu w railu. Sąsiad między „Kontekstem" a „Decyzjami produktowymi". Konkretny przykład, który podałeś.
2. **3 istniejące ID pod „Częścią 6: Architektura"** (`razdwa-architektura-warstwy/-integracje/-testy`) — anchory przygotowane wcześniej, ale nigdy nie wpięte w rail.
3. **12 śródnagłówków h3** traktowanych jako narracja, choć każdy to odrębna koncepcja / decyzja warta osobnego anchora (od „Jak rozpoznałem problem" po „Co dalej z projektem").

Razem rail miał **14 pozycji**, treść miała **realnie 30 punktów orientacyjnych**.

## Lista dodanych anchorów

### Nowy L1 (1)
- `razdwa-architektura-ekosystem` — na `<div class="kwcs-sec">` wokół `<h2>Architektura ekosystemu</h2>` (wzorzec jak `razdwa-summary` i `razdwa-kontekst`).

### Nowe L2 (12)
| ID | Sekcja nadrzędna | Tekst h3 |
|---|---|---|
| `razdwa-decyzje-problem` | Decyzje produktowe | Jak rozpoznałem problem |
| `razdwa-decyzje-kluczowe` | Decyzje produktowe | Kluczowe decyzje produktowe |
| `razdwa-decyzje-zakres` | Decyzje produktowe | Zakres dostarczony |
| `razdwa-ux-decyzje` | Część 1 UX | Kluczowe decyzje UX |
| `razdwa-cad-logika` | Część 2 CAD | Logika kalkulatora CAD — szczegóły |
| `razdwa-panel-funkcje` | Część 3 Panel | Co panel pozwala zrobić |
| `razdwa-panel-pin` | Część 3 Panel | Bezpieczeństwo: bramka PIN |
| `razdwa-warianty-osobno` | Część 4 Warianty | Dlaczego osobno od cennika |
| `razdwa-droga-etapy` | Część 5 Droga | Pięć etapów |
| `razdwa-potencjal-poligrafia` | Potencjał B2B | Specyficzne dla poligrafii |
| `razdwa-potencjal-uniwersalne` | Potencjał B2B | Uniwersalne moduły |
| `razdwa-rezultat-dalej` | Rezultat | Co dalej z projektem |

### Wpisy w railu (16 nowych)
Rail rozbudowany z **14 → 30 wpisów**: 15 L1 + 15 L2 w **kolejności narracyjnej** (zgodnie z plikiem). L2 oznaczone `data-rail-level="2"`.

## Dokładnie zmienione pliki

| Plik | Zmiana | Linie |
|---|---|---|
| `projects/razdwa_aplikacja.html` | 13 atrybutów `id` na sekcjach/nagłówkach + przebudowa `<ul>` railu (14→30 wpisów) | **+35 / -19** |
| `assets/css/projects.css` | nowe selektory `.razdwa-chapter-link[data-rail-level="2"]` (desktop: wcięcie + kropka + akcent koloru bez tła; mobile: mniejsza pigułka, słabszy kontrast) | **+50** |
| `assets/js/portfolio.js` | **bez zmian** | — |
| `assets/js/projects.js` | **bez zmian** | — |

`initializeChapterRail` / `initChapterRail` używają `querySelectorAll('.razdwa-chapter-link')` — łapią L1 i L2 razem, IntersectionObserver scroll-spy działa dla wszystkich 30 targetów bez modyfikacji.

## Świadomie pominięte

| Czego nie ma | Dlaczego |
|---|---|
| 6 słabszych h3 (User flow / Wielokolumnowy layout / Dynamiczny koszyk / Kalkulator w działaniu / System wariantów w działaniu / Etapy w aplikacji) | tytuły showcase/gallery, nie odrębne koncepcje — nie rozwadniamy TOC |
| Tytuły kart w `.kwcs-trio` (MVP/Iter 2/Backlog, Wyzwanie/Cele/Technologie itd.) | nawigacja do pojedynczej karty kafelka byłaby sztuczna |
| „Rezultat Ostateczny" (linia 1096) | duplikacja L1 — kierunek to `razdwa-rezultat` |
| Mobile rework (bottom bar + sheet) | P1, osobny PR — chcemy odseparować ryzyko JS |
| Cięcia treści | następny krok po zatwierdzeniu railu, osobny task |

## Sanity check struktury

Cross-check anchorów vs. railu:

```
$ python3 audit.py
Rail targets: 30 | IDs in doc: 31
Missing target → ID: NONE
IDs not referenced by rail: NONE
```

(31 = 30 targetów + samo `id="razdwa-chapter-rail"` na `<nav>`.)

Wszystkie 30 linków w railu mają istniejący `id` w dokumencie. Żaden nowy `id` w dokumencie nie pozostał bez wpisu w railu. **Rail prowadzi po całej właściwej strukturze case study.**

### Kolejność w railu (po Twojej decyzji 4 — narracyjna)
```
1.  W skrócie                         [L1]
2.  Kontekst                          [L1]
3.  Architektura ekosystemu           [L1] ⬅ NOWE
4.  Decyzje produktowe                [L1]
5.    Jak rozpoznałem problem         [L2] ⬅ NOWE
6.    Kluczowe decyzje produktowe     [L2] ⬅ NOWE
7.    Zakres dostarczony              [L2] ⬅ NOWE
8.  Role i persony                    [L1]
9.  Część 1 · Interfejs i UX          [L1]
10.   Kluczowe decyzje UX             [L2] ⬅ NOWE
11. Część 2 · Kalkulator CAD          [L1]
12.   Logika CAD (deep dive)          [L2] ⬅ NOWE
13. Część 3 · Panel administracyjny   [L1]
14.   Co panel pozwala zrobić         [L2] ⬅ NOWE
15.   Bramka PIN                      [L2] ⬅ NOWE
16. Część 4 · Warianty produktów      [L1]
17.   Dlaczego osobno od cennika      [L2] ⬅ NOWE
18. Część 5 · Droga zamówienia        [L1]
19.   Pięć etapów                     [L2] ⬅ NOWE
20. Część 6 · Architektura i Integ.   [L1]
21.   Pięć warstw                     [L2] ⬅ NOWE (id istniał, brak wpisu)
22.   Integracje                      [L2] ⬅ NOWE (id istniał, brak wpisu)
23.   Testy automatyczne              [L2] ⬅ NOWE (id istniał, brak wpisu)
24. System UI                         [L1]
25. Moja rola                         [L1]
26. Potencjał B2B                     [L1]
27.   Specyficzne dla poligrafii      [L2] ⬅ NOWE
28.   Uniwersalne moduły              [L2] ⬅ NOWE
29. Rezultat                          [L1]
30.   Co dalej z projektem            [L2] ⬅ NOWE
```

## Zależności / konflikt z innymi PR-ami
- **PR #55** (hotfix rail render) — niezbędny do tego, żeby rail w ogóle się renderował z poziomu `portfolio.html`. Po merge #55, P0 działa od razu. Standalone `razdwa_aplikacja.html` wymaga merge #55 dla działania klików (JS init w `projects.js`). **Zalecam merge #55 przed P0.**
- **PR #53** (sidebar rework CSS) — modyfikuje ten sam blok railu. **Konflikt CSS przy mergu.** Decyzja: albo zamknąć #53 i zachować obecny styl rail-a, albo rebase #53 na P0 po merge.

## Test plan
- [ ] Desktop ≥1280px: rail po lewej, widoczne 30 pozycji w hierarchii L1/L2. Wcięcie L2, kropki, mniejszy font.
- [ ] Klik dowolnego L1 → smooth scroll do sekcji.
- [ ] Klik dowolnego L2 → smooth scroll do śródnagłówka, kropka się podświetla, brak wypełnienia tła (akcent tylko koloru).
- [ ] Scroll-spy: aktywny element się zmienia podczas scrollowania case study.
- [ ] Klik w „Architektura ekosystemu" — działa, scrolluje do nowo dodanej sekcji (linia 196).
- [ ] Klik w „Pięć warstw" / „Integracje" / „Testy automatyczne" — działa (anchory były, teraz są w railu).
- [ ] Mobile ≤1100px: 30 pigułek w top barze, L2 mniejsze i jaśniejsze (świadome — pełny mobile fix w P1).
- [ ] Lightbox: rail nadal chowany przez `body.lightbox-open`.
- [ ] Brak regresji na innych case studies (Karoma, Power of Mind, KW-Design itd.).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNi6jDQsDLXyrD4mEe2weo)_