### PR TITLE
RAZDWA cleanup pkg 1: usuń System UI, scal Architekturę, uprość rail

### DIFF
--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -171,7 +171,6 @@
         <li><a class="razdwa-chapter-link" href="#razdwa-summary" data-rail-target="razdwa-summary" title="W skrócie" aria-label="W skrócie">W skrócie</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-contribution" data-rail-target="razdwa-contribution" title="Moja rola" aria-label="Moja rola">Moja rola</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-kontekst" data-rail-target="razdwa-kontekst" title="Kontekst" aria-label="Kontekst">Kontekst</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-architektura-ekosystem" data-rail-target="razdwa-architektura-ekosystem" title="Architektura ekosystemu" aria-label="Architektura ekosystemu">Architektura ekosystemu</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-decyzje" data-rail-target="razdwa-decyzje" title="Decyzje produktowe" aria-label="Decyzje produktowe">Decyzje produktowe</a></li>
         <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-decyzje-problem" data-rail-target="razdwa-decyzje-problem" title="Jak rozpoznałem problem" aria-label="Jak rozpoznałem problem">Jak rozpoznałem problem</a></li>
         <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-decyzje-kluczowe" data-rail-target="razdwa-decyzje-kluczowe" title="Kluczowe decyzje produktowe" aria-label="Kluczowe decyzje produktowe">Kluczowe decyzje produktowe</a></li>
@@ -185,19 +184,16 @@
         <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-panel-funkcje" data-rail-target="razdwa-panel-funkcje" title="Co panel pozwala zrobić" aria-label="Co panel pozwala zrobić">Co panel pozwala zrobić</a></li>
         <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-panel-pin" data-rail-target="razdwa-panel-pin" title="Bramka PIN" aria-label="Bramka PIN">Bramka PIN</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-warianty" data-rail-target="razdwa-warianty" title="Część 4: Warianty produktów" aria-label="Część 4: Warianty produktów">Część 4 · Warianty produktów</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-warianty-osobno" data-rail-target="razdwa-warianty-osobno" title="Dlaczego osobno od cennika" aria-label="Dlaczego osobno od cennika">Dlaczego osobno od cennika</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-droga" data-rail-target="razdwa-droga" title="Część 5: Droga zamówienia" aria-label="Część 5: Droga zamówienia">Część 5 · Droga zamówienia</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-droga-etapy" data-rail-target="razdwa-droga-etapy" title="Pięć etapów" aria-label="Pięć etapów">Pięć etapów</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-architektura" data-rail-target="razdwa-architektura" title="Część 6: Architektura i Integracje" aria-label="Część 6: Architektura i Integracje">Część 6 · Architektura i Integracje</a></li>
+        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-ekosystem" data-rail-target="razdwa-architektura-ekosystem" title="Ekosystem (high-level)" aria-label="Ekosystem (high-level)">Ekosystem (high-level)</a></li>
         <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-warstwy" data-rail-target="razdwa-architektura-warstwy" title="Pięć warstw" aria-label="Pięć warstw">Pięć warstw</a></li>
         <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-integracje" data-rail-target="razdwa-architektura-integracje" title="Integracje" aria-label="Integracje">Integracje</a></li>
         <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-testy" data-rail-target="razdwa-architektura-testy" title="Testy automatyczne" aria-label="Testy automatyczne">Testy automatyczne</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-systemui" data-rail-target="razdwa-systemui" title="System UI" aria-label="System UI">System UI</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-potencjal" data-rail-target="razdwa-potencjal" title="Potencjał B2B" aria-label="Potencjał B2B">Potencjał B2B</a></li>
         <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-potencjal-poligrafia" data-rail-target="razdwa-potencjal-poligrafia" title="Specyficzne dla poligrafii" aria-label="Specyficzne dla poligrafii">Specyficzne dla poligrafii</a></li>
         <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-potencjal-uniwersalne" data-rail-target="razdwa-potencjal-uniwersalne" title="Uniwersalne moduły" aria-label="Uniwersalne moduły">Uniwersalne moduły</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-rezultat" data-rail-target="razdwa-rezultat" title="Rezultat" aria-label="Rezultat">Rezultat</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-rezultat-dalej" data-rail-target="razdwa-rezultat-dalej" title="Co dalej z projektem" aria-label="Co dalej z projektem">Co dalej z projektem</a></li>
       </ul>
     </nav>
 
