### PR TITLE
Raz Dwa Druk — crop hero image + skrócenie nagłówków H2

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -174,8 +174,10 @@
 .hero-content-grid > .hero-image:only-child { grid-column: 1 / -1; }
 
 /* Hero image (tylko Raz Dwa) — responsywny, bez zniekształceń: plik ma proporcje
-   ~1450x1306, a atrybuty width/height 1200x630 wymuszaly spłaszczenie; brakowało
-   reguły CSS. Scope #case-razdwa-pelne, żeby nie ruszać innych case studies. */
+   ~1450x1306, ale zrzut ma pusty, biały dół (formularz). Kadrujemy go wizualnie
+   przez aspect-ratio + object-fit:cover + object-position:top, żeby pokazać tylko
+   górną, treściwą część (nagłówek, siatka kategorii, panel podsumowania) i nie
+   robić niepotrzebnie wysokiego hero. Scope #case-razdwa-pelne. */
 #case-razdwa-pelne .kwcs-hero-body .hero-image {
   width: 100%;
   display: flex;
@@ -186,7 +188,9 @@
   width: 100%;
   max-width: 1040px;
   height: auto;
-  object-fit: contain;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  object-position: top;
   border-radius: 14px;
   box-shadow: 0 24px 60px -28px rgba(15, 23, 42, 0.32);
 }

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -178,6 +178,18 @@
    przez aspect-ratio + object-fit:cover + object-position:top, żeby pokazać tylko
    górną, treściwą część (nagłówek, siatka kategorii, panel podsumowania) i nie
    robić niepotrzebnie wysokiego hero. Scope #case-razdwa-pelne. */
+/* Podtytuł pod skróconym H2 (tylko Raz Dwa) — nosi korzyść przeniesioną
+   z dawnego długiego nagłówka. Ciemniejszy i pogrubiony nad muted leadem. */
+#case-razdwa-pelne .razdwa-h2-sub {
+  max-width: 760px;
+  margin: -0.25rem auto 1.25rem;
+  text-align: center;
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 1.15rem;
+  line-height: 1.5;
+}
+
 #case-razdwa-pelne .kwcs-hero-body .hero-image {
   width: 100%;
   display: flex;

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -151,12 +151,13 @@
 
 
     
-  <h2 class="section-divider" id="razdwa-kontekst">Zanim powstała aplikacja: wycena trwała godzinę i łatwo było o pomyłkę</h2>
+  <h2 class="section-divider" id="razdwa-kontekst">Zanim powstała aplikacja</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">
+    <p class="razdwa-h2-sub">Wycena trwała nawet godzinę i łatwo było o kosztowną pomyłkę.</p>
     <p class="kwcs-section-lead">
-      Drukarnia wyceniała zlecenia ręcznie, z papierowego cennika. Przy ladzie oznaczało to <strong>presję czasu</strong>, a przy złożonych zamówieniach — realne ryzyko, że <strong>cena wyjdzie błędna</strong> i firma na tym straci.
+      Drukarnia wyceniała zlecenia ręcznie, z papierowego cennika — przy ladzie i pod <strong>presją czasu</strong>.
     </p>
 
     <div class="ux-decision-grid">
@@ -172,12 +173,13 @@
   </div>
 </div>
 
-<h2 class="section-divider" id="razdwa-rola">Moja rola: od rozpoznania procesu po działające narzędzie</h2>
+<h2 class="section-divider" id="razdwa-rola">Od diagnozy po wdrożenie</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">
+    <p class="razdwa-h2-sub">Jeden wykonawca odpowiedzialny za całość — od rozpoznania procesu po działające narzędzie.</p>
     <p class="kwcs-section-lead">
-      Prowadziłem projekt <strong>kompleksowo</strong> — od rozpoznania procesu w drukarni po wdrożenie i uruchomienie systemu. Klient miał <strong>jednego wykonawcę</strong> odpowiedzialnego za całość, od diagnozy po efekt.
+      Sam odpowiadałem za każdy etap — od rozmów w drukarni, przez projekt i logikę systemu, po testy i uruchomienie.
     </p>
 
     <div class="contribution-grid--razdwa">
@@ -216,12 +218,13 @@
 
 
     
-<h2 class="section-divider" id="razdwa-decyzje">Trzy decyzje, dzięki którym aplikacja jest tania w utrzymaniu i prosta w obsłudze</h2>
+<h2 class="section-divider" id="razdwa-decyzje">Trzy decyzje, które się opłaciły</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">
+    <p class="razdwa-h2-sub">Każda obniżała koszt utrzymania albo skracała czas pracy przy ladzie.</p>
     <p class="kwcs-section-lead">
-    Problemem nie był tylko długi czas wyceny, ale też liczba wyjątków, ryzyko błędów i brak prostego zarządzania cennikiem. Dlatego rozwiązanie oparłem na trzech decyzjach — każda z nich obniżała koszt utrzymania albo skracała czas pracy przy ladzie.
+    Problemem nie był tylko długi czas wyceny, ale też liczba wyjątków, ryzyko błędów i brak prostego zarządzania cennikiem.
     </p>
 
     <div class="ux-decision-grid ux-decision-grid--trio">
