### PR TITLE
RAZDWA cleanup pkg 2: Lessons learned przed Rezultatem

### DIFF
--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -193,6 +193,7 @@
         <li><a class="razdwa-chapter-link" href="#razdwa-potencjal" data-rail-target="razdwa-potencjal" title="Potencjał B2B" aria-label="Potencjał B2B">Potencjał B2B</a></li>
         <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-potencjal-poligrafia" data-rail-target="razdwa-potencjal-poligrafia" title="Specyficzne dla poligrafii" aria-label="Specyficzne dla poligrafii">Specyficzne dla poligrafii</a></li>
         <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-potencjal-uniwersalne" data-rail-target="razdwa-potencjal-uniwersalne" title="Uniwersalne moduły" aria-label="Uniwersalne moduły">Uniwersalne moduły</a></li>
+        <li><a class="razdwa-chapter-link" href="#razdwa-lessons" data-rail-target="razdwa-lessons" title="Lessons learned" aria-label="Lessons learned">Lessons learned</a></li>
         <li><a class="razdwa-chapter-link" href="#razdwa-rezultat" data-rail-target="razdwa-rezultat" title="Rezultat" aria-label="Rezultat">Rezultat</a></li>
       </ul>
     </nav>
@@ -906,6 +907,34 @@
           <li><strong>Stabilność rdzenia:</strong> Warstwy interfejsu, logiki i persystencji pozostają nienaruszone.</li>
         </ul>
       </article>
+    </div>
+  </div>
+</div>
+
+<h2 class="section-divider" id="razdwa-lessons">Lessons learned</h2>
+
+<div class="kwcs-sec" style="background:#f8fafc;">
+  <div class="wrap">
+    <p style="max-width:760px; margin:0 auto 2rem; text-align:center; color:#475569;">
+      Trzy rzeczy, które zostały po dostarczeniu produktu i które zabieram do następnego projektu.
+    </p>
+
+    <div class="ux-decision-grid">
+      <div class="ux-decision-box">
+        <div class="ux-label">Co zrobiłbym inaczej</div>
+        <h4>Zacząć od shadowingu operatora, nie od rozmowy z klientem</h4>
+        <p>Wymagania właścicielki dotyczyły funkcji („chcę panelu z PIN"), a operator pokazywał blokery procesu („przepisuję ten sam wymiar trzy razy"). Gdybym zaczynał ponownie, jedna zmiana w drukarni przed pierwszą rozmową z klientem skróciłaby fazę odkrywania o około miesiąc.</p>
+      </div>
+      <div class="ux-decision-box">
+        <div class="ux-label">Co zaskoczyło</div>
+        <h4>Środowisko wymusza architekturę bardziej niż preferencje techniczne</h4>
+        <p>Brak stabilnego internetu w warsztacie i klient czekający przy ladzie wymusiły decyzje, które inaczej trudno byłoby uzasadnić — PWA offline, panel z PIN, eksport PDF lokalnie. Ograniczenia środowiska okazały się silniejszym argumentem niż czysta inżynieria.</p>
+      </div>
+      <div class="ux-decision-box">
+        <div class="ux-label">Co zmieniło się w iteracji 2</div>
+        <h4>System wariantów własnych powstał z obserwacji, nie z briefu</h4>
+        <p>„Wizytówki Premium" jako odrębna pozycja w cenniku — to wynik obserwacji, że klient zamawia z nazwy produktu, a nie ze specyfikacji. Zmiana architektury wariantów, której nie przewidziałem w MVP, ale która okazała się kluczowa dla codziennej obsługi zleceń.</p>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Pakiet 2 — Lessons learned przed Rezultatem

Z trzech zatwierdzonych punktów pakietu 2 **dwa były już zrealizowane** wcześniej. Realnie w tym PR-e tylko Lessons learned.

## 1. Ile słów zostało w Decyzjach produktowych

**272 słowa** (cel ~450).