@@ -227,48 +223,6 @@
       <div class="razdwa-stat">
         <div class="razdwa-stat-num">0 zł</div>
         <div class="razdwa-stat-label">kosztów utrzymania serwerów</div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="kwcs-sec" style="background: #f8fafc;" id="razdwa-architektura-ekosystem">
-  <div class="wrap">
-    <h2 style="text-align:center; margin-bottom:2rem;">Architektura ekosystemu</h2>
-
-    <div class="razdwa-ecosystem">
-      <div class="razdwa-ecosystem-row">
-        <div class="eco-node">
-          <div class="eco-node-icon">🖨️</div>
-          <div class="eco-node-label">Kalkulatory CAD</div>
-          <div class="eco-node-sub">Upload pliku, automatyczna detekcja formatu i natychmiastowa wycena.</div>
-        </div>
-        <div class="eco-arrow">→</div>
-        <div class="eco-node">
-          <div class="eco-node-icon">🛒</div>
-          <div class="eco-node-label">Koszyk i Interfejs</div>
-          <div class="eco-node-sub">Obsługa rabatów, trybu EXPRESS oraz przeliczanie sumy na żywo.</div>
-        </div>
-      </div>
-      <div class="razdwa-ecosystem-row">
-        <div class="eco-node">
-          <div class="eco-node-icon">📄</div>
-          <div class="eco-node-label">Eksport raportów PDF</div>
-          <div class="eco-node-sub">Generowanie gotowego podsumowania dla klienta bezpośrednio w przeglądarce.</div>
-        </div>
-        <div class="eco-arrow">↔</div>
-        <div class="eco-node">
-          <div class="eco-node-icon">📊</div>
-          <div class="eco-node-label">Zintegrowany Google Sheets</div>
-          <div class="eco-node-sub">Automatyczna rejestracja transakcji i replikacja danych w chmurze.</div>
-        </div>
-      </div>
-      <div class="razdwa-ecosystem-row">
-        <div class="eco-node">
-          <div class="eco-node-icon">⚙️</div>
-          <div class="eco-node-label">Dynamiczny System Cenników</div>
-          <div class="eco-node-sub">Bezserwerowe przechowywanie stawek i szybka edycja z poziomu UI.</div>
-        </div>
       </div>
     </div>
   </div>
@@ -701,7 +655,45 @@
       Lekka, reaktywna aplikacja webowa (TypeScript + esbuild) w architekturze <strong>Serverless</strong>. Rezygnacja z ciężkich frameworków i baz SQL zredukowała koszty utrzymania infrastruktury do <strong>0 zł</strong>, wykorzystując ekosystem Google jako API i bazę danych.
     </p>
 
-    <h3 style="text-align:center" id="razdwa-architektura-warstwy">Architektura: Rozdzielenie odpowiedzialności (SoC)</h3>
+    <h3 style="text-align:center" id="razdwa-architektura-ekosystem">Ekosystem — widok wysokopoziomowy</h3>
+
+    <div class="razdwa-ecosystem">
+      <div class="razdwa-ecosystem-row">
+        <div class="eco-node">
+          <div class="eco-node-icon">🖨️</div>
+          <div class="eco-node-label">Kalkulatory CAD</div>
+          <div class="eco-node-sub">Upload pliku, automatyczna detekcja formatu i natychmiastowa wycena.</div>
+        </div>
+        <div class="eco-arrow">→</div>
+        <div class="eco-node">
+          <div class="eco-node-icon">🛒</div>
+          <div class="eco-node-label">Koszyk i Interfejs</div>
+          <div class="eco-node-sub">Obsługa rabatów, trybu EXPRESS oraz przeliczanie sumy na żywo.</div>
+        </div>
+      </div>
+      <div class="razdwa-ecosystem-row">
+        <div class="eco-node">
+          <div class="eco-node-icon">📄</div>
+          <div class="eco-node-label">Eksport raportów PDF</div>
+          <div class="eco-node-sub">Generowanie gotowego podsumowania dla klienta bezpośrednio w przeglądarce.</div>
+        </div>
+        <div class="eco-arrow">↔</div>
+        <div class="eco-node">
+          <div class="eco-node-icon">📊</div>
+          <div class="eco-node-label">Zintegrowany Google Sheets</div>
+          <div class="eco-node-sub">Automatyczna rejestracja transakcji i replikacja danych w chmurze.</div>
+        </div>
+      </div>
+      <div class="razdwa-ecosystem-row">
+        <div class="eco-node">
+          <div class="eco-node-icon">⚙️</div>
+          <div class="eco-node-label">Dynamiczny System Cenników</div>
+          <div class="eco-node-sub">Bezserwerowe przechowywanie stawek i szybka edycja z poziomu UI.</div>
+        </div>
+      </div>
+    </div>
+
+    <h3 style="text-align:center; margin-top:3rem;" id="razdwa-architektura-warstwy">Architektura: Rozdzielenie odpowiedzialności (SoC)</h3>
     
     <div class="kwcs-accordion">
       <div class="kwcs-item">
