### PR TITLE
Karoma: naprawa layoutu case study (rail + hero)

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3583,6 +3583,70 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
 }
 
 /* ========================================
+   #CASE-KAROMA-PELNE — blok zaproszenia (CTA końcowe) + slot cytatu
+   Odpowiednik bloku #case-razdwa-pelne. Scope karoma — nie rusza innych.
+   ======================================== */
+#case-karoma-pelne .result-invite {
+  margin-top: 2.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.3);
+  text-align: center;
+}
+#case-karoma-pelne .result-invite h3 {
+  font-size: 1.5rem;
+  line-height: 1.3;
+  margin: 0 0 0.75rem;
+  color: #0f172a;
+}
+#case-karoma-pelne .result-invite p {
+  max-width: 640px;
+  margin: 0 auto 0.5rem;
+  color: #475569;
+}
+#case-karoma-pelne .result-invite-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+/* neutralizacja margin:auto z .kwcs-result .kwcs-cta, ktory w flexie
+   rozpychal przyciski na krawedzie */
+#case-karoma-pelne .result-invite-actions .kwcs-cta {
+  margin: 0.5rem 0;
+}
+#case-karoma-pelne .kwcs-cta--ghost {
+  background: transparent;
+  color: #0284c7;
+  box-shadow: none;
+  border: 1px solid #0284c7;
+}
+#case-karoma-pelne .kwcs-cta--ghost:hover {
+  background: rgba(2, 132, 199, 0.08);
+  box-shadow: none;
+}
+
+/* Gotowy styl dla cytatu klienta — aktywny po odkomentowaniu slotu w HTML */
+#case-karoma-pelne .razdwa-quote {
+  margin: 2.5rem auto 0;
+  max-width: 720px;
+  padding: 1.75rem 2rem;
+  border-left: 4px solid #06b6d4;
+  background: rgba(6, 182, 212, 0.07);
+  border-radius: 0 0.75rem 0.75rem 0;
+}
+#case-karoma-pelne .razdwa-quote blockquote {
+  margin: 0 0 1rem;
+  font-size: 1.2rem;
+  line-height: 1.6;
+  font-style: italic;
+  color: #0f172a;
+}
+#case-karoma-pelne .razdwa-quote figcaption {
+  font-weight: 600;
+  color: #334155;
+}
+
+/* ========================================
    KWCS-FOOTER — uproszczony footer case studies
    ======================================== */
 .kwcs-footer {

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3541,6 +3541,48 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
 }
 
 /* ========================================
+   #CASE-KAROMA-PELNE — layout: kompensacja fixed railu + hero image
+   Analogicznie do #case-razdwa-pelne. Fixed .razdwa-chapter-rail nachodzi
+   na treść, jeśli kontener case'a nie dostanie padding-left. Hero image ma
+   realne proporcje 1144x975 (atrybuty w HTML skorygowane), więc contain nie
+   letterboxuje. Scope #case-karoma-pelne — nie rusza innych case studies.
+   ======================================== */
+#case-karoma-pelne .kwcs-hero-body .hero-image {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+#case-karoma-pelne .kwcs-hero-body .hero-image .cover {
+  display: block;
+  width: 100%;
+  max-width: 860px;
+  height: auto;
+  object-fit: contain;
+  border-radius: 14px;
+  box-shadow: 0 24px 60px -28px rgba(15, 23, 42, 0.32);
+}
+
+/* Desktop ≥1280px — content odsunięty w prawo za fixed rail, szersza kolumna */
+@media (min-width: 1280px) {
+  #case-karoma-pelne { padding-left: 216px; --wrap-max: 1240px; }
+}
+/* Laptop 1101-1279px — węższy rail, mniejszy margines */
+@media (min-width: 1101px) and (max-width: 1279px) {
+  #case-karoma-pelne { padding-left: 184px; --wrap-max: 1120px; }
+}
+/* Tablet i mobile ≤1100px — rail jako górny pasek, bez marginesu bocznego */
+@media (max-width: 1100px) {
+  #case-karoma-pelne { padding-left: 0; }
+}
+
+/* Hero CTA na mobile ma width:100% + padding — bez border-box padding wychodzi
+   poza kontener (~16px overflow na 390px). Fix jak w RazDwa. */
+#case-karoma-pelne .hero-image-cta {
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+/* ========================================
    KWCS-FOOTER — uproszczony footer case studies
    ======================================== */
 .kwcs-footer {

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3506,25 +3506,25 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
 .kwcs-breadcrumb-current { font-size: 0.9rem; color: #64748b; }
 
 /* ========================================
-   #CASE-KAROMA — scoped overrides
+   #CASE-KAROMA-PELNE — scoped overrides
    Dopasowanie spacingu i layoutu do wzorca RazDwa
    ======================================== */
-#case-karoma .section-divider + .kwcs-sec { padding-top: 1.25rem; }
+#case-karoma-pelne .section-divider + .kwcs-sec { padding-top: 1.25rem; }
 
-#case-karoma .result-cards {
+#case-karoma-pelne .result-cards {
   grid-template-columns: repeat(3, 1fr);
 }
 @media (max-width: 768px) {
-  #case-karoma .result-cards {
+  #case-karoma-pelne .result-cards {
     grid-template-columns: 1fr;
   }
 }
 
