### PR TITLE
Raz Dwa Druk case study — przebudowa języka i struktury pod SB7

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3714,3 +3714,62 @@ body { overflow-x: hidden; }
     justify-content: flex-end;
   }
 }
+
+/* ============================================================
+   Raz Dwa — blok zaproszenia (CTA końcowe) + slot cytatu klienta
+   Scope: #case-razdwa-pelne (nie wpływa na inne case studies)
+============================================================ */
+#case-razdwa-pelne .result-invite {
+  margin-top: 2.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.3);
+  text-align: center;
+}
+#case-razdwa-pelne .result-invite h3 {
+  font-size: 1.5rem;
+  line-height: 1.3;
+  margin: 0 0 0.75rem;
+  color: #0f172a;
+}
+#case-razdwa-pelne .result-invite p {
+  max-width: 640px;
+  margin: 0 auto 0.5rem;
+  color: #475569;
+}
+#case-razdwa-pelne .result-invite-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+#case-razdwa-pelne .kwcs-cta--ghost {
+  background: transparent;
+  color: #0284c7;
+  box-shadow: none;
+  border: 1px solid #0284c7;
+}
+#case-razdwa-pelne .kwcs-cta--ghost:hover {
+  background: rgba(2, 132, 199, 0.08);
+  box-shadow: none;
+}
+
+/* Gotowy styl dla cytatu klienta — aktywny po odkomentowaniu slotu w HTML */
+#case-razdwa-pelne .razdwa-quote {
+  margin: 2.5rem auto 0;
+  max-width: 720px;
+  padding: 1.75rem 2rem;
+  border-left: 4px solid #06b6d4;
+  background: rgba(6, 182, 212, 0.07);
+  border-radius: 0 0.75rem 0.75rem 0;
+}
+#case-razdwa-pelne .razdwa-quote blockquote {
+  margin: 0 0 1rem;
+  font-size: 1.2rem;
+  line-height: 1.6;
+  font-style: italic;
+  color: #0f172a;
+}
+#case-razdwa-pelne .razdwa-quote figcaption {
+  font-weight: 600;
+  color: #334155;
+}

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3735,26 +3735,6 @@ body { overflow-x: hidden; }
 }
 
 /* ============================================================
-   Raz Dwa — hero image: responsywne skalowanie i poprawne proporcje
-   (plik ma ~1450x1306; wcześniej wymuszone width=1200/height=630
-   zniekształcało obraz i powodowało overflow poza viewport)
-   Scope: #case-razdwa-pelne (nie wpływa na inne case studies)
-============================================================ */
-#case-razdwa-pelne .kwcs-hero-body .hero-image {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-}
-#case-razdwa-pelne .kwcs-hero-body .cover {
-  display: block;
-  width: 100%;
-  max-width: 760px;
-  height: auto;
-  border-radius: 14px;
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
-}
-
-/* ============================================================
    Raz Dwa — blok zaproszenia (CTA końcowe) + slot cytatu klienta
    Scope: #case-razdwa-pelne (nie wpływa na inne case studies)
 ============================================================ */

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -2721,7 +2721,7 @@ body.lightbox-open {
   border-radius: 0.85rem;
   padding: 0.75rem 0.7rem;
   margin: 0;
-  width: 220px;
+  width: 180px;
   max-height: calc(100vh - 32px);
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -2831,28 +2831,29 @@ body.lightbox-open {
    żeby rail nie nachodził na sekcje przy max-width 1200 wycentrowanych */
 @media (min-width: 1280px) {
   .razdwa-chapter-rail {
-    width: 232px;
+    width: 172px;
     padding: 0.8rem 0.7rem;
   }
   .razdwa-chapter-link {
     font-size: 0.79rem;
     padding: 0.38rem 0.65rem;
   }
-  /* Wypchnij content RAZDWA w prawo, żeby rail (16 + 232 + ~24 gap) nie nachodził */
-  #case-razdwa-pelne { padding-left: 272px; }
+  /* Odsuń content RAZDWA za rail (16 + ~196 wizualnie + gap) i poszerz kolumnę,
+     żeby treść dosunęła się w lewo i zmniejszył się prawy margines */
+  #case-razdwa-pelne { padding-left: 216px; --wrap-max: 1240px; }
 }
 
 /* Laptop 1101-1279px — węższy rail, mniejszy margin contentu */
 @media (min-width: 1101px) and (max-width: 1279px) {
   .razdwa-chapter-rail {
-    width: 190px;
+    width: 150px;
     padding: 0.6rem 0.55rem;
   }
   .razdwa-chapter-link {
     font-size: 0.74rem;
     padding: 0.32rem 0.5rem;
   }
-  #case-razdwa-pelne { padding-left: 232px; }
+  #case-razdwa-pelne { padding-left: 184px; --wrap-max: 1120px; }
 }
 
 /* Tablet i mobile ≤1100px — fixed top bar z poziomym scrollem pigułek */

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3735,6 +3735,26 @@ body { overflow-x: hidden; }
 }
 
 /* ============================================================
+   Raz Dwa — hero image: responsywne skalowanie i poprawne proporcje
+   (plik ma ~1450x1306; wcześniej wymuszone width=1200/height=630
+   zniekształcało obraz i powodowało overflow poza viewport)
+   Scope: #case-razdwa-pelne (nie wpływa na inne case studies)
+============================================================ */
+#case-razdwa-pelne .kwcs-hero-body .hero-image {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+#case-razdwa-pelne .kwcs-hero-body .cover {
+  display: block;
+  width: 100%;
+  max-width: 760px;
+  height: auto;
+  border-radius: 14px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+}
+
+/* ============================================================
    Raz Dwa — blok zaproszenia (CTA końcowe) + slot cytatu klienta
    Scope: #case-razdwa-pelne (nie wpływa na inne case studies)
 ============================================================ */

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3735,6 +3735,18 @@ body { overflow-x: hidden; }
 }
 
 /* ============================================================
+   Raz Dwa — hero CTA: na mobile ma width:100% + padding, ale bez
+   box-sizing:border-box padding wychodzil poza szerokosc (overflow
+   ~16px na 390px). border-box wlacza padding w szerokosc.
+   Na desktopie przycisk ma width:fit-content, wiec bez zmian.
+   Scope: #case-razdwa-pelne (nie wpływa na inne case studies)
+============================================================ */
+#case-razdwa-pelne .hero-image-cta {
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+/* ============================================================
    Raz Dwa — blok zaproszenia (CTA końcowe) + slot cytatu klienta
    Scope: #case-razdwa-pelne (nie wpływa na inne case studies)
 ============================================================ */

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3742,6 +3742,11 @@ body { overflow-x: hidden; }
   gap: 1rem;
   justify-content: center;
 }
