### PR TITLE
Portfolio: restore preview images on all 8 project cards

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -120,6 +120,9 @@
             <div class="portfolio-new-grid">
 
                 <article class="portfolio-new-card" data-project="cyfradruk" role="button" tabindex="0" aria-label="CyfraDruk — Automatyzacja pre-press">
+                    <div class="card-image-wrapper">
+                        <img src="assets/images/Automatyzacja_liniekolory.webp" alt="CyfraDruk — automatyczne wykrywanie błędów kolorów i cienkich linii przed drukiem" loading="eager" decoding="async">
+                    </div>
                     <div class="card-content">
                         <span class="card-category">Automatyzacja · Pre-press</span>
                         <h3 class="card-title">CyfraDruk</h3>
@@ -134,6 +137,9 @@
                 </article>
 
                 <article class="portfolio-new-card" data-project="karoma" role="button" tabindex="0" aria-label="Karoma — E-commerce i branding">
+                    <div class="card-image-wrapper">
+                        <img src="assets/images/KAROMA_FRONT.webp" alt="Karoma — front sklepu WooCommerce z identyfikacją wizualną marki" loading="eager" decoding="async">
+                    </div>
                     <div class="card-content">
                         <span class="card-category">E-commerce · Branding</span>
                         <h3 class="card-title">Karoma</h3>
@@ -148,6 +154,9 @@
                 </article>
 
                 <article class="portfolio-new-card" data-project="power-of-mind" role="button" tabindex="0" aria-label="Power of Mind — Serwis i branding">
+                    <div class="card-image-wrapper">
+                        <img src="assets/images/POWEROFMIND_HERO_1.webp" alt="Power of Mind — hero strony marki trenerki odporności psychicznej" loading="eager" decoding="async">
+                    </div>
                     <div class="card-content">
                         <span class="card-category">WordPress · Branding</span>
                         <h3 class="card-title">Power of Mind</h3>
@@ -162,6 +171,9 @@
                 </article>
 
                 <article class="portfolio-new-card" data-project="KW-Design" role="button" tabindex="0" aria-label="KW Design — Logo i identyfikacja">
+                    <div class="card-image-wrapper">
+                        <img src="assets/images/KWDESIGN_FRONT.png" alt="KW Design — logo i identyfikacja wizualna marki projektanta" loading="lazy" decoding="async">
+                    </div>
                     <div class="card-content">
                         <span class="card-category">Branding · Identyfikacja</span>
                         <h3 class="card-title">KW Design</h3>
@@ -176,6 +188,9 @@
                 </article>
 
                 <article class="portfolio-new-card" data-project="RazDwa" role="button" tabindex="0" aria-label="Raz Dwa Druk — Aplikacja biznesowa PWA">
+                    <div class="card-image-wrapper">
+                        <img src="assets/images/Ekran_RAZDWA_KWdesign.webp" alt="Raz Dwa Druk — ekran aplikacji PWA do wyceny druku" loading="lazy" decoding="async">
+                    </div>
                     <div class="card-content">
                         <span class="card-category">Aplikacja biznesowa · PWA</span>
                         <h3 class="card-title">Raz Dwa Druk</h3>
@@ -190,6 +205,9 @@
                 </article>
 
                 <article class="portfolio-new-card" data-project="savage" role="button" tabindex="0" aria-label="Savage — Branding i strona WWW">
+                    <div class="card-image-wrapper">
+                        <img src="assets/KARUZELAJ/Savage.jpg" alt="Savage — identyfikacja wizualna marki i wdrożenie strony WordPress" loading="lazy" decoding="async">
+                    </div>
                     <div class="card-content">
                         <span class="card-category">WordPress · Branding</span>
                         <h3 class="card-title">Savage</h3>
@@ -204,6 +222,9 @@
                 </article>
 
                 <article class="portfolio-new-card" data-project="sir-roger" role="button" tabindex="0" aria-label="Sir Roger — Rebranding i opakowania">
+                    <div class="card-image-wrapper">
+                        <img src="assets/images/Roger.png" alt="Sir Roger — rebranding i opakowania marki herbat premium" loading="lazy" decoding="async">
+                    </div>
                     <div class="card-content">
                         <span class="card-category">Branding · Opakowania</span>
                         <h3 class="card-title">Sir Roger</h3>
@@ -217,6 +238,9 @@
                 </article>
 
                 <article class="portfolio-new-card" data-project="voucher-magdy" role="button" tabindex="0" aria-label="Voucher Salon u Magdy — Grafika i druk">
+                    <div class="card-image-wrapper">
+                        <img src="assets/images/salon Magdy mockup copy.webp" alt="Voucher Salon u Magdy — mockup vouchera prezentowego przygotowanego do druku" loading="lazy" decoding="async">
+                    </div>
                     <div class="card-content">
                         <span class="card-category">Grafika · Druk</span>
                         <h3 class="card-title">Voucher Salon u Magdy</h3>


### PR DESCRIPTION
## Podsumowanie

Follow-up po zmergowanym PR #63. Przywraca warstwę szybkiego zrozumienia projektów na poziomie gridu portfolio — preview image w każdej z 8 kart. Zmiana wyłącznie w `portfolio.html` (reużyty istniejący CSS `.card-image-wrapper`; JS bez zmian).

## Zmiany

- Dodano `.card-image-wrapper` + `<img>` jako pierwsze dziecko każdej z 8 kart `.portfolio-new-card`.
- `object-fit: contain`, `aspect-ratio: 16/10` (istniejący CSS) → spójne proporcje, stabilny layout (brak CLS).
- Strategia ładowania: pierwszy rząd (cyfradruk, karoma, power-of-mind) `eager`; pozostałe `lazy`; wszystkie `decoding="async"`.
- Opisowy `alt` per projekt (wsparcie zrozumienia, nie dekoracja).

## Mapowanie obraz → karta

| Karta | Obraz |
|-------|-------|
| cyfradruk | `assets/images/Automatyzacja_liniekolory.webp` |
| karoma | `assets/images/KAROMA_FRONT.webp` |
| power-of-mind | `assets/images/POWEROFMIND_HERO_1.webp` |
| KW-Design | `assets/images/KWDESIGN_FRONT.png` |
| RazDwa | `assets/images/Ekran_RAZDWA_KWdesign.webp` |
| savage | `assets/KARUZELAJ/Savage.jpg` |
| sir-roger | `assets/images/Roger.png` |
| voucher-magdy | `assets/images/salon Magdy mockup copy.webp` |

## Poza zakresem (zgodnie z decyzjami ownera)

- Bez powrotu karuzeli, bez inline injection / SPA, bez zmian kolejności kart i układu.
- Bez zmian w podstronach projektów, w CSS i w JS.

## Weryfikacja

Render w Chromium (Playwright, file://): 8/8 obrazów ładuje się, zero błędnych żądań, `object-fit: contain`, `aspect-ratio 16/10`, lazy-loading działa (6/8 przed scrollem, 8/8 po).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FYMSNW2BpfcAiw8kPpuFW

---
_Generated by [Claude Code](https://claude.ai/code/session_014FYMSNW2BpfcAiw8kPpuFW)_