-#case-karoma .kwcs-sec--alt .kwcs-trio { margin-top: 1.5rem; }
+#case-karoma-pelne .kwcs-sec--alt .kwcs-trio { margin-top: 1.5rem; }
 
 /* "Za co odpowiadałem" — domknięcie kompozycji: full-width w 3-col gridzie,
    max-width dopasowany do szerokości ux-decision-grid powyżej */
-#case-karoma .contribution-cell--solo {
+#case-karoma-pelne .contribution-cell--solo {
   grid-column: 1 / -1;
   max-width: 900px;
   margin-inline: auto;

--- a/projects/karoma.html
+++ b/projects/karoma.html
@@ -82,7 +82,7 @@
           <span class="pm-meta-sep">·</span>
           <span><strong>Zakres</strong> Branding · Sklep · Wdrożenie</span>
           <span class="pm-meta-sep">·</span>
-          <span><strong>Efekt</strong> Spójna marka + sklep gotowy na zamówienia B2B</span>
+          <span><strong>Efekt</strong> Spójna marka + działający sklep B2B</span>
         </div>
       </div>
     </div>
@@ -129,7 +129,7 @@
           </div>
           <div class="razdwa-summary-cell">
             <div class="label">Efekt</div>
-            <div class="value">Spójna identyfikacja we wszystkich kanałach, sklep uruchomiony produkcyjnie i gotowy na zamówienia B2B.</div>
+            <div class="value">Spójna marka na wszystkich nośnikach i sklep, który klient prowadzi samodzielnie od dnia startu.</div>
           </div>
         </div>
         <p class="kwcs-footnote">Czas i zakres na podstawie briefu klienta oraz dokumentacji projektowej.</p>
@@ -242,7 +242,7 @@
       <div class="wrap">
         <p class="razdwa-h2-sub">Logo w 3 rundach iteracji, przetestowane na 7 nośnikach — od wizytówki po katalog.</p>
         <p class="kwcs-section-lead">
-          Logo przeszło przez 3 rundy iteracji, w których wspólnie z klientem dopracowywaliśmy kształt, kolorystykę i symbolikę. Kluczowym elementem była geometria przypominająca frez CNC — narzędzie będące sercem oferty marki.
+          W każdej rundzie wspólnie z klientem dopracowywaliśmy kształt, kolorystykę i symbolikę znaku. Kluczowym elementem była geometria przypominająca frez CNC — narzędzie będące sercem oferty marki.
         </p>
         <div class="kwcs-gallery-grid">
           <div class="gallery-item">

--- a/projects/karoma.html
+++ b/projects/karoma.html
@@ -60,7 +60,8 @@
       <div class="razdwa-chapter-rail-label">Rozdziały</div>
       <ul class="razdwa-chapter-rail-list">
         <li><a class="razdwa-chapter-link" href="#karoma-summary" data-rail-target="karoma-summary" title="W skrócie" aria-label="W skrócie">W skrócie</a></li>
