### PR TITLE
RAZDWA case study — UX/UI cleanup (5 sekcji)

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3298,3 +3298,65 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
     margin-inline: 0;
   }
 }
+
+/* ========================================================
+   RAZDWA — UX/UI cleanup pass (5 sekcji)
+   Zakres ograniczony do #case-razdwa-pelne, żeby nie ruszać
+   innych projektów współdzielących te klasy.
+   ======================================================== */
+
+/* 1. „Za co odpowiadałem" — świadome domknięcie sekcji
+   zamiast samotnego boksu w lewej kolumnie 3-col gridu. */
+#case-razdwa-pelne .contribution-grid--razdwa:has(.contribution-cell:only-child) {
+  display: block;
+  max-width: 760px;
+}
+#case-razdwa-pelne .contribution-grid--razdwa:has(.contribution-cell:only-child) .contribution-cell {
+  padding: 1.75rem 2rem;
+}
+#case-razdwa-pelne .contribution-grid--razdwa:has(.contribution-cell:only-child) .contribution-cell ul {
+  columns: 2;
+  column-gap: 2.5rem;
+}
+#case-razdwa-pelne .contribution-grid--razdwa:has(.contribution-cell:only-child) .contribution-cell li {
+  break-inside: avoid;
+}
+@media (max-width: 600px) {
+  #case-razdwa-pelne .contribution-grid--razdwa:has(.contribution-cell:only-child) .contribution-cell ul {
+    columns: 1;
+  }
+}
+
+/* 2. + 3. „Kluczowe decyzje" i „Zarządzanie cennikiem" —
+   zestaw trzech kart jako triada w jednym rzędzie,
+   bez orphana wiszącego po lewej. */
+#case-razdwa-pelne .ux-decision-grid--triad {
+  grid-template-columns: repeat(3, 1fr);
+}
+@media (max-width: 768px) {
+  #case-razdwa-pelne .ux-decision-grid--triad {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* 4. „Jak współpracują główne moduły" — ostatni węzeł
+   ekosystemu wycentrowany i kompozycyjnie domknięty. */
+#case-razdwa-pelne .razdwa-ecosystem-row:has(.eco-node:only-child) {
+  grid-template-columns: minmax(0, 430px);
+  justify-content: center;
+}
+
+/* 5. „Co zmieniło się po wdrożeniu" — lead i karty na wspólnej
+   szerokości kolumny, żeby krawędzie się pokrywały. */
+#case-razdwa-pelne .result-lead {
+  max-width: 820px;
+}
+#case-razdwa-pelne .result-cards {
+  max-width: 820px;
+  grid-template-columns: repeat(3, 1fr);
+}
+@media (max-width: 768px) {
+  #case-razdwa-pelne .result-cards {
+    grid-template-columns: 1fr;
+  }
+}

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -203,7 +203,7 @@
       Analiza pracy w drukarni pokazała, że problemem nie był tylko sam czas wyceny, ale też duża liczba wyjątków, ryzyko błędów i brak prostego zarządzania cennikiem. Dlatego projekt oparłem na trzech decyzjach, które jednocześnie upraszczały pracę operatora i ograniczały koszty utrzymania.
     </p>
 
-    <div class="ux-decision-grid">
+    <div class="ux-decision-grid ux-decision-grid--triad">
       <div class="ux-decision-box">
         <div class="ux-label">Decyzja 1</div>
         <h4>Dedykowana aplikacja zamiast gotowego sklepu</h4>
@@ -355,7 +355,7 @@
       Jednym z kluczowych celów było uniezależnienie klienta od programisty przy zmianach cen i rozwijaniu oferty. Dlatego zaprojektowałem panel, który pozwala samodzielnie aktualizować stawki, kontrolować dostęp do edycji i dodawać nowe warianty produktów bez psucia struktury systemu.
     </p>
 
-    <div class="ux-decision-grid">
+    <div class="ux-decision-grid ux-decision-grid--triad">
       <div class="ux-decision-box">
         <div class="ux-label">Funkcja 1</div>
         <h4>Jedno miejsce do zarządzania cenami</h4>


### PR DESCRIPTION
Jeden spójny pass UX/UI cleanup dla case study RAZDWA w portfolio (`projects/razdwa_aplikacja.html`). Layout uporządkowany pod kątem hierarchii i kompozycji — bez przebudowy designu.

## Zmiany w 5 sekcjach

1. **„Za co odpowiadałem"** — samotny box w 3-col gridzie przekształcony w świadomy, wycentrowany blok domykający; 6-elementowa lista rozłożona na 2 kolumny.
2. **„Kluczowe decyzje produktowe"** — trzy karty jako triada w jednym rzędzie (3-col), znika trzeci box wiszący po lewej.
3. **„Zarządzanie cennikiem i ofertą"** — ten sam wariant 3-col; „Funkcja 3" nie wisi już po lewej.
4. **„Jak współpracują główne moduły"** — ostatni węzeł ekosystemu wycentrowany i kompozycyjnie domknięty.
5. **„Co zmieniło się po wdrożeniu"** — lead i karty wyrównane do wspólnej szerokości kolumny (820px).

## Zasady utrzymane
- Głównie **CSS-only**; HTML ruszony minimalnie (dodana klasa `ux-decision-grid--triad` na 2 gridach).
- Wszystkie zmiany generycznych klas (`ux-decision-grid`, `result-cards`/`result-lead`) **zaskopowane pod `#case-razdwa-pelne`** — inne projekty współdzielące te klasy (m.in. KW-Design) pozostają nietknięte.
- Aplikacja produkcyjna RAZDWA nieruszana.
- Responsywność: triady i karty wyników zwijają się do 1-col na ≤768px, lista w bloku domykającym do 1-col na ≤600px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01193LJsDare45kF9reTgc56

---
_Generated by [Claude Code](https://claude.ai/code/session_01193LJsDare45kF9reTgc56)_