### PR TITLE
Portfolio: reorder projects, unify Kontakt link, trim experience section

### DIFF
--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -1211,9 +1211,11 @@ body.portfolio-page.page-voucher-magdy .breadcrumbs a:hover{color:#0f44b7;}
 
 .exp-stats-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: var(--space-4);
   margin-top: var(--space-10);
+  margin-left: auto;
+  margin-right: auto;
   max-width: 860px;
 }
 

--- a/portfolio.html
+++ b/portfolio.html
@@ -115,7 +115,7 @@
     <section id="portfolio-section" class="portfolio-section">
         <div class="container">
             <h2 class="section-title">Wybrane projekty</h2>
-            <p class="section-subtitle">Realizacje od analizy problemu po wdrożenie — strony, aplikacje i automatyzacje zaprojektowane pod konkretny proces</p>
+            <p class="section-subtitle">Do drobnego usprawnienia wystarcza automatyzacja, do większego — strona albo wdrożenie web, do złożonego procesu — dedykowany produkt cyfrowy. Poniższe realizacje pokazują te trzy poziomy w praktyce.</p>
 
             <div class="portfolio-new-grid">
 

--- a/portfolio.html
+++ b/portfolio.html
@@ -73,7 +73,7 @@
                     <li><a href="index.html">Start</a></li>
                     <li><a href="portfolio.html" class="active">Portfolio</a></li>
                     <li><a href="uslugi.html">Usługi</a></li>
-                    <li><a href="index.html#contact" class="smooth">Kontakt</a></li>
+                    <li><a href="index.html#contact">Kontakt</a></li>
                 </ul>
                 <div class="hamburger">
                     <span></span>
@@ -119,20 +119,6 @@
 
             <div class="portfolio-new-grid">
 
-                <article class="portfolio-new-card" data-project="RazDwa" role="button" tabindex="0" aria-label="Raz Dwa Druk — Aplikacja biznesowa PWA">
-                    <div class="card-content">
-                        <span class="card-category">Aplikacja biznesowa · PWA</span>
-                        <h3 class="card-title">Raz Dwa Druk</h3>
-                        <p class="card-description">Kalkulator wycen PWA z integracją Google Sheets — wycena skrócona z godziny do 5 minut.</p>
-                        <div class="card-features">
-                            <span class="feature-item">PWA</span>
-                            <span class="feature-item">Google Sheets</span>
-                            <span class="feature-item">PDF</span>
-                        </div>
-                        <span class="card-cta">Zobacz projekt <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></span>
-                    </div>
-                </article>
-
                 <article class="portfolio-new-card" data-project="cyfradruk" role="button" tabindex="0" aria-label="CyfraDruk — Automatyzacja pre-press">
                     <div class="card-content">
                         <span class="card-category">Automatyzacja · Pre-press</span>
@@ -175,19 +161,6 @@
                     </div>
                 </article>
 
-                <article class="portfolio-new-card" data-project="sir-roger" role="button" tabindex="0" aria-label="Sir Roger — Rebranding i opakowania">
-                    <div class="card-content">
-                        <span class="card-category">Branding · Opakowania</span>
-                        <h3 class="card-title">Sir Roger</h3>
-                        <p class="card-description">Nowa odsłona marki herbat premium — opakowania i rebranding systemu wizualnego.</p>
-                        <div class="card-features">
-                            <span class="feature-item">Opakowania</span>
-                            <span class="feature-item">Identyfikacja</span>
-                        </div>
-                        <span class="card-cta">Zobacz projekt <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></span>
-                    </div>
-                </article>
-
                 <article class="portfolio-new-card" data-project="KW-Design" role="button" tabindex="0" aria-label="KW Design — Logo i identyfikacja">
                     <div class="card-content">
                         <span class="card-category">Branding · Identyfikacja</span>
@@ -202,6 +175,20 @@
                     </div>
                 </article>
 
