### PR TITLE
RAZDWA: redesign railu — collapsible groups (desktop) + drawer (mobile)

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -2709,49 +2709,218 @@ body.lightbox-open {
   #case-razdwa-pelne { padding-left: 232px; }
 }
 
-/* Tablet i mobile ≤1100px — fixed top bar z poziomym scrollem pigułek */
+/* ── Desktop ≥1101px — collapsible groups w sticky sidebarze ── */
+.razdwa-rail-mobile-trigger { display: none; }
+.razdwa-rail-backdrop { display: none; }
+.razdwa-rail-close { display: none; }
+.razdwa-rail-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.4rem;
+}
+.razdwa-rail-group-head {
+  display: flex;
+  align-items: center;
+  gap: 0.15rem;
+}
+.razdwa-rail-group-head .razdwa-chapter-link { flex: 1 1 auto; min-width: 0; }
+.razdwa-rail-toggle {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: #94a3b8;
+  cursor: pointer;
+  padding: 0.3rem 0.35rem;
+  border-radius: 0.3rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.18s ease, color 0.18s ease, background 0.18s ease;
+}
+.razdwa-rail-toggle:hover { color: #06b6d4; background: #f1f5f9; }
+.razdwa-rail-toggle:focus-visible { outline: 2px solid #06b6d4; outline-offset: 1px; }
+.razdwa-rail-toggle[aria-expanded="true"] { transform: rotate(180deg); color: #0284c7; }
+
+.razdwa-rail-sub {
+  list-style: none;
+  padding: 0;
+  margin: 0.1rem 0 0.25rem;
+  display: none;
+}
+.razdwa-rail-sub li { margin: 0; }
+.razdwa-rail-sub li::before { content: none !important; }
+.razdwa-rail-group[data-open="true"] > .razdwa-rail-sub { display: block; }
+
+/* ── Mobile ≤1100px — floating button + bottom sheet drawer ── */
 @media (max-width: 1100px) {
+  /* Hostujący <nav> nie rysuje już żadnej pigułki — jest tylko kontenerem */
   .razdwa-chapter-rail {
-    left: 12px;
-    right: 12px;
-    top: 12px;
+    position: fixed;
+    inset: auto auto 16px 16px;
+    right: 16px;
+    top: auto;
     transform: none;
     width: auto;
     max-width: none;
     max-height: none;
-    padding: 0.55rem 0.7rem;
-    border-radius: 0.7rem;
+    padding: 0;
+    margin: 0;
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    overflow: visible;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
   }
-  .razdwa-chapter-rail-label { display: none; }
+
+  /* Floating trigger button — prawy dolny róg z safe-area-inset */
+  .razdwa-rail-mobile-trigger {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-left: auto;
+    background: #0284c7;
+    color: #fff;
+    border: none;
+    border-radius: 9999px;
+    padding: 0.6rem 1rem 0.6rem 0.8rem;
+    box-shadow: 0 14px 30px -10px rgba(2, 132, 199, 0.55);
+    cursor: pointer;
+    font-family: inherit;
+    margin-bottom: calc(env(safe-area-inset-bottom, 0px));
+  }
+  .razdwa-rail-mobile-trigger:focus-visible {
+    outline: 3px solid #06b6d4;
+    outline-offset: 3px;
+  }
+  .razdwa-rail-mobile-icon { font-size: 1.1rem; line-height: 1; }
+  .razdwa-rail-mobile-text {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    line-height: 1.15;
+    max-width: 55vw;
+  }
+  .razdwa-rail-mobile-text small {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.85;
+  }
+  .razdwa-rail-mobile-text strong {
+    font-size: 0.9rem;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+  }
+
+  /* Bottom sheet (panel) — domyślnie schowany pod krawędzią */
+  .razdwa-rail-panel {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    top: auto;
+    max-height: 80vh;
+    overflow-y: auto;
+    background: #fff;
+    border-radius: 1rem 1rem 0 0;
+    padding: 1rem 1.1rem calc(1.5rem + env(safe-area-inset-bottom, 0px));
+    transform: translateY(100%);
+    transition: transform 0.32s cubic-bezier(0.16, 0.84, 0.44, 1);
+    z-index: 60;
+    box-shadow: 0 -20px 50px -16px rgba(15, 23, 42, 0.35);
+    visibility: hidden;
+  }
+  body.razdwa-rail-open .razdwa-rail-panel {
+    transform: translateY(0);
+    visibility: visible;
+  }
+  .razdwa-rail-panel-head {
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.6rem;
+    border-bottom: 1px solid #f1f5f9;
+  }
+  .razdwa-chapter-rail-label {
+    margin: 0;
+    padding: 0;
+    border: none;
+    text-align: left;
+  }
+  .razdwa-rail-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: #f1f5f9;
+    border: none;
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
+    font-size: 1.4rem;
+    line-height: 1;
+    color: #475569;
+    cursor: pointer;
+  }
+  .razdwa-rail-close:focus-visible { outline: 2px solid #06b6d4; outline-offset: 2px; }
+
+  /* Backdrop */
+  .razdwa-rail-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.24s ease, visibility 0.24s ease;
+    z-index: 55;
+  }
+  body.razdwa-rail-open .razdwa-rail-backdrop {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  /* W drawerze cała lista to pionowy układ pełnowymiarowych linków,
+     L2 ZAWSZE rozwinięte (brak toggle button) */
   .razdwa-chapter-rail-list {
-    flex-direction: row;
+    flex-direction: column;
     flex-wrap: nowrap;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    gap: 0.35rem;
+    overflow: visible;
+    gap: 0.05rem;
   }
+  .razdwa-rail-toggle { display: none; }
+  .razdwa-rail-sub { display: block; padding-left: 0.5rem; margin: 0.1rem 0 0.4rem; border-left: 2px solid #e2e8f0; }
+  .razdwa-rail-group-head .razdwa-chapter-link { padding-right: 0.7rem; }
+
   .razdwa-chapter-link {
     flex-shrink: 0;
-    white-space: nowrap;
-    background: #f1f5f9;
-    border: 1px solid #e2e8f0;
-    border-radius: 9999px;
-    padding: 0.3rem 0.7rem;
-    font-size: 0.78rem;
+    display: block;
+    white-space: normal;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 0.5rem;
+    padding: 0.55rem 0.7rem;
+    font-size: 0.92rem;
     color: #0f172a;
+    width: 100%;
+    text-align: left;
+    line-height: 1.35;
   }
   .razdwa-chapter-link:hover {
-    background: #06b6d4;
-    border-color: #06b6d4;
-    color: #fff;
+    background: #f1f5f9;
+    color: #0f172a;
   }
-  /* Mobile L2 — mniejsza pigułka, słabszy kontrast (bez wcięcia, bo top bar
-     jest horyzontalny — wcięcie nie ma sensu, hierarchia przez rozmiar) */
+  .razdwa-chapter-link.is-active {
+    background: #0284c7;
+    color: #fff;
+    border-color: #0284c7;
+  }
   .razdwa-chapter-link[data-rail-level="2"] {
-    padding: 0.2rem 0.55rem;
-    font-size: 0.7rem;
-    background: #f8fafc;
-    color: #64748b;
+    padding: 0.4rem 0.65rem;
+    font-size: 0.82rem;
+    color: #475569;
   }
   .razdwa-chapter-link[data-rail-level="2"]::before { content: none !important; }
   .razdwa-chapter-link[data-rail-level="2"].is-active {
@@ -2759,7 +2928,8 @@ body.lightbox-open {
     color: #0284c7;
     border-color: #bae6fd;
   }
-  /* Mobile top bar nie wymaga marginesu sekcji */
+
+  /* Mobile drawer nie wymaga padding-left sekcji */
   #case-razdwa-pelne { padding-left: 0; }
 }
 

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -233,6 +233,11 @@ document.addEventListener('DOMContentLoaded', () => {
       window.__razdwaRailObserver.disconnect();
       window.__razdwaRailObserver = null;
     }
+    if (window.__razdwaRailEscHandler) {
+      document.removeEventListener('keydown', window.__razdwaRailEscHandler);
+      window.__razdwaRailEscHandler = null;
+    }
+    document.body.classList.remove('razdwa-rail-open');
   }
 
   function initializeChapterRail() {
@@ -253,6 +258,54 @@ document.addEventListener('DOMContentLoaded', () => {
     const getTargetId = (link) =>
       link.dataset.railTarget || (link.getAttribute('href') || '').replace('#', '');
 
+    const trigger = rail.querySelector('.razdwa-rail-mobile-trigger');
+    const triggerLabel = trigger ? trigger.querySelector('[data-current-section]') : null;
+    const closeBtn = rail.querySelector('.razdwa-rail-close');
+    const backdrop = rail.querySelector('[data-rail-backdrop]');
+    const toggles = Array.from(rail.querySelectorAll('.razdwa-rail-toggle'));
+    const labelByTarget = Object.fromEntries(
+      links.map(l => [getTargetId(l), l.textContent.trim()])
+    );
+
+    // Drawer open/close (mobile)
+    const openDrawer = () => {
+      document.body.classList.add('razdwa-rail-open');
+      if (trigger) trigger.setAttribute('aria-expanded', 'true');
+    };
+    const closeDrawer = () => {
+      document.body.classList.remove('razdwa-rail-open');
+      if (trigger) trigger.setAttribute('aria-expanded', 'false');
+    };
+    if (trigger) {
+      trigger.addEventListener('click', () => {
+        if (document.body.classList.contains('razdwa-rail-open')) closeDrawer();
+        else openDrawer();
+      });
+    }
+    if (closeBtn) closeBtn.addEventListener('click', closeDrawer);
+    if (backdrop) backdrop.addEventListener('click', closeDrawer);
+    const escHandler = (e) => {
+      if (e.key === 'Escape' && document.body.classList.contains('razdwa-rail-open')) {
+        closeDrawer();
+      }
+    };
+    document.addEventListener('keydown', escHandler);
+    window.__razdwaRailEscHandler = escHandler;
+
+    // Toggle buttons (desktop collapsible groups)
+    toggles.forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const group = btn.closest('.razdwa-rail-group');
+        if (!group) return;
+        const isOpen = group.getAttribute('data-open') === 'true';
+        group.setAttribute('data-open', isOpen ? 'false' : 'true');
+        btn.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+      });
+    });
+
+    // Link clicks — scroll, set active, close drawer
     links.forEach(link => {
       link.addEventListener('click', (e) => {
         e.preventDefault();
@@ -262,9 +315,11 @@ document.addEventListener('DOMContentLoaded', () => {
         target.scrollIntoView({ behavior: 'smooth', block: 'start' });
         links.forEach(l => l.classList.remove('is-active'));
         link.classList.add('is-active');
+        closeDrawer();
       });
     });
 
+    // Scroll spy
     const targets = links
       .map(link => document.getElementById(getTargetId(link)))
       .filter(Boolean);
@@ -277,6 +332,20 @@ document.addEventListener('DOMContentLoaded', () => {
           links.forEach(l => {
             l.classList.toggle('is-active', getTargetId(l) === id);
           });
+          // Update mobile trigger label
+          if (triggerLabel && labelByTarget[id]) {
+            triggerLabel.textContent = labelByTarget[id];
+          }
+          // Auto-expand parent group when L2 is active
+          const activeLink = links.find(l => getTargetId(l) === id);
+          if (activeLink && activeLink.dataset.railLevel === '2') {
+            const parentGroup = activeLink.closest('.razdwa-rail-group');
+            if (parentGroup) {
+              parentGroup.setAttribute('data-open', 'true');
+              const toggleBtn = parentGroup.querySelector('.razdwa-rail-toggle');
+              if (toggleBtn) toggleBtn.setAttribute('aria-expanded', 'true');
+            }
+          }
         });
       }, {
         rootMargin: '-30% 0px -60% 0px',

--- a/assets/js/projects.js
+++ b/assets/js/projects.js
@@ -252,6 +252,49 @@ function initChapterRail() {
   const getTargetId = (link) =>
     link.dataset.railTarget || (link.getAttribute('href') || '').replace('#', '');
 
+  const trigger = rail.querySelector('.razdwa-rail-mobile-trigger');
+  const triggerLabel = trigger ? trigger.querySelector('[data-current-section]') : null;
+  const closeBtn = rail.querySelector('.razdwa-rail-close');
+  const backdrop = rail.querySelector('[data-rail-backdrop]');
+  const toggles = Array.from(rail.querySelectorAll('.razdwa-rail-toggle'));
+  const labelByTarget = Object.fromEntries(
+    links.map(l => [getTargetId(l), l.textContent.trim()])
+  );
+
+  const openDrawer = () => {
+    document.body.classList.add('razdwa-rail-open');
+    if (trigger) trigger.setAttribute('aria-expanded', 'true');
+  };
+  const closeDrawer = () => {
+    document.body.classList.remove('razdwa-rail-open');
+    if (trigger) trigger.setAttribute('aria-expanded', 'false');
+  };
+  if (trigger) {
+    trigger.addEventListener('click', () => {
+      if (document.body.classList.contains('razdwa-rail-open')) closeDrawer();
+      else openDrawer();
+    });
+  }
+  if (closeBtn) closeBtn.addEventListener('click', closeDrawer);
+  if (backdrop) backdrop.addEventListener('click', closeDrawer);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && document.body.classList.contains('razdwa-rail-open')) {
+      closeDrawer();
+    }
+  });
+
+  toggles.forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const group = btn.closest('.razdwa-rail-group');
+      if (!group) return;
+      const isOpen = group.getAttribute('data-open') === 'true';
+      group.setAttribute('data-open', isOpen ? 'false' : 'true');
+      btn.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+    });
+  });
+
   links.forEach(link => {
     link.addEventListener('click', (e) => {
       e.preventDefault();
@@ -261,6 +304,7 @@ function initChapterRail() {
       target.scrollIntoView({ behavior: 'smooth', block: 'start' });
       links.forEach(l => l.classList.remove('is-active'));
       link.classList.add('is-active');
+      closeDrawer();
     });
   });
 
@@ -276,6 +320,18 @@ function initChapterRail() {
         links.forEach(l => {
           l.classList.toggle('is-active', getTargetId(l) === id);
         });
+        if (triggerLabel && labelByTarget[id]) {
+          triggerLabel.textContent = labelByTarget[id];
+        }
+        const activeLink = links.find(l => getTargetId(l) === id);
+        if (activeLink && activeLink.dataset.railLevel === '2') {
+          const parentGroup = activeLink.closest('.razdwa-rail-group');
+          if (parentGroup) {
+            parentGroup.setAttribute('data-open', 'true');
+            const toggleBtn = parentGroup.querySelector('.razdwa-rail-toggle');
+            if (toggleBtn) toggleBtn.setAttribute('aria-expanded', 'true');
+          }
+        }
       });
     }, {
       rootMargin: '-30% 0px -60% 0px',

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -166,36 +166,78 @@
          Chapter rail — sticky TOC z internal anchors
     ============================================================ -->
     <nav class="razdwa-chapter-rail" id="razdwa-chapter-rail" aria-label="Spis treści case study">
-      <div class="razdwa-chapter-rail-label">Rozdziały</div>
-      <ul class="razdwa-chapter-rail-list">
-        <li><a class="razdwa-chapter-link" href="#razdwa-summary" data-rail-target="razdwa-summary" title="W skrócie" aria-label="W skrócie">W skrócie</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-contribution" data-rail-target="razdwa-contribution" title="Moja rola" aria-label="Moja rola">Moja rola</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-kontekst" data-rail-target="razdwa-kontekst" title="Kontekst" aria-label="Kontekst">Kontekst</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-decyzje" data-rail-target="razdwa-decyzje" title="Decyzje produktowe" aria-label="Decyzje produktowe">Decyzje produktowe</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-decyzje-problem" data-rail-target="razdwa-decyzje-problem" title="Jak rozpoznałem problem" aria-label="Jak rozpoznałem problem">Jak rozpoznałem problem</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-decyzje-kluczowe" data-rail-target="razdwa-decyzje-kluczowe" title="Kluczowe decyzje produktowe" aria-label="Kluczowe decyzje produktowe">Kluczowe decyzje produktowe</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-decyzje-zakres" data-rail-target="razdwa-decyzje-zakres" title="Zakres dostarczony" aria-label="Zakres dostarczony">Zakres dostarczony</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-role" data-rail-target="razdwa-role" title="Role i persony" aria-label="Role i persony">Role i persony</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-ux" data-rail-target="razdwa-ux" title="Część 1: Interfejs i UX" aria-label="Część 1: Interfejs i UX">Część 1 · Interfejs i UX</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-ux-decyzje" data-rail-target="razdwa-ux-decyzje" title="Kluczowe decyzje UX" aria-label="Kluczowe decyzje UX">Kluczowe decyzje UX</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-cad" data-rail-target="razdwa-cad" title="Część 2: Kalkulator CAD" aria-label="Część 2: Kalkulator CAD">Część 2 · Kalkulator CAD</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-cad-logika" data-rail-target="razdwa-cad-logika" title="Logika CAD (deep dive)" aria-label="Logika CAD (deep dive)">Logika CAD (deep dive)</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-panel" data-rail-target="razdwa-panel" title="Część 3: Panel administracyjny" aria-label="Część 3: Panel administracyjny">Część 3 · Panel administracyjny</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-panel-funkcje" data-rail-target="razdwa-panel-funkcje" title="Co panel pozwala zrobić" aria-label="Co panel pozwala zrobić">Co panel pozwala zrobić</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-panel-pin" data-rail-target="razdwa-panel-pin" title="Bramka PIN" aria-label="Bramka PIN">Bramka PIN</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-warianty" data-rail-target="razdwa-warianty" title="Część 4: Warianty produktów" aria-label="Część 4: Warianty produktów">Część 4 · Warianty produktów</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-droga" data-rail-target="razdwa-droga" title="Część 5: Droga zamówienia" aria-label="Część 5: Droga zamówienia">Część 5 · Droga zamówienia</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-architektura" data-rail-target="razdwa-architektura" title="Część 6: Architektura i Integracje" aria-label="Część 6: Architektura i Integracje">Część 6 · Architektura i Integracje</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-ekosystem" data-rail-target="razdwa-architektura-ekosystem" title="Ekosystem (high-level)" aria-label="Ekosystem (high-level)">Ekosystem (high-level)</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-warstwy" data-rail-target="razdwa-architektura-warstwy" title="Pięć warstw" aria-label="Pięć warstw">Pięć warstw</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-integracje" data-rail-target="razdwa-architektura-integracje" title="Integracje" aria-label="Integracje">Integracje</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-testy" data-rail-target="razdwa-architektura-testy" title="Testy automatyczne" aria-label="Testy automatyczne">Testy automatyczne</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-potencjal" data-rail-target="razdwa-potencjal" title="Potencjał B2B" aria-label="Potencjał B2B">Potencjał B2B</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-potencjal-poligrafia" data-rail-target="razdwa-potencjal-poligrafia" title="Specyficzne dla poligrafii" aria-label="Specyficzne dla poligrafii">Specyficzne dla poligrafii</a></li>
-        <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-potencjal-uniwersalne" data-rail-target="razdwa-potencjal-uniwersalne" title="Uniwersalne moduły" aria-label="Uniwersalne moduły">Uniwersalne moduły</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-lessons" data-rail-target="razdwa-lessons" title="Lessons learned" aria-label="Lessons learned">Lessons learned</a></li>
-        <li><a class="razdwa-chapter-link" href="#razdwa-rezultat" data-rail-target="razdwa-rezultat" title="Rezultat" aria-label="Rezultat">Rezultat</a></li>
-      </ul>
+      <!-- Mobile-only trigger (button otwierający drawer/sheet) -->
+      <button class="razdwa-rail-mobile-trigger" type="button" aria-controls="razdwa-rail-panel" aria-expanded="false">
+        <span class="razdwa-rail-mobile-icon" aria-hidden="true">☰</span>
+        <span class="razdwa-rail-mobile-text">
+          <small>Spis treści</small>
+          <strong data-current-section>W skrócie</strong>
+        </span>
+      </button>
+
+      <div class="razdwa-rail-panel" id="razdwa-rail-panel">
+        <div class="razdwa-rail-panel-head">
+          <div class="razdwa-chapter-rail-label">Rozdziały</div>
+          <button class="razdwa-rail-close" type="button" aria-label="Zamknij spis treści">&times;</button>
+        </div>
+        <ul class="razdwa-chapter-rail-list">
+          <li><a class="razdwa-chapter-link" href="#razdwa-summary" data-rail-target="razdwa-summary">W skrócie</a></li>
+          <li><a class="razdwa-chapter-link" href="#razdwa-contribution" data-rail-target="razdwa-contribution">Moja rola</a></li>
+          <li><a class="razdwa-chapter-link" href="#razdwa-kontekst" data-rail-target="razdwa-kontekst">Kontekst</a></li>
+
+          <li class="razdwa-rail-group" data-open="false">
+            <div class="razdwa-rail-group-head">
+              <a class="razdwa-chapter-link" href="#razdwa-decyzje" data-rail-target="razdwa-decyzje">Decyzje produktowe</a>
+              <button class="razdwa-rail-toggle" type="button" aria-expanded="false" aria-controls="sub-decyzje" aria-label="Rozwiń podsekcje Decyzje produktowe">
+                <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><polyline points="6 9 12 15 18 9" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+            </div>
+            <ul class="razdwa-rail-sub" id="sub-decyzje">
+              <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-decyzje-problem" data-rail-target="razdwa-decyzje-problem">Jak rozpoznałem problem</a></li>
+              <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-decyzje-kluczowe" data-rail-target="razdwa-decyzje-kluczowe">Kluczowe decyzje produktowe</a></li>
+              <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-decyzje-zakres" data-rail-target="razdwa-decyzje-zakres">Zakres dostarczony</a></li>
+            </ul>
+          </li>
+
+          <li><a class="razdwa-chapter-link" href="#razdwa-ux" data-rail-target="razdwa-ux">Część 1 · Interfejs i UX</a></li>
+          <li><a class="razdwa-chapter-link" href="#razdwa-cad" data-rail-target="razdwa-cad">Część 2 · Kalkulator CAD</a></li>
+
+          <li class="razdwa-rail-group" data-open="false">
+            <div class="razdwa-rail-group-head">
+              <a class="razdwa-chapter-link" href="#razdwa-panel" data-rail-target="razdwa-panel">Część 3 · Panel administracyjny</a>
+              <button class="razdwa-rail-toggle" type="button" aria-expanded="false" aria-controls="sub-panel" aria-label="Rozwiń podsekcje Panel administracyjny">
+                <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><polyline points="6 9 12 15 18 9" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+            </div>
+            <ul class="razdwa-rail-sub" id="sub-panel">
+              <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-panel-pin" data-rail-target="razdwa-panel-pin">Bramka PIN</a></li>
+            </ul>
+          </li>
+
+          <li><a class="razdwa-chapter-link" href="#razdwa-droga" data-rail-target="razdwa-droga">Część 5 · Droga zamówienia</a></li>
+
+          <li class="razdwa-rail-group" data-open="false">
+            <div class="razdwa-rail-group-head">
+              <a class="razdwa-chapter-link" href="#razdwa-architektura" data-rail-target="razdwa-architektura">Część 6 · Architektura i Integracje</a>
+              <button class="razdwa-rail-toggle" type="button" aria-expanded="false" aria-controls="sub-arch" aria-label="Rozwiń podsekcje Architektura i Integracje">
+                <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><polyline points="6 9 12 15 18 9" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+            </div>
+            <ul class="razdwa-rail-sub" id="sub-arch">
+              <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-ekosystem" data-rail-target="razdwa-architektura-ekosystem">Ekosystem (high-level)</a></li>
+              <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-warstwy" data-rail-target="razdwa-architektura-warstwy">Pięć warstw</a></li>
+              <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-integracje" data-rail-target="razdwa-architektura-integracje">Integracje</a></li>
+              <li><a class="razdwa-chapter-link" data-rail-level="2" href="#razdwa-architektura-testy" data-rail-target="razdwa-architektura-testy">Testy automatyczne</a></li>
+            </ul>
+          </li>
+
+          <li><a class="razdwa-chapter-link" href="#razdwa-lessons" data-rail-target="razdwa-lessons">Lessons learned</a></li>
+          <li><a class="razdwa-chapter-link" href="#razdwa-rezultat" data-rail-target="razdwa-rezultat">Rezultat</a></li>
+          <li><a class="razdwa-chapter-link" href="#razdwa-potencjal" data-rail-target="razdwa-potencjal">Potencjał B2B</a></li>
+        </ul>
+      </div>
+
+      <div class="razdwa-rail-backdrop" data-rail-backdrop aria-hidden="true"></div>
     </nav>
 
     <div class="kwcs-sec kwcs-context-section" id="razdwa-kontekst">
@@ -860,57 +902,6 @@
     </div>
   </div>
 </div>
-<h2 class="section-divider" id="razdwa-potencjal">Część 8: Skalowalność i Potencjał Biznesowy</h2>
-
-<div class="kwcs-sec">
-  <div class="wrap">
-    <p style="max-width:760px; margin:0 auto 2rem; text-align:center; color:#475569;">
-      System rozwiązuje uniwersalny problem rynkowy: <strong>jak wdrożyć zaawansowany silnik kalkulacyjny i ewidencję zamówień bez kosztów utrzymania serwerów</strong>. Dzięki separacji warstw, rdzeń aplikacji jest agnostyczny i łatwy do adaptacji w innych branżach.
-    </p>
-
-    <h3 style="text-align:center" id="razdwa-potencjal-poligrafia">Warstwa specyficzna dla domeny (Poligrafia)</h3>
-    <ul style="max-width:760px; margin:0 auto 2rem; color:#475569; line-height:1.7;">
-      <li><strong>Parser wektorowy CAD:</strong> Automatyczna detekcja formatu (A0–A3) z plików wejściowych.</li>
-      <li><strong>Kalkulator liniowy:</strong> Przeliczanie metrów bieżących na podstawie szerokości rolki papieru.</li>
-      <li><strong>Algorytm tolerancji:</strong> Kompensacja niedokładności skanowania w zakresie ±5 mm.</li>
-      <li><strong>Modyfikatory technologiczne:</strong> Narzuty za wykończenie (składanie, oczkowanie, gramatura).</li>
-    </ul>
-
-    <h3 style="text-align:center" id="razdwa-potencjal-uniwersalne">Skalowalność komponentów (Whitelabel Readiness)</h3>
-    <div class="kwcs-trio">
-      <article class="kwcs-card">
-        <h3>Reużywalne moduły jądra</h3>
-        <ul>
-          <li><strong>Silnik koszyka:</strong> Arytmetyka stałoprzecinkowa z obsługą trybu EXPRESS.</li>
-          <li><strong>Silnik cennika:</strong> Wielopoziomowe tabele regresji ilościowej i narzutów.</li>
-          <li><strong>Panel administracyjny:</strong> Bezserwerowe zarządzanie i autoryzacja bramką PIN.</li>
-          <li><strong>Eksport i replikacja:</strong> Generowanie PDF/Excel offline oraz zapis do Google Sheets.</li>
-        </ul>
-      </article>
-      
-      <article class="kwcs-card">
-        <h3>Potencjalne rynki</h3>
-        <ul>
-          <li><strong>Usługi i warsztaty (Automotive):</strong> Wycena roboczogodzin, części i dopłat dynamicznych.</li>
-          <li><strong>Hurtownie i dystrybucja:</strong> Automatyczne cenniki progresywne zależne od wolumenu.</li>
-          <li><strong>Catering i cukiernie:</strong> Wizualny konfigurator specyfikacji zamówienia.</li>
-          <li><strong>Produkcja Custom (Stolarstwo):</strong> Szacowanie kosztów materiału na podstawie wymiarów.</li>
-        </ul>
-      </article>
-      
-      <article class="kwcs-card">
-        <h3>Procedura migracji</h3>
-        <ul>
-          <li><strong>Podmiana procesorów:</strong> Wdrożenie nowych klas obliczeniowych w Feature Layer.</li>
-          <li><strong>Aktualizacja schematu:</strong> Zmiana konfiguracji JSON oraz mapowania bazy danych.</li>
-          <li><strong>Profilowanie widoków:</strong> Dostosowanie pól formularzy do modelu B2B lub B2C.</li>
-          <li><strong>Stabilność rdzenia:</strong> Warstwy interfejsu, logiki i persystencji pozostają nienaruszone.</li>
-        </ul>
-      </article>
-    </div>
-  </div>
-</div>
-
 <h2 class="section-divider" id="razdwa-lessons">Lessons learned</h2>
 
 <div class="kwcs-sec" style="background:#f8fafc;">
@@ -983,6 +974,57 @@
           Kolejnym krokiem jest integracja natywnego parsera plików DWG/DXF do bezpośredniej analizy rysunków technicznych w przeglądarce. Planowane jest także uruchomienie Portalu Klienta z systemem uprawnień, maskowaniem marż operacyjnych oraz integracją płatności online.
         </p>
       </div>
+    </div>
+  </div>
+</div>
+
+<h2 class="section-divider" id="razdwa-potencjal">Potencjał B2B</h2>
+
+<div class="kwcs-sec">
+  <div class="wrap">
+    <p style="max-width:760px; margin:0 auto 2rem; text-align:center; color:#475569;">
+      System rozwiązuje uniwersalny problem rynkowy: <strong>jak wdrożyć zaawansowany silnik kalkulacyjny i ewidencję zamówień bez kosztów utrzymania serwerów</strong>. Dzięki separacji warstw, rdzeń aplikacji jest agnostyczny i łatwy do adaptacji w innych branżach.
+    </p>
+
+    <h3 style="text-align:center" id="razdwa-potencjal-poligrafia">Warstwa specyficzna dla domeny (Poligrafia)</h3>
+    <ul style="max-width:760px; margin:0 auto 2rem; color:#475569; line-height:1.7;">
+      <li><strong>Parser wektorowy CAD:</strong> Automatyczna detekcja formatu (A0–A3) z plików wejściowych.</li>
+      <li><strong>Kalkulator liniowy:</strong> Przeliczanie metrów bieżących na podstawie szerokości rolki papieru.</li>
+      <li><strong>Algorytm tolerancji:</strong> Kompensacja niedokładności skanowania w zakresie ±5 mm.</li>
+      <li><strong>Modyfikatory technologiczne:</strong> Narzuty za wykończenie (składanie, oczkowanie, gramatura).</li>
+    </ul>
+
+    <h3 style="text-align:center" id="razdwa-potencjal-uniwersalne">Skalowalność komponentów (Whitelabel Readiness)</h3>
+    <div class="kwcs-trio">
+      <article class="kwcs-card">
+        <h3>Reużywalne moduły jądra</h3>
+        <ul>
+          <li><strong>Silnik koszyka:</strong> Arytmetyka stałoprzecinkowa z obsługą trybu EXPRESS.</li>
+          <li><strong>Silnik cennika:</strong> Wielopoziomowe tabele regresji ilościowej i narzutów.</li>
+          <li><strong>Panel administracyjny:</strong> Bezserwerowe zarządzanie i autoryzacja bramką PIN.</li>
+          <li><strong>Eksport i replikacja:</strong> Generowanie PDF/Excel offline oraz zapis do Google Sheets.</li>
+        </ul>
+      </article>
+
+      <article class="kwcs-card">
+        <h3>Potencjalne rynki</h3>
+        <ul>
+          <li><strong>Usługi i warsztaty (Automotive):</strong> Wycena roboczogodzin, części i dopłat dynamicznych.</li>
+          <li><strong>Hurtownie i dystrybucja:</strong> Automatyczne cenniki progresywne zależne od wolumenu.</li>
+          <li><strong>Catering i cukiernie:</strong> Wizualny konfigurator specyfikacji zamówienia.</li>
+          <li><strong>Produkcja Custom (Stolarstwo):</strong> Szacowanie kosztów materiału na podstawie wymiarów.</li>
+        </ul>
+      </article>
+
+      <article class="kwcs-card">
+        <h3>Procedura migracji</h3>
+        <ul>
+          <li><strong>Podmiana procesorów:</strong> Wdrożenie nowych klas obliczeniowych w Feature Layer.</li>
+          <li><strong>Aktualizacja schematu:</strong> Zmiana konfiguracji JSON oraz mapowania bazy danych.</li>
+          <li><strong>Profilowanie widoków:</strong> Dostosowanie pól formularzy do modelu B2B lub B2C.</li>
+          <li><strong>Stabilność rdzenia:</strong> Warstwy interfejsu, logiki i persystencji pozostają nienaruszone.</li>
+        </ul>
+      </article>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Redesign railu — collapsible groups (desktop) + drawer (mobile)

> **Zależność:** PR #59 (pkg 2 — Lessons learned) musi być zmergowany pierwszy.
> Bazuję na `claude/razdwa-cleanup-pkg2`, żeby diff pokazywał **tylko** delta redesignu railu. Po merge #59 retargetuję na `main`.

## Nowa struktura railu (20 wpisów: 12 L1 + 8 L2)

```
 1. W skrócie
 2. Moja rola
 3. Kontekst
 4. ▸ Decyzje produktowe        [collapsible — 3 L2]
       Jak rozpoznałem problem
       Kluczowe decyzje produktowe
       Zakres dostarczony
 5. Część 1 · Interfejs i UX
 6. Część 2 · Kalkulator CAD
 7. ▸ Część 3 · Panel administracyjny  [collapsible — 1 L2]
       Bramka PIN
 8. Część 5 · Droga zamówienia
 9. ▸ Część 6 · Architektura i Integracje  [collapsible — 4 L2]
       Ekosystem (high-level)
       Pięć warstw
       Integracje
       Testy automatyczne
10. Lessons learned
11. Rezultat
12. Potencjał B2B
```

**Liczby:**
- L1 widoczne zawsze: **12** (poprzednio 15).
- L2 ukryte domyślnie pod L1, łącznie: **8** (poprzednio 12).
- Widoczny poziom przy załadowaniu strony: **12 pozycji L1**.
- Po rozwinięciu wszystkich 3 grup z chevronem: **20 pozycji**.

## Wycięte z railu (sekcje w pliku zostają, brak widoczności w TOC)
- Role i persony · Część 4 Warianty produktów · Kluczowe decyzje UX · Logika CAD (deep dive) · Co panel pozwala zrobić · Specyficzne dla poligrafii · Uniwersalne moduły

## Reorder w dokumencie
**Potencjał B2B** przeniesiony **PO** Rezultat (poprzednio przed Lessons learned). Spekulatywna sekcja nie zatrzymuje czytelnika przed wynikami.

## Jak działa na mobile (≤1100px)

1. **Floating trigger button** w prawym dolnym rogu — pigułka cyan `#0284c7`:
   ```
   [☰] SPIS TREŚCI
       W skrócie               ← aktualna sekcja, update przez scroll-spy
   ```
   Pasek nie zajmuje stałej przestrzeni na górze ekranu (jak poprzednio top bar) — siedzi na safe-area-inset z prawej, nie zasłania treści.

2. **Tap na trigger → bottom sheet** wjeżdża z dołu (slide-up, 0.32s cubic-bezier):
   - Pełna lista wszystkich 20 pozycji w pionie.
   - L1 jako duże klikalne pozycje.
   - L2 wcięte z lewej ramką (pionowa linia border-left), **zawsze rozwinięte** w drawerze.
   - Nagłówek panel: „Rozdziały" + X (close button kółko).
   - Backdrop ciemny rgba(15,23,42,0.45) z fade-in.

3. **Zamknięcie drawera:**
   - Tap X.
   - Tap backdrop.
   - ESC.
   - Klik dowolnego linka (auto-close po wyborze → smooth scroll do sekcji).

4. Safe-area-inset uwzględnione (iPhone notch + dolne padding).

## Jak działa na desktop (≥1101px)

1. Rail jako sticky sidebar po lewej (jak dotychczas).
2. **L1 z dziećmi** ma chevron `⌄` po prawej. Klik chevronu → toggle expand/collapse grupy. Klik tekstu linku → smooth scroll do sekcji L1.
3. **L2 ukryte domyślnie** (`.razdwa-rail-sub { display: none }`).
4. **Auto-expand**: gdy scroll-spy aktywuje L2, parent grupa otwiera się automatycznie (czytelnik nie musi sam rozwijać).
5. Chevron rotuje 180° przy `aria-expanded="true"`.
6. Wszystkie inne grupy bez dzieci (W skrócie, Moja rola, Kontekst, UX, CAD, Droga, Lessons, Rezultat, Potencjał) — proste linki bez collapse.

## Ile pozycji ma widoczny poziom

| Stan | Widocznych | Klikalnych |
|---|---|---|
| Desktop, default (wszystko zwinięte) | **12** | 12 |
| Desktop, jedna grupa rozwinięta | 13–16 | 13–16 |
| Desktop, wszystkie 3 grupy rozwinięte | **20** | 20 |
| Mobile, trigger zamknięty | 1 (trigger) | 1 |
| Mobile, drawer otwarty | **20** | 20 |

## Czy nie ma dublowania „co dalej"

**Brak.** Sprawdzone:
- `grep -ic "co dalej" → 0`
- Jedyna fraza zbliżona: „**Kierunki dalszego rozwoju (Roadmap)**" w Rezultacie (linia 972) — to roadmap przyszłości produktu.
- W Lessons learned jest „**Co zmieniło się w iteracji 2**" (linia 925) — to retrospekcja, inny temat.

## Pliki

| Plik | Zmiana | Skala |
|---|---|---|
| `projects/razdwa_aplikacja.html` | przebudowa railu (zagnieżdżona struktura, mobile trigger, drawer, backdrop) + reorder Potencjał ↔ Rezultat | +97 / -107 |
| `assets/css/projects.css` | nowe selektory: trigger, panel, close, backdrop, group-head, toggle, sub-list + override mobile na drawer | +222 / −33 |
| `assets/js/portfolio.js` | drawer handlery, toggle buttons, scroll-spy update label + auto-expand | +59 / -2 |
| `assets/js/projects.js` | mirror tej samej logiki dla standalone | +56 |

## Sanity check
```
JS:  portfolio.js  OK
JS:  projects.js   OK
CSS: braces 606 == 606  OK
HTML: Rail links: 20 | Missing targets: NONE | L1: 12 | L2: 8
```

## Test plan
- [ ] **Desktop ≥1280px:** rail widoczny, 12 L1, 3 grupy z chevronem.
- [ ] Klik na chevron → grupa się rozwija, ikona obraca się 180°.
- [ ] Klik na tekst L1 (np. „Decyzje produktowe") → smooth scroll, grupa zostaje zwinięta.
- [ ] Scroll do L2 (np. „Bramka PIN") → parent „Część 3" auto-otwiera się.
- [ ] **Mobile ≤1100px:** rail nie blokuje treści, widoczny tylko trigger button w prawym dolnym rogu.
- [ ] Trigger pokazuje aktualną sekcję (update podczas scrollowania).
- [ ] Tap trigger → bottom sheet wjeżdża z dołu z backdropem.
- [ ] Lista w drawerze: wszystkie 20 pozycji widoczne, L2 wcięte z linią.
- [ ] Tap link → smooth scroll + drawer się zamyka.
- [ ] Tap backdrop / X / ESC → drawer się zamyka.
- [ ] iPhone (safe-area-inset) — trigger i drawer nie zachodzą na notch / home indicator.
- [ ] Sekcja Potencjał B2B teraz w pliku PO Rezultacie (nie przed).
- [ ] Brak regresji na innych case studies.

## Co NIE w tym pakiecie
- Sekcje wycięte z railu (Role i persony, Część 4, ux-decyzje, cad-logika, panel-funkcje, potencjał-poligrafia, potencjał-uniwersalne) **dalej są w pliku** — można je przewinąć, ale nie ma ich w nawigacji. Jeśli chcesz wyciąć fizycznie ze strony — to osobny pakiet.
- Metryka „−90% / 5 min" w hero / summary / Kontekst stats — nieruszane.
- Inne sekcje (Część 1, 2, 3, 5) — nieruszane.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNi6jDQsDLXyrD4mEe2weo)_