-        <li><a class="razdwa-chapter-link" href="#karoma-kontekst" data-rail-target="karoma-kontekst" title="Kontekst i moja rola" aria-label="Kontekst i moja rola">Kontekst i moja rola</a></li>
+        <li><a class="razdwa-chapter-link" href="#karoma-problem" data-rail-target="karoma-problem" title="Problem: nowa branża bez tożsamości" aria-label="Problem: nowa branża bez tożsamości">Problem</a></li>
+        <li><a class="razdwa-chapter-link" href="#karoma-rola" data-rail-target="karoma-rola" title="Moja rola" aria-label="Moja rola">Moja rola</a></li>
         <li><a class="razdwa-chapter-link" href="#karoma-decyzje" data-rail-target="karoma-decyzje" title="Kluczowe decyzje projektowe" aria-label="Kluczowe decyzje projektowe">Kluczowe decyzje</a></li>
         <li><a class="razdwa-chapter-link" href="#karoma-branding" data-rail-target="karoma-branding" title="Branding i system identyfikacji" aria-label="Branding i system identyfikacji">Branding</a></li>
         <li><a class="razdwa-chapter-link" href="#karoma-strona" data-rail-target="karoma-strona" title="Realizacja strony internetowej" aria-label="Realizacja strony internetowej">Realizacja strony</a></li>
@@ -135,23 +136,40 @@
       </div>
     </div>
 
-    <h2 class="section-divider" id="karoma-kontekst">Kontekst i moja rola</h2>
+    <h2 class="section-divider" id="karoma-problem">Nowa branża, zero tożsamości</h2>
 
     <div class="kwcs-sec">
       <div class="wrap">
+        <p class="razdwa-h2-sub">Marka, sklep i prezentacja produktów — wszystko naraz, w 8 tygodni.</p>
         <p class="kwcs-section-lead">
-          Projekt prowadziłem end-to-end: od wywiadu z klientem i analizy branży, przez brand design i budowę sklepu, po wdrożenie produkcyjne i szkolenie klienta z obsługi systemu.
+          Firma zmieniła profil działalności — z kół gumowych na frezy i narzędzia CNC dla klientów B2B. W nowej branży zaczynała bez rozpoznawalnej marki i bez kanału sprzedaży online.
         </p>
 
         <div class="ux-decision-grid">
           <div class="ux-decision-box">
-            <h4>Wyzwanie biznesowe</h4>
-            <p>Firma zmieniła profil działalności — z kół gumowych na frezy i narzędzia CNC dla klientów B2B. Nowa branża wymagała nowej tożsamości od zera: marki odzwierciedlającej precyzję, działającego sklepu z obsługą płatności i profesjonalnej prezentacji produktów — wszystkiego jednocześnie, w 8 tygodni.</p>
+            <h4>Zmiana profilu, marka od zera</h4>
+            <p>Przejście z kół gumowych na frezy i narzędzia CNC oznaczało nowego odbiorcę B2B i zupełnie inną komunikację. Dotychczasowa tożsamość nie pasowała do nowej oferty — markę trzeba było zbudować od podstaw, tak by od pierwszego kontaktu kojarzyła się z precyzją.</p>
           </div>
           <div class="ux-decision-box">
-            <h4>Dwie strefy pracy w jednym projekcie</h4>
-            <p><strong>Brand design:</strong> logo i system identyfikacji wizualnej, paleta, typografia, materiały firmowe, testowanie marki na 7 nośnikach. <strong>Wdrożenie techniczne:</strong> sklep WooCommerce, dedykowane skrypty JS, integracja Przelewy24, hosting, SEO i szkolenie klienta.</p>
+            <h4>Wszystko naraz, w 8 tygodni</h4>
+            <p>Marka odzwierciedlająca precyzję, działający sklep z obsługą płatności i profesjonalna prezentacja produktów — wszystko było potrzebne jednocześnie, w oknie ośmiu tygodni. Brand design i wdrożenie techniczne musiały powstawać równolegle.</p>
           </div>