Manual edits w `main` (commity `ddfed93`, `59cfb34` po #57) już skróciły każdą z 4 decyzji do jednego paragrafu po 23–28 słów:

| Decyzja | Słów |
|---|---|
| Decyzja 1 · Architektura (PWA zamiast SaaS) | 28 |
| Decyzja 2 · Zaplecze (Google zamiast SQL) | 24 |
| Decyzja 3 · Utrzymanie (panel admina) | 24 |
| Decyzja 4 · Frontend (TypeScript + esbuild) | 23 |

Plus „Rozpoznanie problemu" (2 boxy, ~55 słów) i „Ewolucja produktu" (3 karty MVP/Iter 2/Backlog z bulletami, ~70 słów). **Każda decyzja ma już jeden paragraf — `Dlaczego` + `Kontekst decyzji` zostały zwinięte w syntezę.** Nic do cięcia.

## 2. Pełny tekst Lessons learned (do zatwierdzenia)

Trzy `ux-decision-box` w jednym `kwcs-sec` ze stylem szarawego tła (jak Role i persony) dla konsystencji wizualnej.

> ### Lessons learned
>
> Trzy rzeczy, które zostały po dostarczeniu produktu i które zabieram do następnego projektu.

---

**Box 1 — etykieta „Co zrobiłbym inaczej"**

> **Zacząć od shadowingu operatora, nie od rozmowy z klientem**
>
> Wymagania właścicielki dotyczyły funkcji („chcę panelu z PIN"), a operator pokazywał blokery procesu („przepisuję ten sam wymiar trzy razy"). Gdybym zaczynał ponownie, jedna zmiana w drukarni przed pierwszą rozmową z klientem skróciłaby fazę odkrywania o około miesiąc.

**Box 2 — etykieta „Co zaskoczyło"**

> **Środowisko wymusza architekturę bardziej niż preferencje techniczne**
>
> Brak stabilnego internetu w warsztacie i klient czekający przy ladzie wymusiły decyzje, które inaczej trudno byłoby uzasadnić — PWA offline, panel z PIN, eksport PDF lokalnie. Ograniczenia środowiska okazały się silniejszym argumentem niż czysta inżynieria.

**Box 3 — etykieta „Co zmieniło się w iteracji 2"**

> **System wariantów własnych powstał z obserwacji, nie z briefu**
>
> „Wizytówki Premium" jako odrębna pozycja w cenniku — to wynik obserwacji, że klient zamawia z nazwy produktu, a nie ze specyfikacji. Zmiana architektury wariantów, której nie przewidziałem w MVP, ale która okazała się kluczowa dla codziennej obsługi zleceń.

**Razem: 6 zdań, ~160 słów.**

Jeśli któryś box chcesz przepisać / zmienić ton / wyciąć — daj znać konkretnie, poprawiam i pushuję commit do tego samego PR-a.

## 3. Czy Rezultat ma teraz maks. 3 elementy?

**Tak.** Sanity check skryptem:
```
result-lead:  1
result-cards: 1
result-next:  1
kwcs-trio:    0
```

`kwcs-trio` usunięte w pakiecie 1 (#58, już zmergowane do main). Rezultat ma teraz dokładnie `result-lead → result-cards → result-next` w tej kolejności, plus CTA „Uruchom aplikację" pomiędzy cards a next.

## Rail po pakiecie 2

```
 1. W skrócie
 2. Moja rola
 3. Kontekst
 4. Decyzje produktowe + 3 L2
 5. Role i persony
 6. Część 1 · UX + L2
 7. Część 2 · CAD + L2
 8. Część 3 · Panel + 2 L2
 9. Część 4 · Warianty
10. Część 5 · Droga zamówienia
11. Część 6 · Architektura i Integracje + 4 L2
12. Potencjał B2B + 2 L2
13. Lessons learned                  ⬅ NOWE
14. Rezultat
```

**26 → 27 wpisów** (15 L1 + 12 L2). Brak orphan ID, brak duplikatów.

## Diff
```
projects/razdwa_aplikacja.html | 29 +++++++++++++++++++++++++++++
1 file changed, 29 insertions(+)
```

Jeden plik. Zero CSS (Lessons learned używa istniejących klas `ux-decision-grid`, `ux-decision-box`, `ux-label`, `kwcs-sec`).

## Co NIE w tym pakiecie (zgodnie z Twoim zakresem)
- Potencjał B2B (cięcie trio z branżami)
- Role i persony (wzmocnienie lub redukcja)
- Część 3 Panel admina (duplikacja PIN)
- Część 5 Droga zamówienia
- Metryka „−90% / 5 min" w hero / summary / Kontekst stats

## Test plan
- [ ] Sekcja „Lessons learned" widoczna między Potencjałem B2B a Rezultatem (Część 9).
- [ ] Trzy boxy: „Co zrobiłbym inaczej" / „Co zaskoczyło" / „Co zmieniło się w iteracji 2".
- [ ] Klik na „Lessons learned" w railu → smooth scroll do nowej sekcji.
- [ ] Inne case studies bez regresji.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNi6jDQsDLXyrD4mEe2weo)_