### PR TITLE
Karoma: full-bleed tła kolorowych sekcji (rail nad tłem)

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3565,12 +3565,26 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
 /* Desktop ≥1280px — content odsunięty w prawo za fixed rail, szersza kolumna */
 @media (min-width: 1280px) {
   #case-karoma-pelne { padding-left: 216px; --wrap-max: 1240px; }
+  /* Full-bleed kolorowych sekcji: cofamy padding kontenera (216) marginesem,
+     żeby tło sięgało lewej krawędzi treści strony (rail pływa nad tłem).
+     Kompensujący padding-left utrzymuje treść w tym samym miejscu. */
+  #case-karoma-pelne > .razdwa-summary,
+  #case-karoma-pelne > .kwcs-sec--alt {
+    margin-left: -216px;
+    padding-left: calc(216px + 1rem);
+  }
 }
 /* Laptop 1101-1279px — węższy rail, mniejszy margines */
 @media (min-width: 1101px) and (max-width: 1279px) {
   #case-karoma-pelne { padding-left: 184px; --wrap-max: 1120px; }
+  #case-karoma-pelne > .razdwa-summary,
+  #case-karoma-pelne > .kwcs-sec--alt {
+    margin-left: -184px;
+    padding-left: calc(184px + 1rem);
+  }
 }
-/* Tablet i mobile ≤1100px — rail jako górny pasek, bez marginesu bocznego */
+/* Tablet i mobile ≤1100px — rail jako górny pasek, bez marginesu bocznego.
+   Sekcje są już pełnej szerokości, więc full-bleed nie jest potrzebny. */
 @media (max-width: 1100px) {
   #case-karoma-pelne { padding-left: 0; }
 }

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3562,6 +3562,18 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
   box-shadow: 0 24px 60px -28px rgba(15, 23, 42, 0.32);
 }
 
+/* Podtytuł H2 — wyśrodkowany pod tytułem (section-divider jest center).
+   Karoma nie miała tej reguły, więc podtytuły renderowały się do lewej. */
+#case-karoma-pelne .razdwa-h2-sub {
+  max-width: 760px;
+  margin: -0.25rem auto 1.25rem;
+  text-align: center;
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 1.15rem;
+  line-height: 1.5;
+}
+
 /* Desktop ≥1280px — content odsunięty w prawo za fixed rail, szersza kolumna */
 @media (min-width: 1280px) {
   #case-karoma-pelne { padding-left: 216px; --wrap-max: 1240px; }


### PR DESCRIPTION
## Problem

W case study Karoma tła kolorowych sekcji (`razdwa-summary` — bluish gradient; `kwcs-sec--alt` — szary, sekcja Wnioski) nie sięgały lewej krawędzi strony. Przyczyna: `padding-left: 216px` na kontenerze `#case-karoma-pelne` wciskał **całe** sekcje (razem z ich tłem) do x=224, przez co lewy pas przy railu (spis treści) zostawał biały — tło „urywało się" przy railu, wyglądało niespójnie.

## Rozwiązanie (wariant A)

Full-bleed dwóch kolorowych sekcji do krawędzi treści strony: ujemny `margin-left` cofa padding kontenera, a kompensujący `padding-left: calc(<pad> + 1rem)` utrzymuje treść dokładnie w tym samym miejscu. Rail (`position: fixed`, półprzezroczysty z blur) pływa nad pełnym tłem — zgodnie z ustaleniem.

- Scoped `#case-karoma-pelne > .razdwa-summary, > .kwcs-sec--alt` — nie rusza innych case studies.
- Breakpoint-aware: 216px (≥1280), 184px (1101–1279); przy ≤1100 rail jest górnym paskiem, a sekcje i tak są pełnej szerokości, więc full-bleed nie jest potrzebny.
- Treść bez zmian: `summaryWrap` left=278 przed i po.

## Weryfikacja

`docOverflow=0` na 390 / 1200 / 1440. Geometria po zmianie: `razdwa-summary` i `kwcs-sec--alt` = [8, vw-8] (pełna szerokość treści strony, spójne z breadcrumb/footer/hero), przy niezmienionej pozycji treści.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuTGpYHuZtyGfkYJ71DfPe)_