@@ -867,117 +859,6 @@
     </div>
   </div>
 </div>
-   <!-- ============================================================
-     System UI projektu
-============================================================ -->
-<!-- ============================================================
-      System UI projektu
-============================================================ -->
-<h2 class="section-divider" id="razdwa-systemui">Część 7: System UI i Tokeny Projektowe</h2>
-
-<div class="kwcs-sec" style="background:#f8fafc;">
-  <div class="wrap">
-    <p style="max-width:760px; margin:0 auto 2rem; text-align:center; color:#475569;">
-      Interfejs opiera się na minimalistycznej palecie tokenów UI. Architektura wykorzystuje jeden kolor przewodni (Cyan), neutralną paletę Slate dla kontrastu oraz komponenty wielokrotnego użytku, co zapewnia spójność wizualną i łatwe skalowanie cennika.
-    </p>
-
-    <div class="razdwa-systemui">
-      <div class="systemui-card">
-        <h3 style="text-align:center; margin-bottom:2rem;">Paleta kolorów i mapowanie tokenów</h3>
-        <div class="systemui-swatches">
-          <div class="systemui-swatch">
-            <div class="systemui-swatch-color" style="background:#06b6d4"></div>
-            <div class="systemui-swatch-meta">
-              <div class="systemui-swatch-name">Brand / Action Primary</div>
-              <div class="systemui-swatch-code">#06b6d4</div>
-            </div>
-          </div>
-          <div class="systemui-swatch">
-            <div class="systemui-swatch-color" style="background:#0284c7"></div>
-            <div class="systemui-swatch-meta">
-              <div class="systemui-swatch-name">Action Hover / Active</div>
-              <div class="systemui-swatch-code">#0284c7</div>
-            </div>
-          </div>
-          <div class="systemui-swatch">
-            <div class="systemui-swatch-color" style="background:#0f172a"></div>
-            <div class="systemui-swatch-meta">
-              <div class="systemui-swatch-name">Text Primary</div>
-              <div class="systemui-swatch-code">#0f172a</div>
-            </div>
-          </div>
-          <div class="systemui-swatch">
-            <div class="systemui-swatch-color" style="background:#475569"></div>
-            <div class="systemui-swatch-meta">
-              <div class="systemui-swatch-name">Text Secondary</div>
-              <div class="systemui-swatch-code">#475569</div>
-            </div>
-          </div>
-          <div class="systemui-swatch">
-            <div class="systemui-swatch-color" style="background:#f8fafc; border-color:#e2e8f0"></div>
-            <div class="systemui-swatch-meta">
-              <div class="systemui-swatch-name">Background Neutral</div>
-              <div class="systemui-swatch-code">#f8fafc</div>
-            </div>
-          </div>
-          <div class="systemui-swatch">
-            <div class="systemui-swatch-color" style="background:#10b981"></div>
-            <div class="systemui-swatch-meta">
-              <div class="systemui-swatch-name">State Success</div>
-              <div class="systemui-swatch-code">#10b981</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="kwcs-sec">
-  <div class="wrap">
-    <div class="systemui-card">
-      <h3 style="text-align:center; margin-bottom:2rem;">System typograficzny</h3>
-      <div class="systemui-typo">
-        <div class="systemui-typo-row">
-          <span class="systemui-typo-sample is-display">Aa</span>
-          <span class="systemui-typo-meta"><strong>Playfair Display (Bold 700)</strong> — Nagłówki sekcji i główna hierarchia wizualna.</span>
-        </div>
-        <div class="systemui-typo-row">
-          <span class="systemui-typo-sample is-heading">Aa</span>
-          <span class="systemui-typo-meta"><strong>Inter (Bold 700)</strong> — Podnagłówki interfejsu, etykiety danych i komponenty akcji.</span>
-        </div>
-        <div class="systemui-typo-row">
-          <span class="systemui-typo-sample is-body">Aa</span>
-          <span class="systemui-typo-meta"><strong>Inter (Regular 400)</strong> — Opisy funkcjonalne, komunikaty systemowe i warstwa tekstowa.</span>
-        </div>
-        <div class="systemui-typo-row">
-          <span class="systemui-typo-sample is-mono">Aa</span>
-          <span class="systemui-typo-meta"><strong>Courier / Monospace</strong> — Dane strukturyzowane, sygnatury techniczne i klucze cennika.</span>
-        </div>
-      </div>
-    </div>
-
-    <div class="systemui-card" style="grid-column: 1 / -1; margin-top: 2rem;">
-      <h3 style="text-align:center; margin-bottom:1rem;">Zasoby modularne (Komponenty wielokrotnego użytku)</h3>
-      <p style="max-width:720px; margin:0 auto 2rem; color:#475569; text-align:center; font-size:0.95rem;">
-        Interfejs bazuje na atomowej strukturze klas CSS. Każdy moduł cennika wykorzystuje te same, zunifikowane elementy, co upraszcza rozwój i redukuje wagę plików arkuszy stylów.
-      </p>
-      <div class="systemui-components" style="display: flex; flex-wrap: wrap; gap: 0.5rem; justify-content: center;">
-        <span class="arch-tag"><code>.razdwa-stat</code> (Metryki)</span>
-        <span class="arch-tag"><code>.eco-node</code> (Przepływ danych)</span>
-        <span class="arch-tag"><code>.ux-decision-box</code> (Decyzje UX)</span>
-        <span class="arch-tag"><code>.kwcs-card</code> (Kontenery asortymentu)</span>
-        <span class="arch-tag"><code>.arch-layer / .arch-tag</code> (Architektura)</span>
-        <span class="arch-tag"><code>.int-card</code> (Integracje API)</span>
-        <span class="arch-tag"><code>.test-item</code> (Statusy QA)</span>
-        <span class="arch-tag"><code>.kwcs-accordion</code> (Akordeony)</span>
-        <span class="arch-tag"><code>.razdwa-summary-cell</code> (Agregatory koszyka)</span>
-        <span class="arch-tag"><code>.contribution-cell</code> (Siatki podsumowań)</span>
-      </div>
-    </div>
-  </div>
-</div>
-
 <h2 class="section-divider" id="razdwa-potencjal">Część 8: Skalowalność i Potencjał Biznesowy</h2>
 
 <div class="kwcs-sec">
