### PR TITLE
Portfolio: project prev/next navigation + KW Design pilot fixes

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3615,3 +3615,102 @@ body { overflow-x: hidden; }
     margin-top: 0.5rem;
   }
 }
+
+/* ========================================
+   PROJECT PREV/NEXT NAVIGATION
+   Cykliczna nawigacja między case studies
+   ======================================== */
+.kwcs-project-nav {
+  padding: clamp(2rem, 5vw, 3rem) 1rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.kwcs-project-nav .wrap {
+  max-width: var(--wrap-max);
+  margin: 0 auto;
+  padding: 0 1rem;
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.kwcs-project-nav__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  max-width: 48%;
+  text-decoration: none;
+  color: #0f172a;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.85rem;
+  padding: 1rem 1.35rem;
+  box-shadow: 0 2px 10px rgba(2, 6, 23, 0.05);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.kwcs-project-nav__link:hover {
+  transform: translateY(-3px);
+  border-color: var(--color-primary, #06b6d4);
+  box-shadow: 0 10px 26px rgba(6, 182, 212, 0.18);
+}
+
+.kwcs-project-nav__link:focus-visible {
+  outline: 3px solid #2563eb;
+  outline-offset: 3px;
+}
+
+.kwcs-project-nav__next {
+  margin-left: auto;
+}
+
+.kwcs-project-nav__text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.3;
+}
+
+.kwcs-project-nav__prev .kwcs-project-nav__text {
+  align-items: flex-start;
+  text-align: left;
+}
+
+.kwcs-project-nav__next .kwcs-project-nav__text {
+  align-items: flex-end;
+  text-align: right;
+}
+
+.kwcs-project-nav__text small {
+  font-size: 0.72rem;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.15rem;
+}
+
+.kwcs-project-nav__text strong {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.kwcs-project-nav__icon {
+  flex-shrink: 0;
+  color: var(--color-primary, #06b6d4);
+}
+
+@media (max-width: 600px) {
+  .kwcs-project-nav .wrap {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .kwcs-project-nav__link {
+    max-width: 100%;
+    justify-content: flex-start;
+  }
+  .kwcs-project-nav__next {
+    margin-left: 0;
+    justify-content: flex-end;
+  }
+}

--- a/projects/KW-Design.html
+++ b/projects/KW-Design.html
@@ -97,7 +97,8 @@
               class="cover"
               src="/KWdesignnew/assets/images/KWDESIGN_FRONT.png"
               alt="KW Design — logo i identyfikacja wizualna marki projektanta"
-              loading="lazy"
+              loading="eager"
+              fetchpriority="high"
               decoding="async"
               width="1200"
               height="630"
@@ -119,7 +120,7 @@
     <!-- ============================================================
          Sticky chapter rail — persistent timeline navigation
     ============================================================ -->
-    <nav class="razdwa-chapter-rail" id="kwdesign-chapter-rail" aria-label="Spis treści case study">
+    <nav class="razdwa-chapter-rail" id="razdwa-chapter-rail" aria-label="Spis treści case study">
       <div class="razdwa-chapter-rail-label">Rozdziały</div>
       <ul class="razdwa-chapter-rail-list">
         <li><a class="razdwa-chapter-link" href="#kwdesign-summary" data-rail-target="kwdesign-summary" title="W skrócie" aria-label="W skrócie">W skrócie</a></li>
@@ -333,7 +334,7 @@
                 <li>Wektory: AI, EPS, SVG.</li>
                 <li>Rastery: PNG z przezroczystością w kilku rozmiarach.</li>
                 <li>Księga znaku: wersje logo, paleta kolorów, safe zone, minimalne rozmiary, przykłady złego użycia.</li>
-                <li>Wsparcie przez 30 dni przy implementacji i wdrożeniu.</li>
+                <li>Wdrożenie znaku na stronę portfolio i do materiałów marki.</li>
               </ul>
             </div>
           </div>
@@ -355,41 +356,6 @@
           </p>
         </div>
 
-        <div class="kwcs-gallery-grid">
-          <div class="gallery-item">
-            <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-v1.png">
-              <span class="asset-missing-icon" aria-hidden="true">📁</span>
-              <span class="asset-missing-label">Brakujący asset</span>
-              <code class="asset-missing-filename">marka-d-v1.png</code>
-            </div>
-            <p class="img-desc">Wstępne szkice i kierunki</p>
-          </div>
-          <div class="gallery-item">
-            <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-v2.png">
-              <span class="asset-missing-icon" aria-hidden="true">📁</span>
-              <span class="asset-missing-label">Brakujący asset</span>
-              <code class="asset-missing-filename">marka-d-v2.png</code>
-            </div>
-            <p class="img-desc">Dopracowanie kerningu i balansu</p>
-          </div>
-          <div class="gallery-item">
-            <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-v3.png">
-              <span class="asset-missing-icon" aria-hidden="true">📁</span>
-              <span class="asset-missing-label">Brakujący asset</span>
-              <code class="asset-missing-filename">marka-d-v3.png</code>
-            </div>
-            <p class="img-desc">Testy palety kolorów</p>
-          </div>
-          <div class="gallery-item">
-            <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-final.png">
-              <span class="asset-missing-icon" aria-hidden="true">📁</span>
-              <span class="asset-missing-label">Brakujący asset</span>
-              <code class="asset-missing-filename">marka-d-final.png</code>
-            </div>
-            <p class="img-desc">Wersja finalna – ready to use</p>
-          </div>
-        </div>
-
         <p>
           Finalny znak ma <strong>wysoką czytelność</strong> w małych rozmiarach oraz <strong>wyrazisty charakter wizualny</strong>, który wyróżnia markę w branży kreatywnej.
         </p>
@@ -401,56 +367,6 @@
             Logo zostało przetestowane na <strong>wielu nośnikach</strong>: wizytówkach, papeterii firmowej, materiałach social media i w środowisku webowym. Dzięki temu zachowuje spójność i rozpoznawalność w każdym kontekście.
           </p>
 
-          <div class="kwcs-gallery-grid">
-            <div class="gallery-item">
-              <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-brand-guide.png">
-                <span class="asset-missing-icon" aria-hidden="true">📁</span>
-                <span class="asset-missing-label">Brakujący asset</span>
-                <code class="asset-missing-filename">marka-d-brand-guide.png</code>
-              </div>
-              <p class="img-desc">Księga znaku: paleta i typografia</p>
-            </div>
-            <div class="gallery-item">
-              <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-safe-zone.png">
-                <span class="asset-missing-icon" aria-hidden="true">📁</span>
-                <span class="asset-missing-label">Brakujący asset</span>
-                <code class="asset-missing-filename">marka-d-safe-zone.png</code>
-              </div>
-              <p class="img-desc">Safe zone i skalowanie</p>
-            </div>
-            <div class="gallery-item">
-              <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-business-card.png">
-                <span class="asset-missing-icon" aria-hidden="true">📁</span>
-                <span class="asset-missing-label">Brakujący asset</span>
-                <code class="asset-missing-filename">marka-d-business-card.png</code>
-              </div>
-              <p class="img-desc">Wizytówki</p>
-            </div>
-            <div class="gallery-item">
-              <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-social.png">
-                <span class="asset-missing-icon" aria-hidden="true">📁</span>
-                <span class="asset-missing-label">Brakujący asset</span>
-                <code class="asset-missing-filename">marka-d-social.png</code>
-              </div>
-              <p class="img-desc">Szablony social media</p>
-            </div>
-            <div class="gallery-item">
-              <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-stationery.png">
-                <span class="asset-missing-icon" aria-hidden="true">📁</span>
-                <span class="asset-missing-label">Brakujący asset</span>
-                <code class="asset-missing-filename">marka-d-stationery.png</code>
-              </div>
-              <p class="img-desc">Papeteria firmowa</p>
-            </div>
-            <div class="gallery-item">
-              <div class="asset-missing" role="img" aria-label="Brakujący asset: marka-d-web.png">
-                <span class="asset-missing-icon" aria-hidden="true">📁</span>
-                <span class="asset-missing-label">Brakujący asset</span>
-                <code class="asset-missing-filename">marka-d-web.png</code>
-              </div>
-              <p class="img-desc">Implementacja na stronie WWW</p>
-            </div>
-          </div>
         </div>
       </div>
     </div>

--- a/projects/KW-Design.html
+++ b/projects/KW-Design.html
@@ -608,6 +608,25 @@
 
   </section>
 
+  <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
+    <div class="wrap">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="power-of-mind.html">
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
+        <span class="kwcs-project-nav__text">
+          <small>Poprzedni projekt</small>
+          <strong>Power of Mind</strong>
+        </span>
+      </a>
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="razdwa_aplikacja.html">
+        <span class="kwcs-project-nav__text">
+          <small>Następny projekt</small>
+          <strong>Raz Dwa Druk</strong>
+        </span>
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </a>
+    </div>
+  </nav>
+
   <footer class="kwcs-footer">
     <div class="wrap">
       <span>&copy; 2026 Karol Wyszyński</span>

--- a/projects/cyfradruk.html
+++ b/projects/cyfradruk.html
@@ -621,6 +621,25 @@
   </section>
 
 
+  <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
+    <div class="wrap">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="voucher-salon-magdy.html">
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
+        <span class="kwcs-project-nav__text">
+          <small>Poprzedni projekt</small>
+          <strong>Voucher Salon u Magdy</strong>
+        </span>
+      </a>
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="karoma.html">
+        <span class="kwcs-project-nav__text">
+          <small>Następny projekt</small>
+          <strong>Karoma</strong>
+        </span>
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </a>
+    </div>
+  </nav>
+
   <footer class="kwcs-footer">
     <div class="wrap">
       <span>&copy; 2026 Karol Wyszyński</span>

--- a/projects/karoma.html
+++ b/projects/karoma.html
@@ -461,6 +461,25 @@
 
   </section>
 
+  <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
+    <div class="wrap">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="cyfradruk.html">
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
+        <span class="kwcs-project-nav__text">
+          <small>Poprzedni projekt</small>
+          <strong>CyfraDruk</strong>
+        </span>
+      </a>
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="power-of-mind.html">
+        <span class="kwcs-project-nav__text">
+          <small>Następny projekt</small>
+          <strong>Power of Mind</strong>
+        </span>
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </a>
+    </div>
+  </nav>
+
   <footer class="kwcs-footer">
     <div class="wrap">
       <span>&copy; 2026 Karol Wyszyński</span>

--- a/projects/power-of-mind.html
+++ b/projects/power-of-mind.html
@@ -858,6 +858,25 @@
 
   </section>
 
+  <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
+    <div class="wrap">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="karoma.html">
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
+        <span class="kwcs-project-nav__text">
+          <small>Poprzedni projekt</small>
+          <strong>Karoma</strong>
+        </span>
+      </a>
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="KW-Design.html">
+        <span class="kwcs-project-nav__text">
+          <small>Następny projekt</small>
+          <strong>KW Design</strong>
+        </span>
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </a>
+    </div>
+  </nav>
+
   <footer class="kwcs-footer">
     <div class="wrap">
       <span>&copy; 2026 Karol Wyszyński</span>

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -521,6 +521,25 @@
 
   </section>
 
+  <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
+    <div class="wrap">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="KW-Design.html">
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
+        <span class="kwcs-project-nav__text">
+          <small>Poprzedni projekt</small>
+          <strong>KW Design</strong>
+        </span>
+      </a>
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="savage.html">
+        <span class="kwcs-project-nav__text">
+          <small>Następny projekt</small>
+          <strong>Savage</strong>
+        </span>
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </a>
+    </div>
+  </nav>
+
   <footer class="kwcs-footer">
     <div class="wrap">
       <span>&copy; 2026 Karol Wyszyński</span>

--- a/projects/savage.html
+++ b/projects/savage.html
@@ -502,6 +502,25 @@
     
   </section>
 
+  <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
+    <div class="wrap">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="razdwa_aplikacja.html">
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
+        <span class="kwcs-project-nav__text">
+          <small>Poprzedni projekt</small>
+          <strong>Raz Dwa Druk</strong>
+        </span>
+      </a>
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="sir-roger.html">
+        <span class="kwcs-project-nav__text">
+          <small>Następny projekt</small>
+          <strong>Sir Roger</strong>
+        </span>
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </a>
+    </div>
+  </nav>
+
   <footer class="kwcs-footer">
     <div class="wrap">
       <span>&copy; 2026 Karol Wyszyński</span>

--- a/projects/sir-roger.html
+++ b/projects/sir-roger.html
@@ -417,6 +417,25 @@
     
   </section>
 
+  <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
+    <div class="wrap">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="savage.html">
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
+        <span class="kwcs-project-nav__text">
+          <small>Poprzedni projekt</small>
+          <strong>Savage</strong>
+        </span>
+      </a>
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="voucher-salon-magdy.html">
+        <span class="kwcs-project-nav__text">
+          <small>Następny projekt</small>
+          <strong>Voucher Salon u Magdy</strong>
+        </span>
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </a>
+    </div>
+  </nav>
+
   <footer class="kwcs-footer">
     <div class="wrap">
       <span>&copy; 2026 Karol Wyszyński</span>

--- a/projects/voucher-salon-magdy.html
+++ b/projects/voucher-salon-magdy.html
@@ -632,6 +632,25 @@
 
   </section>
 
+  <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
+    <div class="wrap">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="sir-roger.html">
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
+        <span class="kwcs-project-nav__text">
+          <small>Poprzedni projekt</small>
+          <strong>Sir Roger</strong>
+        </span>
+      </a>
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="cyfradruk.html">
+        <span class="kwcs-project-nav__text">
+          <small>Następny projekt</small>
+          <strong>CyfraDruk</strong>
+        </span>
+        <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="9 18 15 12 9 6"></polyline></svg>
+      </a>
+    </div>
+  </nav>
+
   <footer class="kwcs-footer">
     <div class="wrap">
       <span>&copy; 2026 Karol Wyszyński</span>


### PR DESCRIPTION
Dwa niezależne pakiety w dwóch osobnych commitach.

## Commit 1 — `feat(projects): add prev-next navigation across case studies`
Cykliczna nawigacja prev/next między projektami, dodana przed stopką na wszystkich 8 podstronach case study. Nowy komponent `.kwcs-project-nav` w `projects.css` (responsywny, reużywa istniejących tokenów). Linki statyczne, bez zmian w JS; `wizualizacje.html` celowo poza cyklem.

**Pliki:** `assets/css/projects.css`, `projects/{cyfradruk,karoma,power-of-mind,KW-Design,razdwa_aplikacja,savage,sir-roger,voucher-salon-magdy}.html`

## Commit 2 — `fix(kw-design): clean up pilot case study and remove placeholder assets`
Poprawki pilota standardu, wyłącznie na case study KW Design:
- naprawa id chapter rail na to, którego oczekuje współdzielony JS (rail znów działa),
- hero image `loading="eager"` + `fetchpriority="high"` (LCP nad foldem),
- przeredagowanie copy dostawy, by nie sugerowało procesu klienckiego niepasującego do marki własnej,
- usunięcie 10 pustych bloków „Brakujący asset" z galerii Ewolucja + Zastosowania; sekcje skrócone do realnej treści.

**Pliki:** `projects/KW-Design.html`

## Uwaga o podziale
`projects/KW-Design.html` należy do obu pakietów (Pakiet 1 dodał nav do wszystkich 8 podstron; Pakiet 2 to jego pilot). Rozdzielono na poziomie hunków: blok `kwcs-project-nav` → Commit 1, pozostałe zmiany → Commit 2. Każdy commit zawiera wyłącznie hunki swojego pakietu.

## Weryfikacja
- Nav: render przez HTTP potwierdził poprawny wygląd desktop/mobile, DOM przed stopką, wszystkie 16 celów prev/next istnieje.
- KW Design: rail zainicjalizowany (klik przechwycony przez JS, smooth-scroll), hero `eager` załadowany, akordeon działa, zero widocznych placeholderów, zero błędów JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FYMSNW2BpfcAiw8kPpuFW

---
_Generated by [Claude Code](https://claude.ai/code/session_014FYMSNW2BpfcAiw8kPpuFW)_