+        </div>
+      </div>
+    </div>
+
+    <h2 class="section-divider" id="karoma-rola">Od marki po wdrożenie sklepu</h2>
+
+    <div class="kwcs-sec">
+      <div class="wrap">
+        <p class="razdwa-h2-sub">Jeden wykonawca odpowiedzialny za całość — od wywiadu z klientem po działający sklep.</p>
+        <p class="kwcs-section-lead">
+          Projekt prowadziłem end-to-end: od wywiadu z klientem i analizy branży, przez brand design i budowę sklepu, po wdrożenie produkcyjne i szkolenie klienta z obsługi systemu.
+        </p>
+
+        <div class="ux-decision-box">
+          <h4>Dwie strefy pracy w jednym projekcie</h4>
+          <p><strong>Brand design:</strong> logo i system identyfikacji wizualnej, paleta, typografia, materiały firmowe, testowanie marki na 7 nośnikach. <strong>Wdrożenie techniczne:</strong> sklep WooCommerce, dedykowane skrypty JS, integracja Przelewy24, hosting, SEO i szkolenie klienta.</p>
         </div>
 
         <div class="contribution-grid--razdwa">

--- a/projects/karoma.html
+++ b/projects/karoma.html
@@ -190,19 +190,19 @@
         <div class="razdwa-stats">
           <div class="razdwa-stat">
             <div class="razdwa-stat-num">3</div>
-            <div class="razdwa-stat-label">rundy iteracji logo</div>
+            <div class="razdwa-stat-label">rundy iteracji — od szkiców do znaku zatwierdzonego przez klienta</div>
           </div>
           <div class="razdwa-stat">
-            <div class="razdwa-stat-num">7</div>
-            <div class="razdwa-stat-label">nośników testowania marki</div>
+            <div class="razdwa-stat-num">0 → 7</div>
+            <div class="razdwa-stat-label">nośników ze spójną marką — w nowej branży od zera</div>
           </div>
           <div class="razdwa-stat">
             <div class="razdwa-stat-num">~8 tyg.</div>
-            <div class="razdwa-stat-label">od briefu do wdrożenia</div>
+            <div class="razdwa-stat-label">od briefu do launchu — marka i sklep powstały równolegle</div>
           </div>
           <div class="razdwa-stat">
             <div class="razdwa-stat-num">1</div>
-            <div class="razdwa-stat-label">projektant — pełny zakres</div>
+            <div class="razdwa-stat-label">wykonawca — jeden punkt kontaktu od brandingu po wdrożenie</div>
           </div>
         </div>
       </div>

--- a/projects/karoma.html
+++ b/projects/karoma.html
@@ -54,7 +54,7 @@
     </div>
   </nav>
 
-  <section class="kwcs" id="case-karoma" aria-label="Case Study: Karoma — Sklep B2B i identyfikacja wizualna">
+  <section class="kwcs" id="case-karoma-pelne" aria-label="Case Study: Karoma — Sklep B2B i identyfikacja wizualna">
 
     <nav class="razdwa-chapter-rail" id="karoma-chapter-rail" aria-label="Spis treści case study">
       <div class="razdwa-chapter-rail-label">Rozdziały</div>

--- a/projects/karoma.html
+++ b/projects/karoma.html
@@ -415,12 +415,39 @@
               <p>Szkolenie CMS przed launchem. Klient dodaje produkty, obsługuje zamówienia i zarządza treścią bez zewnętrznego wsparcia.</p>
             </div>
           </div>