@@ -1031,40 +912,6 @@
 
 <h2 class="section-divider" id="razdwa-rezultat">Część 9: Podsumowanie Projektu i Metryki Sukcesu</h2>
 
-<div class="kwcs-sec" id="zakres">
-  <div class="wrap kwcs-trio">
-    <article class="kwcs-card">
-      <h3>Stan początkowy i wyzwania</h3>
-      <ul>
-        <li><strong>Ryzyko operacyjne:</strong> Ręczna wycena w arkuszach generująca błędy przy rysunkach CAD.</li>
-        <li><strong>Silosy informacyjne:</strong> Brak centralnego rejestru zamówień oraz trudna aktualizacja stawek.</li>
-        <li><strong>Infrastruktura:</strong> Praca w warunkach produkcyjnych o zmiennej stabilności sieci.</li>
-        <li><strong>Bariera wejścia:</strong> Wymóg prostego interfejsu niewymagającego szkoleń stanowiskowych.</li>
-      </ul>
-    </article>
-
-    <article class="kwcs-card">
-      <h3>Wdrożone rozwiązania i ROI</h3>
-      <ul>
-        <li><strong>Automatyzacja:</strong> Parser CAD redukuje czas analizy formatu plików do zera.</li>
-        <li><strong>Efektywność:</strong> Skrócenie czasu kalkulacji z 60 minut do poniżej 5 minut (optymalizacja o 90%).</li>
-        <li><strong>Koszty:</strong> Standard PWA offline-first wyeliminował wydatki na serwery i bazy danych.</li>
-        <li><strong>Bezpieczeństwo:</strong> Redukcja pomyłek finansowych dzięki obliczeniom na groszach.</li>
-      </ul>
-    </article>
-
-    <article class="kwcs-card">
-      <h3>Stack technologiczny</h3>
-      <ul>
-        <li><strong>Vanilla TypeScript + esbuild:</strong> Lekka paczka produkcyjna bez narzutu frameworków.</li>
-        <li><strong>Service Worker & Grid:</strong> Obsługa trybu offline i responsywny układ layoutu.</li>
-        <li><strong>Zod & pdf-lib:</strong> Walidacja schematów JSON i generowanie raportów PDF po stronie klienta.</li>
-        <li><strong>Google Apps Script:</strong> Bezserwerowe API przesyłające dane bezpośrednio do Google Sheets.</li>
-      </ul>
-    </article>
-  </div>
-</div>
-
 <div class="kwcs-sec" id="rezultat">
   <div class="wrap">
     <div class="kwcs-result">
