### PR TITLE
Usuń niedokończone case study Savage z publicznego flow portfolio

### DIFF
--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'power-of-mind': 'projects/power-of-mind.html',
     'KW-Design': 'projects/KW-Design.html',
     'sir-roger': 'projects/sir-roger.html',
-    'savage': 'projects/savage.html',
+    // 'savage' wyłączone z publicznego flow do czasu dostarczenia finalnych grafik
     'RazDwa': 'projects/razdwa_aplikacja.html',
     'cyfradruk': 'projects/cyfradruk.html',
   };

--- a/portfolio.html
+++ b/portfolio.html
@@ -204,22 +204,7 @@
                     </div>
                 </article>
 
-                <article class="portfolio-new-card" data-project="savage" role="button" tabindex="0" aria-label="Savage — Branding i strona WWW">
-                    <div class="card-image-wrapper">
-                        <img src="assets/KARUZELAJ/Savage.jpg" alt="Savage — identyfikacja wizualna marki i wdrożenie strony WordPress" loading="lazy" decoding="async">
-                    </div>
-                    <div class="card-content">
-                        <span class="card-category">WordPress · Branding</span>
-                        <h3 class="card-title">Savage</h3>
-                        <p class="card-description">Kompleksowy pakiet: logo, identyfikacja wizualna i wdrożenie strony WordPress.</p>
-                        <div class="card-features">
-                            <span class="feature-item">WordPress</span>
-                            <span class="feature-item">Logo</span>
-                            <span class="feature-item">UX/UI</span>
-                        </div>
-                        <span class="card-cta">Zobacz projekt <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></span>
-                    </div>
-                </article>
+                <!-- Karta Savage tymczasowo wyłączona z publicznego flow — case study czeka na finalne grafiki (projects/savage.html zostaje w repo) -->
 
                 <article class="portfolio-new-card" data-project="sir-roger" role="button" tabindex="0" aria-label="Sir Roger — Rebranding i opakowania">
                     <div class="card-image-wrapper">

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -540,10 +540,10 @@
           <strong>KW Design</strong>
         </span>
       </a>
-      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="savage.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="sir-roger.html">
         <span class="kwcs-project-nav__text">
           <small>Następny projekt</small>
-          <strong>Savage</strong>
+          <strong>Sir Roger</strong>
         </span>
         <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="9 18 15 12 9 6"></polyline></svg>
       </a>


### PR DESCRIPTION
## Zakres

Minimalny bezpieczny zakres: usunięcie z publicznego flow tylko niedokończonego case study **Savage** (wszystkie 15 obrazów to `placeholder.jpg`). Plik `projects/savage.html` **zostaje w repo bez zmian** — wraca do flow po dostarczeniu finalnych grafik.

### Zmiany

- **`portfolio.html`** — karta Savage usunięta z gridu; w jej miejscu komentarz HTML z powodem, żeby przywrócenie było oczywiste.
- **`assets/js/portfolio.js`** — wpis `'savage'` wyłączony z mapy `projectPages` (zakomentowany). To jedno miejsce steruje kartą, deep-linkiem `portfolio.html#savage` i `hashchange` — po zmianie hash `#savage` jest po prostu ignorowany, bez błędu.
- **`projects/razdwa_aplikacja.html`** — link „Następny projekt" przekierowany z Savage na Sir Roger (kolejny projekt w łańcuchu prev/next).

### Poza zakresem (oznaczone)

- `projects/sir-roger.html` ma link „Poprzedni projekt" → `savage.html` — zgodnie z ustaleniem sir-roger nie jest ruszany w tym pakiecie. Link widoczny tylko przy bezpośrednim wejściu na `projects/sir-roger.html` (nawigacja prev/next nie jest wstrzykiwana do viewera na portfolio.html).
- `projects/wizualizacje.html` używa obrazka `Savage.jpg` bez linku do strony — bez zmian.
- Bezpośredni URL `projects/savage.html` pozostaje technicznie osiągalny (plik nie jest usuwany), ale nie prowadzi do niego żaden publiczny link z flow portfolio.

### Weryfikacja

- `node --check assets/js/portfolio.js` — składnia OK.
- Balans tagów HTML w `portfolio.html` i `razdwa_aplikacja.html` — OK.
- `grep` po repo: brak linków do savage poza `sir-roger.html` (poza zakresem) i samym plikiem case study.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgNaQc9ekvGySWyq2GQ6bn

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgNaQc9ekvGySWyq2GQ6bn)_