+                <article class="portfolio-new-card" data-project="RazDwa" role="button" tabindex="0" aria-label="Raz Dwa Druk — Aplikacja biznesowa PWA">
+                    <div class="card-content">
+                        <span class="card-category">Aplikacja biznesowa · PWA</span>
+                        <h3 class="card-title">Raz Dwa Druk</h3>
+                        <p class="card-description">Kalkulator wycen PWA z integracją Google Sheets — wycena skrócona z godziny do 5 minut.</p>
+                        <div class="card-features">
+                            <span class="feature-item">PWA</span>
+                            <span class="feature-item">Google Sheets</span>
+                            <span class="feature-item">PDF</span>
+                        </div>
+                        <span class="card-cta">Zobacz projekt <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></span>
+                    </div>
+                </article>
+
                 <article class="portfolio-new-card" data-project="savage" role="button" tabindex="0" aria-label="Savage — Branding i strona WWW">
                     <div class="card-content">
                         <span class="card-category">WordPress · Branding</span>
@@ -211,6 +198,19 @@
                             <span class="feature-item">WordPress</span>
                             <span class="feature-item">Logo</span>
                             <span class="feature-item">UX/UI</span>
+                        </div>
+                        <span class="card-cta">Zobacz projekt <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></span>
+                    </div>
+                </article>
+
+                <article class="portfolio-new-card" data-project="sir-roger" role="button" tabindex="0" aria-label="Sir Roger — Rebranding i opakowania">
+                    <div class="card-content">
+                        <span class="card-category">Branding · Opakowania</span>
+                        <h3 class="card-title">Sir Roger</h3>
+                        <p class="card-description">Nowa odsłona marki herbat premium — opakowania i rebranding systemu wizualnego.</p>
+                        <div class="card-features">
+                            <span class="feature-item">Opakowania</span>
+                            <span class="feature-item">Identyfikacja</span>
                         </div>
                         <span class="card-cta">Zobacz projekt <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></span>
                     </div>
@@ -252,10 +252,6 @@
                 <div class="adg-item">
                     <span class="adg-label">Zrealizowane</span>
                     <p>5 stron · 1 aplikacja biznesowa · 10+ automatyzacji</p>
-                </div>
-                <div class="adg-item">
-                    <span class="adg-label">Sposób pracy</span>
-                    <p>Analiza → projekt → budowa → testy → wdrożenie</p>
                 </div>
             </div>
 


### PR DESCRIPTION
## Podsumowanie

Pakiet zmian na stronie portfolio zgodny z zaakceptowanym planem i decyzjami ownera. Praca wyłącznie na `portfolio.html`, `assets/css/portfolio.css`, `assets/js/portfolio.js` (JS bez zmian).

## Zmiany

- **Kolejność projektów** — 8 istniejących kart przestawionych wg priorytetu kategorii ownera:
  1. Automatyzacje: CyfraDruk
  2. Strony / wdrożenia web: Karoma, Power of Mind, KW Design
  3. Produkty cyfrowe / UX/UI: Raz Dwa Druk
  4. Drugorzędne / branding: Savage, Sir Roger, Voucher Salon u Magdy
  Treść kart, `data-project` i etykiety `card-category` bez zmian; grupowanie wyrażone samą kolejnością (bez nowych sekcji).
- **Link „Kontakt"** — usunięta bezużyteczna klasa `smooth` z linku w nawigacji; nawigacja i stopka używają teraz identycznego, zwykłego linku międzystronowego `index.html#contact`.
- **Sekcja „Doświadczenie"** — skrócona z 4 do 3 kafelków (usunięty kafelek „Sposób pracy" / metodologia). `exp-stats-grid` przełączony na `repeat(3,1fr)` i wycentrowany względem strony (`margin: auto`).

## Poza zakresem (zgodnie z decyzjami ownera)

- `wizualizacje.html` nie dodana w tym pakiecie.
- Bez zmian etykiet `card-category`, bez filtrów, bez nowych sekcji, bez zmiany `href` „Kontaktu" ani adresu e-mail.

## Weryfikacja

Render w Chromium (Playwright, file://):
- Kolejność kart: `cyfradruk > karoma > power-of-mind > KW-Design > RazDwa > savage > sir-roger > voucher-magdy` ✅
- 8 kart, brak duplikatów ✅
- Kafelki „Doświadczenie": Branże | Staż | Zrealizowane (3) ✅
- `exp-stats-grid`: 3 kolumny, `leftGap == rightGap` (160px = 160px) → wycentrowane ✅
- Nawigacja i stopka „Kontakt" → `index.html#contact` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FYMSNW2BpfcAiw8kPpuFW

---
_Generated by [Claude Code](https://claude.ai/code/session_014FYMSNW2BpfcAiw8kPpuFW)_