@@ -1102,7 +949,7 @@
       </a>
 
       <div class="result-next">
-        <h4 id="razdwa-rezultat-dalej" style="font-size:1.5rem; margin-bottom:1rem;">Kierunki dalszego rozwoju (Roadmap)</h4>
+        <h4 style="font-size:1.5rem; margin-bottom:1rem;">Kierunki dalszego rozwoju (Roadmap)</h4>
         <p>
           Kolejnym krokiem jest integracja natywnego parsera plików DWG/DXF do bezpośredniej analizy rysunków technicznych w przeglądarce. Planowane jest także uruchomienie Portalu Klienta z systemem uprawnień, maskowaniem marż operacyjnych oraz integracją płatności online.
         </p>


### PR DESCRIPTION
## Pakiet 1 z krytycznego audytu — usunięcie System UI, scal Architektury, uproszczenie railu

## 1. Final diff

```
 projects/razdwa_aplikacja.html | 235 +++++----------------------------
 1 file changed, 41 insertions(+), 194 deletions(-)
```

Tylko jeden plik. Zero zmian w CSS/JS — sekcja System UI używała klas `.razdwa-systemui`, `.systemui-card`, `.systemui-swatch` itd., ale to `display: grid` + tła — nie trzeba ich usuwać z CSS, pozostają jako martwy kod do osobnego sprzątania.

## 2. Co dokładnie usunięte

| Element | Powód |
|---|---|
| **Cała sekcja „Część 7: System UI i Tokeny Projektowe"** (~110 linii) | Pokazywała klasy CSS portfolio (`.razdwa-stat`, `.eco-node`, `.contribution-cell` itd.), nie tokens aplikacji RAZDWA. Pomyłka w warstwie abstrakcji — najsłabszy sygnał case study'a. |
| **kwcs-trio w Rezultacie** (3 karty: Stan początkowy / Wdrożone rozwiązania / Stack technologiczny, ~40 linii) | Dubeltowała summary i Decyzje produktowe. Cztery podsumowania w jednej sekcji końcowej. |
| **L1 „System UI" w railu** | Sekcja usunięta. |
| **L1 „Architektura ekosystemu" w railu** (jako standalone L1) | Przeniesiona do Części 6. |
| **L2 „Co dalej z projektem" w railu** | Anchor na 2 zdania w Roadmap — niewart osobnego punktu nawigacyjnego. |
| **L2 „Dlaczego osobno od cennika" w railu** | Orphan — h3 z ID `razdwa-warianty-osobno` zniknęło w ręcznych edytach main. |
| **L2 „Pięć etapów" w railu** | Orphan — h3 z ID `razdwa-droga-etapy` zniknęło w ręcznych edytach main. |
| **ID `razdwa-rezultat-dalej`** | Anchor wycięty z railu, ID stało się martwe. |

## 3. Co zostało przeniesione

**„Architektura ekosystemu"** (40-linijkowy blok z `razdwa-ecosystem-row` × 3 + 5 eco-node) wycięty z pozycji 4 (między Kontekstem a Decyzjami) i wklejony do Części 6 jako **pierwszy** podpunkt — przed h3 „Architektura: Rozdzielenie odpowiedzialności (SoC)".

Nowy h3: **„Ekosystem — widok wysokopoziomowy"** z `id="razdwa-architektura-ekosystem"` (ten sam ID co poprzednio na sekcji standalone — anchory zewnętrzne nadal działają).

W railu pojawia się jako nowy L2 wpis: „Ekosystem (high-level)" zaraz po L1 „Część 6 · Architektura i Integracje".

## 4. Czy rail ma 28 wpisów?

**Nie — ma 26.** Wytłumaczenie:

Plan zakładał:
- 30 → 28 (cele audytu: −1 System UI L1, −1 Architektura ekosystemu L1, +1 Ekosystem L2, −1 Co dalej L2 = 30 − 2 = 28).

