### PR TITLE
Polish wizualny: case study Raz Dwa Druk (scoped)

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3227,3 +3227,59 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
   color: #475569;
 }
 .ux-decision-box .ux-context strong { color: #0f172a; }
+
+/* ============================================================
+   RAZ DWA DRUK — scoped visual polish (1 pass)
+   Wszystko pod #case-razdwa-pelne. Zero edycji globalnych klas —
+   nie wpływa na pozostałe case studies.
+   ============================================================ */
+
+/* 2 · Ujednolicony akcent: cyan #06b6d4 w całym case study.
+   .razdwa-stat-num był jedynym elementem na #0ea5e9 (rozjazd z
+   summary / divider / callout, które używają #06b6d4). */
+#case-razdwa-pelne .razdwa-stat-num { color: #06b6d4; }
+
+/* 3 · Pojedyncze obrazy nie zostawiają pustej połowy rzędu.
+   Modyfikatory dodane tylko na blokach 1-obrazkowych w HTML;
+   galerie wieloobrazowe (bez --single) zachowują się jak dotąd. */
+#case-razdwa-pelne .kwcs-gallery-grid--single {
+  grid-template-columns: minmax(0, 760px);
+  justify-content: center;
+}
+#case-razdwa-pelne .showcase-row--single {
+  grid-template-columns: minmax(0, 860px);
+  justify-content: center;
+}
+
+/* 4 · Rytm pionowy: tytuł sekcji (.section-divider) bliżej własnej
+   treści. Globalnie gap title->content wynosił ~4.25rem
+   (divider margin-bottom 1.25 + .kwcs-sec padding-top 3). */
+#case-razdwa-pelne .section-divider + .kwcs-sec { padding-top: 1.25rem; }
+
+/* 5 · Spójność H2: sekcja "Kontekst projektu" (.kwcs-context-section,
+   jedyny H2 w .kwcs-sec poza dividerami w tym case study) dostaje
+   ten sam wygląd co .section-divider — Playfair + podkreślenie. */
+#case-razdwa-pelne .kwcs-context-section h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(1.5rem, 3.2vw, 2.1rem);
+}
+#case-razdwa-pelne .kwcs-context-section h2::after {
+  content: '';
+  display: block;
+  width: 60px;
+  height: 4px;
+  background: #06b6d4;
+  margin: 1rem auto 0;
+  border-radius: 2px;
+}
+
+/* 6 · Podpisy pod obrazami — spójne w całym case study (bez italic,
+   jednolity rozmiar/kolor/wyśrodkowanie). */
+#case-razdwa-pelne .gallery-item .img-desc,
+#case-razdwa-pelne .showcase-item p {
+  font-style: normal;
+  font-size: 0.875rem;
+  color: #64748b;
+  line-height: 1.5;
+  text-align: center;
+}

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -386,7 +386,7 @@
       <div class="showcase-section">
         <h3> Wielokolumnowy layout (Desktop)</h3>
        <p class="tab-description">Układ ekranu zapewnia jednoczesny dostęp do kategorii, kalkulatora i podglądu zamówienia bez zbędnego przełączania widoków.</p>
-        <div class="showcase-row">
+        <div class="showcase-row showcase-row--single">
           <div class="showcase-item">
             <img class="lightbox-trigger" src="/KWdesignnew/assets/images/strona 3kolumny_RAZDWA.webp" alt="Layout 3-kolumnowy — desktop" loading="lazy" data-caption="Layout 3-kolumnowy — nawigacja, kalkulator, koszyk">
             <p>Podział ekranu: nawigacja kategorii, aktywny kalkulator oraz podgląd zamówienia.</p>
@@ -471,12 +471,10 @@
         <div class="kwcs-content" id="content-cad-3" role="region" aria-labelledby="header-cad-3">
          <p>System analizuje plik i ogranicza ryzyko błędów przy rozpoznawaniu formatu oraz sposobu wyceny.</p>
           <ul>
-           <ul>
   <li><strong>Przeliczenie px → mm:</strong> wymiary są przeliczane na realny format wydruku.</li>
   <li><strong>Automatyczna orientacja:</strong> system dobiera właściwą szerokość rolki papieru.</li>
   <li><strong>Tolerancja błędu:</strong> uwzględnia niewielkie odchyłki ze starszych skanerów.</li>
   <li><strong>Tryb nienormowany:</strong> dla niestandardowych plików przełącza kalkulację na metry bieżące.</li>
-</ul>
           </ul>
         </div>
       </div>