@@ -246,12 +249,13 @@
 
 
     
-<h2 class="section-divider" id="razdwa-ux">Wycena w kilku krokach, bez przełączania okien</h2>
+<h2 class="section-divider" id="razdwa-ux">Wycena w kilku krokach</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">
+    <p class="razdwa-h2-sub">Wszystko w jednym widoku, bez przełączania okien.</p>
     <p class="kwcs-section-lead">
-      Obsługę zamówienia zaprojektowałem jako jedną, powtarzalną ścieżkę — operator przechodzi od wyboru usługi do gotowego dokumentu bez przeskakiwania między ekranami. Dzięki temu wycena przy ladzie jest szybka, a klient czeka krócej.
+      Obsługę zamówienia zaprojektowałem jako jedną, powtarzalną ścieżkę — od wyboru usługi do gotowego dokumentu. Dzięki temu wycena przy ladzie jest szybka, a klient czeka krócej.
     </p>
     <h3 class="kwcs-h3-center mt-0">Główna ścieżka obsługi zamówienia</h3>
     <div class="user-flow">
@@ -361,12 +365,13 @@
   </div>
 </div>
 
-<h2 class="section-divider" id="razdwa-cennik">Właściciel zmienia ceny sam, bez dzwonienia do programisty</h2>
+<h2 class="section-divider" id="razdwa-cennik">Cennik pod kontrolą właściciela</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">
+    <p class="razdwa-h2-sub">Zmienia stawki sam, bez dzwonienia do programisty.</p>
     <p class="kwcs-section-lead">
-      Panel administracyjny pozwala właścicielowi <strong>samodzielnie</strong> zmieniać stawki i dodawać warianty — bez psucia struktury danych. Ceny aktualizuje się <strong>od ręki, bez programisty</strong> i bez kosztu za każdą zmianę.
+      Panel administracyjny pozwala właścicielowi <strong>samodzielnie</strong> zmieniać stawki i dodawać warianty — bez psucia struktury danych i bez kosztu za każdą zmianę.
     </p>
 
     <div class="kwcs-gallery-grid kwcs-gallery-grid--single" style="margin-bottom:2rem;">
@@ -407,12 +412,13 @@
   </div>
 </div>
 
-<h2 class="section-divider" id="razdwa-architektura">Działa na tym, co klient już zna — bez serwera i stałych opłat</h2>
+<h2 class="section-divider" id="razdwa-architektura">Bez serwera i stałych opłat</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">
+    <p class="razdwa-h2-sub">Działa na narzędziach, które klient już znał.</p>
     <p class="kwcs-section-lead">
-      Zamiast klasycznego backendu i bazy danych oparłem system o <strong>ekosystem Google</strong> — narzędzia, które klient już znał. Dla firmy to <strong>zero opłat za serwer</strong> i brak uzależnienia od jednego dostawcy.
+      Zamiast klasycznego backendu i osobnej bazy danych oparłem system o <strong>ekosystem Google</strong>. Dla firmy to brak uzależnienia od jednego dostawcy i prostsze utrzymanie.
     </p>
 
     <h3 class="kwcs-h3-center mt-0" id="razdwa-architektura-ekosystem">Jak współpracują główne moduły</h3>
@@ -493,7 +499,7 @@
   </div>
 </div>
 
-<h2 class="section-divider" id="razdwa-rezultat">Co zmieniło się w drukarni po wdrożeniu</h2>
+<h2 class="section-divider" id="razdwa-rezultat">Co zmieniło się w drukarni</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">


### PR DESCRIPTION
## Cel

Dwa usprawnienia case study „Raz Dwa Druk" (`projects/razdwa_aplikacja.html`) po merge #71.

## Zakres

- [x] **Zadanie 1 — crop hero image:** zrzut ma pusty biały dół (formularz) → hero było za wysokie. Scoped CSS (`#case-razdwa-pelne`): `object-fit: cover` + `object-position: top` + `aspect-ratio: 16/10`. Wysokość hero: desktop 937→650, mobile 308→214.
- [x] **Zadanie 2 — skrócenie nagłówków H2:** wszystkie H2 skrócone do 3–5 słów (mocny hook), a „zwisająca" treść przeniesiona do krótkiego podtytułu `.razdwa-h2-sub` pod nagłówkiem; zdublowane otwarcia leadów przycięte (informacja zachowana). CAD i Wnioski bez zmian (już krótkie).

## Weryfikacja

Render Playwright na 390px i 1440px: H2 3–5 słów, 6 podtytułów, `docOverflow = 0`, hierarchia H2 → podtytuł → lead czytelna, inne case studies nietknięte.

## Ograniczenia

- Tylko case study Raz Dwa Druk; inne nietknięte.
- Bez nowych bibliotek; scoped CSS pod `#case-razdwa-pelne`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)