+/* neutralizacja margin:auto z .kwcs-result .kwcs-cta, ktory w flexie
+   rozpychal przyciski na krawedzie */
+#case-razdwa-pelne .result-invite-actions .kwcs-cta {
+  margin: 0.5rem 0;
+}
 #case-razdwa-pelne .kwcs-cta--ghost {
   background: transparent;
   color: #0284c7;

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -173,6 +173,24 @@
 }
 .hero-content-grid > .hero-image:only-child { grid-column: 1 / -1; }
 
+/* Hero image (tylko Raz Dwa) — responsywny, bez zniekształceń: plik ma proporcje
+   ~1450x1306, a atrybuty width/height 1200x630 wymuszaly spłaszczenie; brakowało
+   reguły CSS. Scope #case-razdwa-pelne, żeby nie ruszać innych case studies. */
+#case-razdwa-pelne .kwcs-hero-body .hero-image {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+#case-razdwa-pelne .kwcs-hero-body .hero-image .cover {
+  display: block;
+  width: 100%;
+  max-width: 1040px;
+  height: auto;
+  object-fit: contain;
+  border-radius: 14px;
+  box-shadow: 0 24px 60px -28px rgba(15, 23, 42, 0.32);
+}
+
 .hero-buttons-vertical {
   display: flex;
   flex-direction: column;

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -58,14 +58,15 @@
       <div class="razdwa-chapter-rail-label">Rozdziały</div>
   <ul class="razdwa-chapter-rail-list">
   <li><a class="razdwa-chapter-link" href="#razdwa-summary" data-rail-target="razdwa-summary" title="W skrócie" aria-label="W skrócie">W skrócie</a></li>
-  <li><a class="razdwa-chapter-link" href="#razdwa-kontekst" data-rail-target="razdwa-kontekst" title="Kontekst i moja rola" aria-label="Kontekst i moja rola">Kontekst i moja rola</a></li>
-  <li><a class="razdwa-chapter-link" href="#razdwa-decyzje" data-rail-target="razdwa-decyzje" title="Kluczowe decyzje produktowe" aria-label="Kluczowe decyzje produktowe">Kluczowe decyzje</a></li>
-  <li><a class="razdwa-chapter-link" href="#razdwa-ux" data-rail-target="razdwa-ux" title="Interfejs i przepływ pracy" aria-label="Interfejs i przepływ pracy">Interfejs i przepływ pracy</a></li>
-  <li><a class="razdwa-chapter-link" href="#razdwa-logika" data-rail-target="razdwa-logika" title="Automatyzacja wycen CAD" aria-label="Automatyzacja wycen CAD">Automatyzacja CAD</a></li>
-  <li><a class="razdwa-chapter-link" href="#razdwa-cennik" data-rail-target="razdwa-cennik" title="Zarządzanie cennikiem i ofertą" aria-label="Zarządzanie cennikiem i ofertą">Zarządzanie cennikiem</a></li>
-  <li><a class="razdwa-chapter-link" href="#razdwa-architektura" data-rail-target="razdwa-architektura" title="Strategia techniczna i ekosystem" aria-label="Strategia techniczna i ekosystem">Strategia techniczna</a></li>
-  <li><a class="razdwa-chapter-link" href="#razdwa-lessons" data-rail-target="razdwa-lessons" title="Wnioski po wdrożeniu" aria-label="Wnioski po wdrożeniu">Wnioski</a></li>
-  <li><a class="razdwa-chapter-link" href="#razdwa-rezultat" data-rail-target="razdwa-rezultat" title="Rezultat projektu" aria-label="Rezultat projektu">Rezultat</a></li>
+  <li><a class="razdwa-chapter-link" href="#razdwa-kontekst" data-rail-target="razdwa-kontekst" title="Problem: wolna wycena i ryzyko pomyłki" aria-label="Problem: wolna wycena i ryzyko pomyłki">Problem</a></li>
+  <li><a class="razdwa-chapter-link" href="#razdwa-rola" data-rail-target="razdwa-rola" title="Moja rola" aria-label="Moja rola">Moja rola</a></li>
+  <li><a class="razdwa-chapter-link" href="#razdwa-decyzje" data-rail-target="razdwa-decyzje" title="Trzy decyzje: tanie utrzymanie i prosta obsługa" aria-label="Trzy decyzje: tanie utrzymanie i prosta obsługa">Kluczowe decyzje</a></li>
+  <li><a class="razdwa-chapter-link" href="#razdwa-ux" data-rail-target="razdwa-ux" title="Wycena w kilku krokach" aria-label="Wycena w kilku krokach">Szybka wycena</a></li>
+  <li><a class="razdwa-chapter-link" href="#razdwa-logika" data-rail-target="razdwa-logika" title="Najtrudniejsze wyceny liczą się same" aria-label="Najtrudniejsze wyceny liczą się same">Automatyzacja CAD</a></li>
+  <li><a class="razdwa-chapter-link" href="#razdwa-cennik" data-rail-target="razdwa-cennik" title="Właściciel zmienia ceny sam" aria-label="Właściciel zmienia ceny sam">Samodzielny cennik</a></li>
+  <li><a class="razdwa-chapter-link" href="#razdwa-architektura" data-rail-target="razdwa-architektura" title="Bez serwera i stałych opłat" aria-label="Bez serwera i stałych opłat">Lekka architektura</a></li>
+  <li><a class="razdwa-chapter-link" href="#razdwa-lessons" data-rail-target="razdwa-lessons" title="Czego nauczyło mnie to wdrożenie" aria-label="Czego nauczyło mnie to wdrożenie">Wnioski</a></li>
+  <li><a class="razdwa-chapter-link" href="#razdwa-rezultat" data-rail-target="razdwa-rezultat" title="Co zmieniło się w drukarni" aria-label="Co zmieniło się w drukarni">Rezultat</a></li>
 </ul>
     </nav>
 

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -366,7 +366,7 @@
 <div class="kwcs-sec">
   <div class="wrap">
     <p class="kwcs-section-lead">
-      Jeden z kluczowych celów projektu to uniezależnienie właściciela od programisty przy zarządzaniu cenami. Panel administracyjny pozwala samodzielnie aktualizować stawki, kontrolować dostęp do edycji i dodawać nowe warianty bez psucia struktury danych. Dzięki temu firma reaguje na zmiany cen od ręki i nie płaci za każdą aktualizację cennika.
+      Panel administracyjny pozwala właścicielowi <strong>samodzielnie</strong> zmieniać stawki i dodawać warianty — bez psucia struktury danych. Ceny aktualizuje się <strong>od ręki, bez programisty</strong> i bez kosztu za każdą zmianę.
     </p>
 
     <div class="kwcs-gallery-grid kwcs-gallery-grid--single" style="margin-bottom:2rem;">

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -156,7 +156,7 @@
 <div class="kwcs-sec">
   <div class="wrap">
     <p class="kwcs-section-lead">
-      Drukarnia wyceniała zlecenia ręcznie, z papierowego cennika. Przy ladzie oznaczało to presję czasu, a przy złożonych zamówieniach — realne ryzyko, że cena wyjdzie błędna. To właśnie te dwa problemy — czas i pomyłki — kosztowały firmę najwięcej.
+      Drukarnia wyceniała zlecenia ręcznie, z papierowego cennika. Przy ladzie oznaczało to <strong>presję czasu</strong>, a przy złożonych zamówieniach — realne ryzyko, że <strong>cena wyjdzie błędna</strong> i firma na tym straci.
     </p>
 
     <div class="ux-decision-grid">
@@ -177,7 +177,7 @@
 <div class="kwcs-sec">
   <div class="wrap">
     <p class="kwcs-section-lead">
-      Prowadziłem projekt kompleksowo: od rozpoznania procesu w drukarni po zaprojektowanie, wdrożenie i uruchomienie działającego systemu. Klient dostał jednego wykonawcę odpowiedzialnego za całość — od diagnozy problemu po efekt.
+      Prowadziłem projekt <strong>kompleksowo</strong> — od rozpoznania procesu w drukarni po wdrożenie i uruchomienie systemu. Klient miał <strong>jednego wykonawcę</strong> odpowiedzialnego za całość, od diagnozy po efekt.
     </p>
 
     <div class="contribution-grid--razdwa">
@@ -187,8 +187,7 @@
           <li>Analiza procesu wyceny i identyfikacja problemów operacyjnych</li>
           <li>Projekt architektury produktu i głównych przepływów użytkownika</li>
           <li>Opracowanie panelu cen i struktury danych</li>
-          <li>Implementacja rozwiązania produkcyjnego</li>
-          <li>Implementacja, testy i wdrożenie</li>
+          <li>Implementacja produkcyjna, testy i wdrożenie</li>
         </ul>
       </div>
     </div>

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -482,7 +482,7 @@
       <div class="ux-decision-box">
         <div class="ux-label">Wniosek 2</div>
         <h4>Architektura z warunków, nie z preferencji</h4>
-        <p>Google Sheets i Apps Script to nie był tańszy zamiennik serwera. To było jedyne rozwiązanie pasujące do środowiska: brak własnej infrastruktury, znane narzędzia po stronie klienta i zerowy koszt stały. Wybór wynikł z diagnozy, nie z nawyku.</p>
+        <p>Google Sheets i Apps Script to nie był tańszy zamiennik serwera — to było jedyne rozwiązanie pasujące do środowiska klienta. <strong>Wybór wynikł z diagnozy, nie z nawyku.</strong></p>
       </div>
       <div class="ux-decision-box">
         <div class="ux-label">Wniosek 3</div>
@@ -502,7 +502,7 @@
 
       <div class="result-lead">
         <p>
-          Efektem projektu było narzędzie, które uprościło codzienną pracę drukarni i skróciło czas przygotowania wyceny z około godziny do około 5 minut. System uporządkował proces zamówień, zmniejszył ryzyko błędów rachunkowych i oddał klientowi większą kontrolę nad cennikiem bez konieczności angażowania programisty.
+          Drukarnia dostała narzędzie, które skróciło wycenę <strong>z godziny do około 5 minut</strong> i uporządkowało obsługę zamówień. Mniej <strong>błędów rachunkowych</strong>, a właściciel sam panuje nad cennikiem.
         </p>
       </div>
 

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -246,10 +246,13 @@
 
 
     
-<h2 class="section-divider" id="razdwa-ux">Interfejs i przepływ pracy</h2>
+<h2 class="section-divider" id="razdwa-ux">Wycena w kilku krokach, bez przełączania okien</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">
+    <p class="kwcs-section-lead">
+      Obsługę zamówienia zaprojektowałem jako jedną, powtarzalną ścieżkę — operator przechodzi od wyboru usługi do gotowego dokumentu bez przeskakiwania między ekranami. Dzięki temu wycena przy ladzie jest szybka, a klient czeka krócej.
+    </p>
     <h3 class="kwcs-h3-center mt-0">Główna ścieżka obsługi zamówienia</h3>
     <div class="user-flow">
       <div class="flow-step">
@@ -317,18 +320,18 @@
       </div>
       <div class="gallery-item">
         <img class="lightbox-trigger" src="/KWdesignnew/assets/images/razdwa/raport_PDF_RAZDWA.webp" alt="Wygenerowany raport PDF zamówienia" loading="lazy" data-caption="Raport PDF — gotowe podsumowanie techniczne zamówienia">
-        <p class="img-desc"><strong>Gotowy dokument:</strong> Podsumowanie zamówienia powstaje bezpośrednio w aplikacji.</p>
+        <p class="img-desc"><strong>Gotowy dokument:</strong> Podsumowanie zamówienia powstaje bezpośrednio w aplikacji — klient dostaje czytelną wycenę od ręki, bez przepisywania danych.</p>
       </div>
     </div>
   </div>
 </div>
 
-<h2 class="section-divider" id="razdwa-logika">Automatyzacja wycen CAD</h2>
+<h2 class="section-divider" id="razdwa-logika">Najtrudniejsze wyceny liczą się same</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">
     <p class="kwcs-section-lead">
-      Najtrudniejszą technicznie częścią systemu była wycena plików CAD — obsługa parametrów pliku, orientacji wydruku i wyjątków formatowych, które przy ręcznym podejściu generowały największe ryzyko błędów.
+      Najtrudniejszą technicznie częścią systemu była wycena plików CAD — obsługa parametrów pliku, orientacji wydruku i wyjątków formatowych, które przy ręcznym podejściu generowały największe ryzyko błędów. To właśnie tu znikała godzina liczenia: system rozpoznaje parametry i podaje cenę sam, więc operator nie musi liczyć ręcznie, a pomyłka wymiarowa jest znacznie mniej prawdopodobna.
     </p>
 
     <div class="kwcs-gallery-grid kwcs-gallery-grid--mb">

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -216,29 +216,29 @@
 
 
     
-<h2 class="section-divider" id="razdwa-decyzje">Kluczowe decyzje produktowe</h2>
+<h2 class="section-divider" id="razdwa-decyzje">Trzy decyzje, dzięki którym aplikacja jest tania w utrzymaniu i prosta w obsłudze</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">
     <p class="kwcs-section-lead">
-    Problemem nie był tylko długi czas wyceny, ale też liczba wyjątków, ryzyko błędów i brak prostego zarządzania cennikiem. Dlatego rozwiązanie oparłem na trzech decyzjach, które uprościły pracę i ograniczyły koszty utrzymania.
+    Problemem nie był tylko długi czas wyceny, ale też liczba wyjątków, ryzyko błędów i brak prostego zarządzania cennikiem. Dlatego rozwiązanie oparłem na trzech decyzjach — każda z nich obniżała koszt utrzymania albo skracała czas pracy przy ladzie.
     </p>
 
     <div class="ux-decision-grid ux-decision-grid--trio">
       <div class="ux-decision-box">
         <div class="ux-label">Decyzja 1</div>
         <h4>Dedykowana aplikacja zamiast gotowego sklepu</h4>
-        <p>Zamiast skomplikowanego systemu, zaprojektowałem prostą aplikację, dopasowaną do szybkiej obsługi przy ladzie i pracy na starszym sprzęcie.</p>
+        <p>Zamiast skomplikowanego systemu zaprojektowałem prostą aplikację, dopasowaną do szybkiej obsługi przy ladzie i pracy na starszym sprzęcie. Dzięki temu operator nie walczy z narzędziem, tylko szybko obsługuje klienta.</p>
       </div>
       <div class="ux-decision-box">
         <div class="ux-label">Decyzja 2</div>
         <h4>Znane zaplecze zamiast ciężkiej infrastruktury</h4>
-        <p>Google Sheets i Apps Script pozwoliły oprzeć system na narzędziach, które klient już znał, dzięki czemu rozwiązanie było tańsze i prostsze w utrzymaniu.</p>
+        <p>Google Sheets i Apps Script pozwoliły oprzeć system na narzędziach, które klient już znał. Dzięki temu wdrożenie było tańsze, a firma nie płaci co miesiąc za serwer ani za specjalistyczne utrzymanie.</p>
       </div>
       <div class="ux-decision-box">
         <div class="ux-label">Decyzja 3</div>
-        <h4>Panel cen zamiast zależności od developera</h4>
-        <p>Właściciel potrzebował samodzielnie aktualizować stawki, dlatego stworzyłem panel administracyjny, który pozwala zmieniać cennik bez kontaktowania się z programistą.</p>
+        <h4>Panel cen zamiast zależności od programisty</h4>
+        <p>Właściciel potrzebował samodzielnie aktualizować stawki, dlatego stworzyłem panel administracyjny do zmiany cennika. Dzięki temu firma nie czeka na developera i nie płaci za każdą korektę ceny.</p>
       </div>
     </div>
   </div>

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -361,12 +361,12 @@
   </div>
 </div>
 
-<h2 class="section-divider" id="razdwa-cennik">Zarządzanie cennikiem i ofertą</h2>
+<h2 class="section-divider" id="razdwa-cennik">Właściciel zmienia ceny sam, bez dzwonienia do programisty</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">
     <p class="kwcs-section-lead">
-      Jeden z kluczowych celów projektu to uniezależnienie właściciela od programisty przy zarządzaniu cenami. Panel administracyjny pozwala samodzielnie aktualizować stawki, kontrolować dostęp do edycji i dodawać nowe warianty bez psucia struktury danych.
+      Jeden z kluczowych celów projektu to uniezależnienie właściciela od programisty przy zarządzaniu cenami. Panel administracyjny pozwala samodzielnie aktualizować stawki, kontrolować dostęp do edycji i dodawać nowe warianty bez psucia struktury danych. Dzięki temu firma reaguje na zmiany cen od ręki i nie płaci za każdą aktualizację cennika.
     </p>
 
     <div class="kwcs-gallery-grid kwcs-gallery-grid--single" style="margin-bottom:2rem;">
@@ -407,12 +407,12 @@
   </div>
 </div>
 
-<h2 class="section-divider" id="razdwa-architektura">Strategia techniczna i ekosystem</h2>
+<h2 class="section-divider" id="razdwa-architektura">Działa na tym, co klient już zna — bez serwera i stałych opłat</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">
     <p class="kwcs-section-lead">
-      Aplikację zaprojektowałem jako lekkie rozwiązanie bez rozbudowanej infrastruktury. Zamiast klasycznego backendu i osobnej bazy danych wykorzystałem ekosystem Google, co uprościło wdrożenie, ograniczyło koszty i pozwoliło klientowi pracować na znanych narzędziach.
+      Aplikację zaprojektowałem jako lekkie rozwiązanie bez rozbudowanej infrastruktury. Zamiast klasycznego backendu i osobnej bazy danych wykorzystałem ekosystem Google, co uprościło wdrożenie, ograniczyło koszty i pozwoliło klientowi pracować na znanych narzędziach. Dla firmy oznacza to zero comiesięcznych opłat za serwer i brak uzależnienia od jednego dostawcy.
     </p>
 
     <h3 class="kwcs-h3-center mt-0" id="razdwa-architektura-ekosystem">Jak współpracują główne moduły</h3>

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -450,7 +450,7 @@
 
     <div class="kwcs-callout">
       <p>
-        <strong>Efekt architektoniczny:</strong> zamiast inwestować w ciężką infrastrukturę, klient dostał szybkie narzędzie do codziennej pracy, z historią zamówień, panelem cen i prostym modelem utrzymania opartym o narzędzia, które już znał.
+        <strong>Efekt dla firmy:</strong> historia zamówień, cennik i codzienna obsługa w jednym miejscu, które właściciel utrzymuje sam — bez działu IT i bez developera na telefonie.
       </p>
     </div>
 

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -104,8 +104,8 @@
               alt="Raz Dwa Druk — system cyfrowy drukarni"
               loading="lazy"
               decoding="async"
-              width="1200"
-              height="630"
+              width="1450"
+              height="1306"
               data-caption="Raz Dwa Druk — kompletny kalkulator wycen B2B">
           </div>
         </div>

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -150,24 +150,34 @@
 
 
     
-  <h2 class="section-divider" id="razdwa-kontekst">Kontekst i moja rola</h2>
+  <h2 class="section-divider" id="razdwa-kontekst">Zanim powstała aplikacja: wycena trwała godzinę i łatwo było o pomyłkę</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">
     <p class="kwcs-section-lead">
-      Prowadziłem projekt kompleksowo: od rozpoznania procesu w drukarni po zaprojektowanie, wdrożenie i uruchomienie działającego systemu.
+      Drukarnia wyceniała zlecenia ręcznie, z papierowego cennika. Przy ladzie oznaczało to presję czasu, a przy złożonych zamówieniach — realne ryzyko, że cena wyjdzie błędna. To właśnie te dwa problemy — czas i pomyłki — kosztowały firmę najwięcej.
     </p>
 
     <div class="ux-decision-grid">
       <div class="ux-decision-box">
-        <h4>Wyzwanie biznesowe</h4>
+        <h4>Co spowalniało i kosztowało</h4>
         <p>Najtrudniejsze były zlecenia CAD: wiele parametrów, presja czasu i wysoki koszt pomyłki przy obsłudze klienta na miejscu. Ręczna wycena potrafiła zajmować nawet godzinę.</p>
       </div>
       <div class="ux-decision-box">
-        <h4>Dwie role w jednym systemie</h4>
+        <h4>Dwie osoby, dwie różne potrzeby</h4>
         <p><strong>Operator:</strong> potrzebował prostego, szybkiego interfejsu odpornego na błędy. <strong>Właściciel:</strong> potrzebował kontroli nad cennikiem i możliwości samodzielnej edycji stawek.</p>
       </div>
     </div>
+  </div>
+</div>
+
+<h2 class="section-divider" id="razdwa-rola">Moja rola: od rozpoznania procesu po działające narzędzie</h2>
+
+<div class="kwcs-sec">
+  <div class="wrap">
+    <p class="kwcs-section-lead">
+      Prowadziłem projekt kompleksowo: od rozpoznania procesu w drukarni po zaprojektowanie, wdrożenie i uruchomienie działającego systemu. Klient dostał jednego wykonawcę odpowiedzialnego za całość — od diagnozy problemu po efekt.
+    </p>
 
     <div class="contribution-grid--razdwa">
       <div class="contribution-cell contribution-cell--solo">
@@ -185,20 +195,19 @@
     <div class="razdwa-stats">
       <div class="razdwa-stat">
         <div class="razdwa-stat-num">~5 min</div>
-        <div class="razdwa-stat-label">czas wyceny zamiast ok. godziny</div>
+        <div class="razdwa-stat-label">tyle trwa dziś typowa wycena — wcześniej nawet godzina</div>
       </div>
-     
       <div class="razdwa-stat">
-        <div class="razdwa-stat-num">2</div>
-        <div class="razdwa-stat-label">role w systemie: operator i admin</div>
+        <div class="razdwa-stat-num">−90%</div>
+        <div class="razdwa-stat-label">krócej przy dużych zleceniach CAD, gdzie ręczne liczenie było najżmudniejsze</div>
       </div>
       <div class="razdwa-stat">
         <div class="razdwa-stat-num">0 zł</div>
-        <div class="razdwa-stat-label">stałych kosztów serwera</div>
+        <div class="razdwa-stat-label">stałych kosztów serwera miesięcznie</div>
       </div>
-       <div class="razdwa-stat">
-        <div class="razdwa-stat-num">samodzielna edycja cen</div>
-        <div class="razdwa-stat-label">panel administatora do zmiany cen produktów</div>
+      <div class="razdwa-stat">
+        <div class="razdwa-stat-num">2 role</div>
+        <div class="razdwa-stat-label">operator i właściciel obsłużeni jednym systemem</div>
       </div>
     </div>
   </div>

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -75,7 +75,7 @@
         <p class="eyebrow">Case Study · Aplikacja biznesowa dla drukarni</p>
         <h1>Raz Dwa Druk<br>aplikacja, która skróciła wycenę z godziny do 5 minut</h1>
         <p class="sub">
-          Zastąpiłem ręczne liczenie i papierowy cennik na aplikacje, która uprościła wycenę, ograniczyła błędy i uporządkowała obsługę zamówień w drukarni.
+          Zastąpiłem ręczne liczenie i papierowy cennik aplikacją, która uprościła wycenę, ograniczyła błędy i uporządkowała obsługę zamówień w drukarni.
         </p>
        <div class="pm-hero-meta">
   <span><strong>Rola</strong> Product Design, UX/UI, wdrożenie</span>
@@ -84,7 +84,7 @@
   <span class="pm-meta-sep">·</span>
   <span><strong>Zakres</strong> analiza procesu, UX/UI, logika systemu</span>
 <span class="pm-meta-sep">·</span>
-<span><strong>Efekt</strong>  90% krótszy czas wyceny większych zamówień</span>
+<span><strong>Efekt</strong>  wycena z godziny do ok. 5 minut, a przy dużych zleceniach CAD nawet o 90% krócej</span>
 </div>
       </div>
     </div>
@@ -129,7 +129,7 @@
        <div class="razdwa-summary-grid">
   <div class="razdwa-summary-cell">
     <div class="label">Problem</div>
-    <div class="value">Ręczna wycena zajmowała nawet godzinę i zwiększała ryzyko pomyłek.</div>
+    <div class="value">Ręczna wycena zajmowała nawet godzinę, a każda pomyłka w cenie kosztowała drukarnię pieniądze i zaufanie klienta.</div>
   </div>
   <div class="razdwa-summary-cell">
     <div class="label">Moja rola</div>
@@ -141,7 +141,7 @@
   </div>
   <div class="razdwa-summary-cell">
     <div class="label">Efekt</div>
-    <div class="value">Wycena skrócona do około 5 minut, bez kosztów stałego utrzymania.</div>
+    <div class="value">Wycena skrócona z około godziny do około 5 minut — bez stałych kosztów utrzymania.</div>
           </div>
         </div>
         <p class="kwcs-footnote">Szacunek oparty na porównaniu obsługi podobnego zamówienia przed i po wdrożeniu.</p>

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -331,7 +331,7 @@
 <div class="kwcs-sec">
   <div class="wrap">
     <p class="kwcs-section-lead">
-      Najtrudniejszą technicznie częścią systemu była wycena plików CAD — obsługa parametrów pliku, orientacji wydruku i wyjątków formatowych, które przy ręcznym podejściu generowały największe ryzyko błędów. To właśnie tu znikała godzina liczenia: system rozpoznaje parametry i podaje cenę sam, więc operator nie musi liczyć ręcznie, a pomyłka wymiarowa jest znacznie mniej prawdopodobna.
+      Najtrudniejsza technicznie była wycena plików CAD — parametry pliku, orientacja wydruku i wyjątki formatowe, które przy ręcznym liczeniu dawały największe ryzyko błędu. Teraz system <strong>rozpoznaje parametry i liczy cenę sam</strong> — znika godzina pracy, a o <strong>pomyłkę wymiarową znacznie trudniej</strong>.
     </p>
 
     <div class="kwcs-gallery-grid kwcs-gallery-grid--mb">

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -412,7 +412,7 @@
 <div class="kwcs-sec">
   <div class="wrap">
     <p class="kwcs-section-lead">
-      Aplikację zaprojektowałem jako lekkie rozwiązanie bez rozbudowanej infrastruktury. Zamiast klasycznego backendu i osobnej bazy danych wykorzystałem ekosystem Google, co uprościło wdrożenie, ograniczyło koszty i pozwoliło klientowi pracować na znanych narzędziach. Dla firmy oznacza to zero comiesięcznych opłat za serwer i brak uzależnienia od jednego dostawcy.
+      Zamiast klasycznego backendu i bazy danych oparłem system o <strong>ekosystem Google</strong> — narzędzia, które klient już znał. Dla firmy to <strong>zero opłat za serwer</strong> i brak uzależnienia od jednego dostawcy.
     </p>
 
     <h3 class="kwcs-h3-center mt-0" id="razdwa-architektura-ekosystem">Jak współpracują główne moduły</h3>

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -465,12 +465,12 @@
 
 
     
-<h2 class="section-divider" id="razdwa-lessons">Wnioski po wdrożeniu</h2>
+<h2 class="section-divider" id="razdwa-lessons">Czego nauczyło mnie to wdrożenie</h2>
 
 <div class="kwcs-sec kwcs-sec--alt">
   <div class="wrap">
     <p class="kwcs-section-lead">
-      To wdrożenie utwierdziło mnie w trzech rzeczach: najpierw trzeba zobaczyć realną pracę użytkownika, architektura musi wynikać z warunków operacyjnych, a najlepsze funkcje często pojawiają się dopiero po uruchomieniu pierwszej wersji produktu.
+      To wdrożenie utwierdziło mnie w trzech rzeczach: najpierw trzeba zobaczyć realną pracę użytkownika, architektura musi wynikać z warunków operacyjnych, a najlepsze funkcje często pojawiają się dopiero po uruchomieniu pierwszej wersji produktu. Dla klienta oznacza to jedno: pracuję na jego realnym procesie, a nie na założeniach z briefu.
     </p>
 
     <div class="ux-decision-grid ux-decision-grid--trio">
@@ -493,12 +493,12 @@
   </div>
 </div>
 
-<h2 class="section-divider" id="razdwa-rezultat">Rezultat projektu</h2>
+<h2 class="section-divider" id="razdwa-rezultat">Co zmieniło się w drukarni po wdrożeniu</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">
     <div class="kwcs-result">
-      <h3 class="kwcs-result-title">Co zmieniło się po wdrożeniu</h3>
+      <h3 class="kwcs-result-title">Efekt w codziennej pracy</h3>
 
       <div class="result-lead">
         <p>
@@ -521,12 +521,38 @@
         </div>
       </div>
 
-      <a class="kwcs-cta" href="https://kwyszynskidesign.github.io/RAZDWA/" target="_blank" rel="noopener noreferrer" aria-label="Otwórz aplikację Raz Dwa Druk">
-        Otwórz aplikację na żywo
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <polyline points="9 18 15 12 9 6"></polyline>
-        </svg>
-      </a>
+      <!-- ============================================================
+           SLOT NA CYTAT KLIENTA (proof)
+           Celowo NIEWIDOCZNY do czasu uzyskania prawdziwej opinii
+           właściciela drukarni. Zero fikcyjnych nazwisk.
+           Aby aktywować: usuń znaczniki komentarza i uzupełnij treść
+           oraz podpis (imię, rola, firma). Style .razdwa-quote są już
+           gotowe w assets/css/projects.css (scope #case-razdwa-pelne).
+      ============================================================
+      <figure class="razdwa-quote">
+        <blockquote>„TU PRAWDZIWY CYTAT KLIENTA — np. o skróconym czasie wyceny lub mniejszej liczbie pomyłek."</blockquote>
+        <figcaption>Imię Nazwisko — rola, Raz Dwa Druk</figcaption>
+      </figure>
+      -->
+
+      <div class="result-invite">
+        <h3>Masz w firmie proces, który zjada godziny? Zróbmy z niego narzędzie.</h3>
+        <p>Jeśli u Ciebie coś liczy się ręcznie albo powtarza w kółko, prawdopodobnie da się to uprościć — tak jak wycenę w Raz Dwa Druk. Napisz, a podpowiem, od czego zacząć.</p>
+        <div class="result-invite-actions">
+          <a class="kwcs-cta" href="mailto:wyszynski.k@onet.pl?subject=Automatyzacja%20procesu%20w%20mojej%20firmie" aria-label="Napisz do mnie w sprawie podobnego projektu">
+            Napisz do mnie
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </a>
+          <a class="kwcs-cta kwcs-cta--ghost" href="https://kwyszynskidesign.github.io/RAZDWA/" target="_blank" rel="noopener noreferrer" aria-label="Otwórz aplikację Raz Dwa Druk na żywo">
+            Zobacz aplikację na żywo
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </a>
+        </div>
+      </div>
 
       <div class="result-next">
         <h3>Następny projekt</h3>


### PR DESCRIPTION
## Cel

Przebudowa case study „Raz Dwa Druk" (`projects/razdwa_aplikacja.html`) tak, aby każdy nagłówek komunikował **korzyść dla klienta**, a struktura odpowiadała frameworkowi **StoryBrand SB7** (Problem → Guide → Plan → Rozwiązanie → Sukces → CTA) w połączeniu z Before/After/Bridge.

> Uwaga: treść tego case study nie jest w `portfolio.html` — plik `projects/razdwa_aplikacja.html` działa jednocześnie jako samodzielna strona i jest doładowywany do `#case-viewer` w `portfolio.html` (`assets/js/portfolio.js`). Edytowany jest więc jeden plik.

## Zakres zmian

- [x] Krok 1 — hero + „W skrócie": poprawki językowe, rozdzielenie liczb (~5 min vs −90% CAD), kontrast before→after
- [x] Krok 2 — rozdzielenie „Kontekst i moja rola" na Problem + Guide, podpisy liczb z kontekstem
- [x] Krok 3 — Plan („Kluczowe decyzje") → nagłówek-korzyść + zdania „dzięki temu…"
- [x] Krok 4 — sekcje rozwiązania (interfejs, CAD, cennik, tech): nagłówki-korzyści + zdania łącznikowe
- [x] Krok 5 — Wnioski + Rezultat + niewidoczny slot na cytat klienta (HTML comment) + wzmocnione CTA (Napisz do mnie / Zobacz aplikację)
- [x] Krok 6 — aktualizacja chapter rail (10 pozycji, kotwica `razdwa-rola`) + fix layoutu przycisków CTA + weryfikacja responsywności

## Weryfikacja

Render sprawdzony w Chromium (Playwright) na **390px** i **1440px** oraz w kontekście `portfolio.html#RazDwa` (injekcja do `#case-viewer`): 9 sekcji SB7, rail 10 pozycji, slot cytatu niewidoczny, brak błędów JS z kodu strony. Naprawiono rozjeżdżanie się przycisków CTA (dziedziczony `margin:auto` w kontenerze flex).

## Ograniczenia

- Bez nowych bibliotek/zależności — tylko istniejące klasy CSS (`kwcs-*`, `ux-decision-box`, `razdwa-stat`) + drobny scoped dodatek pod `#case-razdwa-pelne`.
- Zmiany dotyczą wyłącznie case study Raz Dwa Druk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)