-          <a class="kwcs-cta" href="mailto:karol2609@gmail.com" aria-label="Napisz do mnie w sprawie podobnego projektu">
-            Masz podobny projekt? Porozmawiajmy
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <polyline points="9 18 15 12 9 6"></polyline>
-            </svg>
-          </a>
+          <!-- ============================================================
+               SLOT NA CYTAT KLIENTA (proof)
+               Celowo NIEWIDOCZNY do czasu uzyskania prawdziwej opinii
+               właściciela Karomy. Zero fikcyjnych nazwisk i cytatów.
+               Aby aktywować: usuń znaczniki komentarza i uzupełnij treść
+               oraz podpis (imię, rola, firma). Style .razdwa-quote są już
+               gotowe w assets/css/projects.css (scope #case-karoma-pelne).
+          ============================================================
+          <figure class="razdwa-quote">
+            <blockquote>„TU PRAWDZIWY CYTAT KLIENTA — np. o spójnej marce, sprawnym wdrożeniu sklepu lub samodzielnej obsłudze zamówień."</blockquote>
+            <figcaption>Imię Nazwisko — rola, Karoma</figcaption>
+          </figure>
+          -->
+
+          <div class="result-invite">
+            <h3>Zmieniasz profil firmy albo startujesz z nową marką? Zbudujmy to razem.</h3>
+            <p>Marka, sklep i sprawne wdrożenie — pod jednym adresem, z jednym punktem kontaktu. Napisz, a podpowiem, od czego zacząć w Twoim przypadku.</p>
+            <div class="result-invite-actions">
+              <a class="kwcs-cta" href="mailto:karol2609@gmail.com?subject=Nowa%20marka%20i%20sklep%20dla%20mojej%20firmy" aria-label="Napisz do mnie w sprawie podobnego projektu">
+                Napisz do mnie
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <polyline points="9 18 15 12 9 6"></polyline>
+                </svg>
+              </a>
+              <a class="kwcs-cta kwcs-cta--ghost" href="https://www.karoma.co/" target="_blank" rel="noopener noreferrer" aria-label="Otwórz sklep Karoma na żywo">
+                Zobacz sklep na żywo
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <polyline points="9 18 15 12 9 6"></polyline>
+                </svg>
+              </a>
+            </div>
+          </div>
+
           <div class="result-next">
             <h3>Następny projekt</h3>
             <a class="kwcs-cta" href="/KWdesignnew/projects/power-of-mind.html" aria-label="Przejdź do projektu Power of Mind — brand, sklep i automatyzacje">

--- a/projects/karoma.html
+++ b/projects/karoma.html
@@ -96,8 +96,8 @@
               alt="Podgląd identyfikacji wizualnej Karoma"
               loading="lazy"
               decoding="async"
-              width="1200"
-              height="630"
+              width="1144"
+              height="975"
               data-caption="Identyfikacja wizualna Karoma — marka i sklep CNC B2B">
           </div>
         </div>

--- a/projects/karoma.html
+++ b/projects/karoma.html
@@ -158,7 +158,7 @@
       </div>
     </div>
 
-    <h2 class="section-divider" id="karoma-rola">Od marki po wdrożenie sklepu</h2>
+    <h2 class="section-divider" id="karoma-rola">Od marki po działający sklep</h2>
 
     <div class="kwcs-sec">
       <div class="wrap">
@@ -208,12 +208,13 @@
       </div>
     </div>
 
-    <h2 class="section-divider" id="karoma-decyzje">Kluczowe decyzje projektowe</h2>
+    <h2 class="section-divider" id="karoma-decyzje">Trzy decyzje pod klienta B2B</h2>
 
     <div class="kwcs-sec">
       <div class="wrap">
+        <p class="razdwa-h2-sub">Każda chroniła budżet klienta albo skracała drogę do zamówienia.</p>
         <p class="kwcs-section-lead">
-          Trzy decyzje ukształtowały kształt marki i sposób działania sklepu — od wyboru formy logo, przez architekturę techniczną, po priorytety UX na stronach produktów.
+          Trzy decyzje ukształtowały markę i sposób działania sklepu — od wyboru formy logo, przez architekturę techniczną, po priorytety UX na stronach produktów.
         </p>
         <div class="ux-decision-grid ux-decision-grid--trio">
           <div class="ux-decision-box">
@@ -235,10 +236,11 @@
       </div>
     </div>
 
-    <h2 class="section-divider" id="karoma-branding">Branding i system identyfikacji</h2>
+    <h2 class="section-divider" id="karoma-branding">Marka, która mówi: precyzja</h2>
 
     <div class="kwcs-sec kwcs-logo-section">
       <div class="wrap">
+        <p class="razdwa-h2-sub">Logo w 3 rundach iteracji, przetestowane na 7 nośnikach — od wizytówki po katalog.</p>
         <p class="kwcs-section-lead">
           Logo przeszło przez 3 rundy iteracji, w których wspólnie z klientem dopracowywaliśmy kształt, kolorystykę i symbolikę. Kluczowym elementem była geometria przypominająca frez CNC — narzędzie będące sercem oferty marki.
         </p>
@@ -286,11 +288,11 @@
       </div>
     </div>
 
-    <h2 class="section-divider" id="karoma-strona">Realizacja strony internetowej</h2>
+    <h2 class="section-divider" id="karoma-strona">Sklep gotowy na zamówienia B2B</h2>
 
     <div class="kwcs-sec kwcs-website-showcase">
       <div class="wrap">
-        <p>Trzy widoki kluczowe dla narracji B2B — homepage, strona produktu i autorski skrypt koszyka.</p>
+        <p class="razdwa-h2-sub">Trzy widoki prowadzące klienta od oferty do koszyka — z autorskim skryptem koszyka.</p>
         <div class="showcase-stack">
 
           <div class="showcase-section">
@@ -362,10 +364,11 @@
       </div>
     </div>
 
-    <h2 class="section-divider" id="karoma-wnioski">Wnioski z projektu</h2>
+    <h2 class="section-divider" id="karoma-wnioski">Czego nauczył mnie ten projekt</h2>
 
     <div class="kwcs-sec kwcs-sec--alt">
       <div class="wrap">
+        <p class="razdwa-h2-sub">Trzy zmiany w tym, jak wyceniam i prowadzę wdrożenia e-commerce.</p>
         <p class="kwcs-section-lead">
           Trzy rzeczy, które zmieniłem w sposobie wyceniania i prowadzenia projektów po tym wdrożeniu.
         </p>
@@ -386,10 +389,11 @@
       </div>
     </div>
 
-    <h2 class="section-divider" id="karoma-rezultat">Rezultat projektu</h2>
+    <h2 class="section-divider" id="karoma-rezultat">Marka i sklep gotowe od startu</h2>
 
     <div class="kwcs-sec">
       <div class="wrap">
+        <p class="razdwa-h2-sub">Uruchomione w 8 tygodni — klient obsługuje zamówienia samodzielnie od dnia launchu.</p>
         <div class="kwcs-result">
           <h3 class="kwcs-result-title">Co zostało wdrożone</h3>
           <div class="result-lead">


### PR DESCRIPTION
## Cel

Naprawa layoutu case study **Karoma** (`projects/karoma.html`), analogicznie do przebudowy Raz Dwa Druk (PR #71/#72). To **Etap 1 — warstwa techniczna/CSS**. Warstwa redakcyjna (StoryBrand SB7 / BAB) planowana jako osobny etap.

## Diagnoza

Karoma używa tego samego mechanizmu `#case-viewer` / `portfolio.js` co Raz Dwa Druk (selektor `section.kwcs`). Szkielet był już częściowo przebudowany (`razdwa-*`, `ux-decision-grid`, chapter rail), ale cały „ciężki" layout w `projects.css` jest scope'owany przez `#case-razdwa-pelne`, podczas gdy Karoma miała `id="case-karoma"` — więc reguły layoutu do niej nie docierały. Skutki: fixed chapter rail nachodził na treść, hero image był spłaszczony.

## Zmiany

- **Ujednolicenie ID**: `#case-karoma` → `#case-karoma-pelne` (konwencja `case-<slug>-pelne`); migracja 5 istniejących reguł CSS na nowe ID.
- **Blok layoutu** scoped `#case-karoma-pelne`:
  - `padding-left` + `--wrap-max` w 3 breakpointach (216px/1240 ≥1280, 184px/1120 1101–1279, 0 ≤1100) — rail nie nachodzi na treść.
  - hero-image `.cover`: `object-fit: contain`, `max-width: 860px`, radius, shadow. Atrybuty hero w HTML skorygowane `1200×630` → `1144×975` (realne proporcje pliku).
  - `.hero-image-cta` `box-sizing: border-box` — koniec ~16px overflow przycisku na mobile.

Scope ograniczony do `#case-karoma-pelne` — zero wpływu na inne case studies.

## Weryfikacja

`docOverflow=0` na 390px i 1440px, standalone oraz w kontekście `portfolio.html#karoma` (sekcja ładuje się do `#case-viewer`, poprawny `id`, rail w swoim gutterze, hero z właściwymi proporcjami).

## Następny etap (osobno)

Warstwa redakcyjna SB7: wydzielenie sekcji Problem, H2 3–6 słów z korzyścią + `.razdwa-h2-sub`, liczby z kontekstem było→jest, niewidoczny slot na cytat, mocne CTA końcowe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuTGpYHuZtyGfkYJ71DfPe)_