### PR TITLE
Fix portfolio images and navigation paths

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,7 +6,7 @@
     <title>404 – Strona nie znaleziona | Karol Wyszyński</title>
     <meta name="robots" content="noindex, follow" />
     <meta name="theme-color" content="#06b6d4" />
-    <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="/KWdesignnew/assets/images/favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet" />
@@ -90,9 +90,9 @@
             albo nigdy jej tu nie było. Sprawdź adres URL albo wróć na stronę główną.
         </p>
         <div class="links">
-            <a href="/">← Strona główna</a>
-            <a href="/portfolio.html" class="secondary">Portfolio</a>
-            <a href="/uslugi.html" class="secondary">Usługi</a>
+            <a href="/KWdesignnew/">← Strona główna</a>
+            <a href="/KWdesignnew/portfolio.html" class="secondary">Portfolio</a>
+            <a href="/KWdesignnew/uslugi.html" class="secondary">Usługi</a>
         </div>
     </div>
 <script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a0884d5d4ef03528',t:'MTc4MDkyNTk2MQ=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>

--- a/assets/css/index-styles.css
+++ b/assets/css/index-styles.css
@@ -3469,6 +3469,12 @@ section {
     transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+/* Portrait/near-square screenshots (np. Raz Dwa) — pokaż cały obraz bez przycinania */
+.card-image-wrapper img.card-image--contain {
+    object-fit: contain;
+    padding: var(--space-3, 12px);
+}
+
 .portfolio-new-card:hover .card-image-wrapper img {
     transform: scale(1.05);
 }

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
             <!-- KARTA 1: Raz Dwa Druk -->
             <a href="portfolio.html#RazDwa" class="portfolio-new-card">
                 <div class="card-image-wrapper">
-                    <img src="assets/images/Ekran_RAZDWA_KWdesign.webp" alt="Raz Dwa Druk – aplikacja B2B, PWA i strona internetowa" loading="lazy" />   
+                    <img src="assets/images/Ekran_RAZDWA_KWdesign.webp" alt="Raz Dwa Druk – aplikacja B2B, PWA i strona internetowa" class="card-image--contain" loading="lazy" />
                 </div>
                 <div class="card-content">
                     <span class="card-category">Aplikacja B2B + PWA + Strona</span>
@@ -184,7 +184,7 @@
             <!-- KARTA 2: Sklep Karoma -->
             <a href="portfolio.html#karoma" class="portfolio-new-card">
                 <div class="card-image-wrapper">
-                    <img src="assets/images/KAROMA_FRONT.webp" alt="Sklep Karoma" loading="lazy" />
+                    <img src="assets/images/karoma/KAROMA_FRONT.webp" alt="Sklep Karoma" loading="lazy" />
                 </div>
                 <div class="card-content">
                     <span class="card-category">E-commerce + Branding</span>

--- a/portfolio.html
+++ b/portfolio.html
@@ -189,7 +189,7 @@
 
                 <article class="portfolio-new-card" data-project="RazDwa" role="button" tabindex="0" aria-label="Raz Dwa Druk — Aplikacja biznesowa PWA">
                     <div class="card-image-wrapper">
-                        <img src="assets/images/Ekran_RAZDWA_KWdesign.webp" alt="Raz Dwa Druk — ekran aplikacji PWA do wyceny druku" loading="lazy" decoding="async">
+                        <img src="assets/images/Ekran_RAZDWA_KWdesign.webp" alt="Raz Dwa Druk — ekran aplikacji PWA do wyceny druku" class="card-image--contain" loading="lazy" decoding="async">
                     </div>
                     <div class="card-content">
                         <span class="card-category">Aplikacja biznesowa · PWA</span>

--- a/projects/karoma.html
+++ b/projects/karoma.html
@@ -401,7 +401,7 @@
           </a>
           <div class="result-next">
             <h3>Następny projekt</h3>
-            <a class="kwcs-cta" href="power-of-mind.html" aria-label="Przejdź do projektu Power of Mind — brand, sklep i automatyzacje">
+            <a class="kwcs-cta" href="/KWdesignnew/projects/power-of-mind.html" aria-label="Przejdź do projektu Power of Mind — brand, sklep i automatyzacje">
               Power of Mind — brand, sklep i automatyzacje
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <polyline points="9 18 15 12 9 6"></polyline>

--- a/projects/power-of-mind.html
+++ b/projects/power-of-mind.html
@@ -45,7 +45,7 @@
 
   <nav class="kwcs-breadcrumb" aria-label="Nawigacja">
     <div class="wrap">
-      <a href="../portfolio.html" class="kwcs-back-btn">
+      <a href="/KWdesignnew/portfolio.html" class="kwcs-back-btn">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><polyline points="15 18 9 12 15 6"></polyline></svg>
         Portfolio
       </a>
@@ -339,7 +339,7 @@
           </a>
           <div class="result-next">
             <h3>Następny projekt</h3>
-            <a class="kwcs-cta" href="KW-Design.html" aria-label="Przejdź do projektu KW Design — logo i identyfikacja wizualna">
+            <a class="kwcs-cta" href="/KWdesignnew/projects/KW-Design.html" aria-label="Przejdź do projektu KW Design — logo i identyfikacja wizualna">
               KW Design — logo i identyfikacja wizualna
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <polyline points="9 18 15 12 9 6"></polyline>
@@ -388,7 +388,7 @@
   <footer class="kwcs-footer">
     <div class="wrap">
       <span>&copy; 2026 Karol Wyszyński</span>
-      <a href="../polityka-prywatnosci.html">Polityka prywatności</a>
+      <a href="/KWdesignnew/polityka-prywatnosci.html">Polityka prywatności</a>
     </div>
   </footer>
 


### PR DESCRIPTION
## Problem

On the home page section **"Przykłady procesów, które pomagam uporządkować"** the Karoma image was broken and the Raz Dwa screenshot was cropped. In the Karoma project case study, the "next project" button pointed to a 404, and the site's 404 page linked to the wrong base path.

## Changes

**Images (index.html + portfolio.html)**
- Fixed the Karoma card image path: `assets/images/KAROMA_FRONT.webp` → `assets/images/karoma/KAROMA_FRONT.webp` (the file lives in the `karoma/` subfolder — the old path 404'd).
- The Raz Dwa screenshot is nearly square (1450×1306) but the card frame is 16:9 with `object-fit: cover`, which cropped the top/bottom of the app UI. Added a `.card-image--contain` modifier (`object-fit: contain`) so the whole screenshot is visible. Applied on both the index and portfolio cards.

**Navigation paths**
- Root cause: `portfolio.js` fetches each project's `section.kwcs` and injects it inline into `/KWdesignnew/portfolio.html`. Relative links like `href="power-of-mind.html"` then resolved against the portfolio URL → `/KWdesignnew/power-of-mind.html` (404). Fixed by using root-absolute `/KWdesignnew/projects/...` links (matching the already-working `razdwa_aplikacja.html`), which resolve correctly both standalone and when injected:
  - `projects/karoma.html`: next-project → `/KWdesignnew/projects/power-of-mind.html`
  - `projects/power-of-mind.html`: next-project → `/KWdesignnew/projects/KW-Design.html`, plus back-button and footer links normalized to `/KWdesignnew/...`.

**404 page (404.html)**
- The site is served under `/KWdesignnew/`, so the root-absolute links (`/`, `/portfolio.html`, `/uslugi.html`) and the relative favicon all 404'd. Repointed them to the `/KWdesignnew/` base.

## Verification
- Confirmed every referenced image now resolves to a real file (index, portfolio, karoma, power-of-mind).
- Rendered the home section in a headless browser — all three cards display correctly, Raz Dwa fully visible.
- Simulated the portfolio injection: the Karoma next-project CTA now resolves to `/KWdesignnew/projects/power-of-mind.html`, and the mailto CTA is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Q1fLxK3UY6de9KhJio1Ft

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q1fLxK3UY6de9KhJio1Ft)_