@@ -488,10 +486,8 @@
         <div class="kwcs-content" id="content-cad-1" role="region" aria-labelledby="header-cad-1">
           <p>Dodatkowe usługi można dodać bezpośrednio w obrębie wycenianej pozycji.</p>
           <ul>
-           <ul>
   <li><strong>Składanie rysunków:</strong> stawka stała lub zależna od powierzchni wydruku.</li>
   <li><strong>Skanowanie wielkoformatowe:</strong> koszt dobierany na podstawie rozmiaru dokumentu.</li>
-</ul>
           </ul>
         </div>
       </div>
@@ -507,7 +503,7 @@
       Jednym z kluczowych celów projektu było uniezależnienie klienta od developera przy każdej zmianie cen. Panel administracyjny oddał właścicielowi pełną kontrolę nad cennikiem i uprościł utrzymanie systemu.
     </p>
 
-    <div class="kwcs-gallery-grid kwcs-gallery-grid--mb">
+    <div class="kwcs-gallery-grid kwcs-gallery-grid--mb kwcs-gallery-grid--single">
       <div class="gallery-item">
         <img class="lightbox-trigger" src="/KWdesignnew/assets/images/ustawienia_cen_RAZDWA.webp" alt="Panel ustawień cen" loading="lazy" data-caption="Panel ustawień cen — edycja in-place dla wszystkich kategorii">
         <p class="img-desc"><strong>Zarządzanie stawkami:</strong> System edycji in-place umożliwia natychmiastową modyfikację cen bezpośrednio w tabeli.</p>
@@ -547,7 +543,7 @@
   Dostęp do panelu administracyjnego musiał być prosty dla właściciela, ale bezpieczny dla danych cennika.
 </p>
 
-<div class="kwcs-gallery-grid kwcs-gallery-grid--mb">
+<div class="kwcs-gallery-grid kwcs-gallery-grid--mb kwcs-gallery-grid--single">
   <div class="gallery-item">
     <img class="lightbox-trigger" src="/KWdesignnew/assets/images/PIN_EKRAN_RAZDWA.webp" alt="Ekran bramki PIN" loading="lazy" data-caption="Bramka PIN — wejście do panelu administracyjnego">
     <p class="img-desc"><strong>Interfejs autoryzacji:</strong> minimalistyczny formularz logowania, zoptymalizowany pod kątem ekranów dotykowych.</p>


### PR DESCRIPTION
## Cel
Jeden bezpieczny pass visual polish **tylko** dla case study „Raz Dwa Druk". Wszystkie reguły CSS są scoped pod `#case-razdwa-pelne` — zero edycji globalnych klas, zero wpływu na pozostałe case studies.

## Zmiany
**`assets/css/projects.css`** (dopisany jeden blok na końcu, wszystko pod `#case-razdwa-pelne`):
- **Akcent** — `.razdwa-stat-num` ujednolicony do `#06b6d4` (był jedynym elementem na `#0ea5e9`, reszta akcentów = `#06b6d4`).
- **Pojedyncze galerie** — `.kwcs-gallery-grid--single` i `.showcase-row--single` (1 kolumna, wyśrodkowane) — koniec pustej połowy rzędu na desktopie.
- **Rytm pionowy** — `.section-divider + .kwcs-sec { padding-top: 1.25rem }` — tytuł bliżej własnej treści (było ~4.25rem gap).
- **Spójność H2** — `.kwcs-context-section h2` dostaje wygląd section-divider (Playfair + podkreślenie).
- **Podpisy** — `.gallery-item .img-desc` / `.showcase-item p` ujednolicone (bez italic, spójny rozmiar/kolor).

**`projects/razdwa_aplikacja.html`**:
- dodane modyfikatory `--single` na 3 blokach 1-obrazkowych,
- naprawione zagnieżdżone `<ul><ul>` w sekcji CAD (2 miejsca).

## Czego NIE ruszono
Copy, kolejność sekcji, linki, ścieżki assetów, logika chapter rail / lightbox, architektura osadzania, globalne klasy CSS.

## Wpływ na inne case studies
Brak. `.kwcs-context-section` występuje też w innych projektach, ale selektor jest pod `#case-razdwa-pelne` (ID istnieje wyłącznie w pliku Raz Dwa). Modyfikatory `--single` dodane tylko w tym pliku.

https://claude.ai/code/session_01UEoEXE1RRBr1ZUmU1gMMKc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEoEXE1RRBr1ZUmU1gMMKc)_