Po ręcznych edytach w `main` (commity `ddfed93`, `59cfb34` po zmergowaniu #57) zniknęły dwa śródnagłówki h3 w sekcjach Warianty i Droga zamówienia. Anchory L2 w railu wskazywały na ich ID i stały się **orphanami** (broken linki). Musiałem je usunąć z railu, żeby nawigacja była spójna.

**Sanity check skryptem:**
```
Rail count: 26
Missing targets: NONE
Orphan IDs: NONE
```

Wszystkie 26 linków prowadzą do istniejących ID. Brak duplikatów. Brak martwych anchorów.

## 5. Czy nie ma duplikacji „−90% / 5 min"?

**W sekcji Rezultat — nie. Występuje dokładnie raz**, w pierwszym result-card („Optymalizacja czasu" → „Skrócenie wyceny złożonych pakietów inżynieryjnych z godziny do poniżej 5 minut").

Pozostałe wzmianki metryki w pliku (poza scope tego pakietu, zgodnie z Twoim wskazaniem „nie ruszaj jeszcze całej reszty"):
- linia 9, 16, 25 — meta tags (`<title>`, og:title, twitter:title)
- linia 46 — h1 hero („skróciła wycenę z godziny do około 5 minut")
- linia 57 — meta-row hero („Wynik: ok. −90% czasu wyceny")
- linia 96 — summary cell „Problem" (godziny jako stan początkowy)
- linia 108 — summary cell „Wynik" („~5 min zamiast godziny (ok. −90%)")
- linia 212–213 — Kontekst stats („~5 min" + „czas wyceny (wcześniej ok. godziny)")

Razem **6 wystąpień poza Rezultatem** + 1 w Rezultacie. Decyzja w następnym pakiecie: które z 6 zostają, które wycinamy. Hero meta-row + summary cell + Kontekst stats — kandydaci do dalszego sprzątania.

## 6. Kolejność rail po cleanupu (26 wpisów)

```
 1. W skrócie
 2. Moja rola
 3. Kontekst
 4. Decyzje produktowe
       Jak rozpoznałem problem
       Kluczowe decyzje produktowe
       Zakres dostarczony
 5. Role i persony
 6. Część 1 · Interfejs i UX
       Kluczowe decyzje UX
 7. Część 2 · Kalkulator CAD
       Logika CAD (deep dive)
 8. Część 3 · Panel administracyjny
       Co panel pozwala zrobić
       Bramka PIN
 9. Część 4 · Warianty produktów
10. Część 5 · Droga zamówienia
11. Część 6 · Architektura i Integracje
       Ekosystem (high-level)        ⬅ NOWE, przeniesione z pozycji 4
       Pięć warstw
       Integracje
       Testy automatyczne
12. Potencjał B2B
       Specyficzne dla poligrafii
       Uniwersalne moduły
13. Rezultat
```

L1: 13 (było 15). L2: 13 (było 15). Razem 26.

## Co NIE w tym pakiecie

Z planu audytu na kolejne pakiety:
- **Lessons learned** (zatwierdzone, ale do kolejnego pakietu — krótka sekcja przed Rezultatem)
- **Decyzje produktowe** — połączenie „Dlaczego" + „Kontekst decyzji" w 1 paragraf per decyzja
- **Potencjał B2B** — wycięcie trio z branżami spekulatywnymi
- **Część 3 Panel admina** — usunięcie duplikacji PIN w 3 miejscach
- **Metryka w hero / summary / Kontekst** — decyzja które zostają

## Konflikty
**Brak.** Branch off świeżego main (HEAD `59cfb34`). Diff dotyka tylko `projects/razdwa_aplikacja.html`.

## Test plan
- [ ] Sekcja „Część 7: System UI…" zniknęła z dokumentu.
- [ ] „Architektura ekosystemu" (z eco-node diagramem) widoczna w Części 6 jako pierwszy podpunkt, z h3 „Ekosystem — widok wysokopoziomowy".
- [ ] Rail ma 26 widocznych pigułek (15 L1 + 11 L2).
- [ ] Klik na każdy z 26 wpisów → smooth scroll do istniejącej sekcji.
- [ ] Rezultat („Część 9") — metryka „5 min zamiast godziny" pojawia się tylko raz, w pierwszej result-card.
- [ ] Roadmap (Co dalej z projektem) nadal widoczny w sekcji Rezultat — usunięty tylko anchor.
- [ ] Brak konsolowych errorów.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNi6jDQsDLXyrD4mEe2weo)_