### PR TITLE
Power of Mind: przebudowa case study na wzorzec Raz Dwa Druk

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3673,6 +3673,161 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
 }
 
 /* ========================================
+   #CASE-POWER-OF-MIND-PELNE — scoped overrides
+   Wdrożenie wzorca RazDwa/Karoma pod nowy slug. Paleta marki:
+   indygo #4f46e5 (primary) + cyan #06b6d4 (akcent). Scope
+   #case-power-of-mind-pelne — nie rusza innych case studies.
+   ======================================== */
+#case-power-of-mind-pelne .section-divider + .kwcs-sec { padding-top: 1.25rem; }
+
+#case-power-of-mind-pelne .result-cards {
+  grid-template-columns: repeat(3, 1fr);
+}
+@media (max-width: 768px) {
+  #case-power-of-mind-pelne .result-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+#case-power-of-mind-pelne .kwcs-sec--alt .kwcs-trio { margin-top: 1.5rem; }
+
+/* "Za co odpowiadałem" — full-width w 3-col gridzie, wyśrodkowany */
+#case-power-of-mind-pelne .contribution-cell--solo {
+  grid-column: 1 / -1;
+  max-width: 900px;
+  margin-inline: auto;
+}
+
+/* Stat-num na cyan akcent marki (spójnie z RazDwa/Karoma) */
+#case-power-of-mind-pelne .razdwa-stat-num { color: #06b6d4; }
+
+/* Chapter rail — subtelniejszy, nie konkuruje z treścią */
+#pom-chapter-rail {
+  box-shadow: 0 2px 12px rgba(15, 23, 42, 0.07);
+  border-color: #edf0f4;
+  background: rgba(255, 255, 255, 0.90);
+}
+#pom-chapter-rail .razdwa-chapter-rail-label {
+  color: #94a3b8;
+}
+
+/* Hero image — realne proporcje 1573x1383, contain (bez letterboxa) */
+#case-power-of-mind-pelne .kwcs-hero-body .hero-image {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+#case-power-of-mind-pelne .kwcs-hero-body .hero-image .cover {
+  display: block;
+  width: 100%;
+  max-width: 860px;
+  height: auto;
+  object-fit: contain;
+  border-radius: 14px;
+  box-shadow: 0 24px 60px -28px rgba(15, 23, 42, 0.32);
+}
+
+/* Podtytuł H2 — wyśrodkowany pod tytułem (section-divider jest center) */
+#case-power-of-mind-pelne .razdwa-h2-sub {
+  max-width: 760px;
+  margin: -0.25rem auto 1.25rem;
+  text-align: center;
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 1.15rem;
+  line-height: 1.5;
+}
+
+/* Desktop ≥1280px — content odsunięty za fixed rail + full-bleed teł */
+@media (min-width: 1280px) {
+  #case-power-of-mind-pelne { padding-left: 216px; --wrap-max: 1240px; }
+  #case-power-of-mind-pelne > .razdwa-summary,
+  #case-power-of-mind-pelne > .kwcs-sec--alt {
+    margin-left: -216px;
+    padding-left: calc(216px + 1rem);
+  }
+}
+/* Laptop 1101-1279px — węższy rail, mniejszy margines */
+@media (min-width: 1101px) and (max-width: 1279px) {
+  #case-power-of-mind-pelne { padding-left: 184px; --wrap-max: 1120px; }
+  #case-power-of-mind-pelne > .razdwa-summary,
+  #case-power-of-mind-pelne > .kwcs-sec--alt {
+    margin-left: -184px;
+    padding-left: calc(184px + 1rem);
+  }
+}
+/* Tablet i mobile ≤1100px — rail jako górny pasek, bez marginesu bocznego */
+@media (max-width: 1100px) {
+  #case-power-of-mind-pelne { padding-left: 0; }
+}
+
+/* Hero CTA na mobile — box-sizing, żeby padding nie dawał overflow na 390px */
+#case-power-of-mind-pelne .hero-image-cta {
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+/* Blok zaproszenia (CTA końcowe) + ghost CTA + slot cytatu */
+#case-power-of-mind-pelne .result-invite {
+  margin-top: 2.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.3);
+  text-align: center;
+}
+#case-power-of-mind-pelne .result-invite h3 {
+  font-size: 1.5rem;
+  line-height: 1.3;
+  margin: 0 0 0.75rem;
+  color: #0f172a;
+}
+#case-power-of-mind-pelne .result-invite p {
+  max-width: 640px;
+  margin: 0 auto 0.5rem;
+  color: #475569;
+}
+#case-power-of-mind-pelne .result-invite-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+/* neutralizacja margin:auto z .kwcs-result .kwcs-cta w flexie */
+#case-power-of-mind-pelne .result-invite-actions .kwcs-cta {
+  margin: 0.5rem 0;
+}
+#case-power-of-mind-pelne .kwcs-cta--ghost {
+  background: transparent;
+  color: #4f46e5;
+  box-shadow: none;
+  border: 1px solid #4f46e5;
+}
+#case-power-of-mind-pelne .kwcs-cta--ghost:hover {
+  background: rgba(79, 70, 229, 0.08);
+  box-shadow: none;
+}
+
+/* Gotowy styl cytatu klientki — aktywny po odkomentowaniu slotu w HTML */
+#case-power-of-mind-pelne .razdwa-quote {
+  margin: 2.5rem auto 0;
+  max-width: 720px;
+  padding: 1.75rem 2rem;
+  border-left: 4px solid #06b6d4;
+  background: rgba(6, 182, 212, 0.07);
+  border-radius: 0 0.75rem 0.75rem 0;
+}
+#case-power-of-mind-pelne .razdwa-quote blockquote {
+  margin: 0 0 1rem;
+  font-size: 1.2rem;
+  line-height: 1.6;
+  font-style: italic;
+  color: #0f172a;
+}
+#case-power-of-mind-pelne .razdwa-quote figcaption {
+  font-weight: 600;
+  color: #334155;
+}
+
+/* ========================================
    KWCS-FOOTER — uproszczony footer case studies
    ======================================== */
 .kwcs-footer {

--- a/projects/power-of-mind.html
+++ b/projects/power-of-mind.html
@@ -6,15 +6,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <title>Case Study: Power of Mind | Karol Wyszyński - Digital Product Designer</title>
-  <meta name="description" content="Brand, strona WordPress z WooCommerce i automatyzacje Google Apps Script dla trenerki oddechu 9D i odporności psychicznej MTQ.">
+  <title>Power of Mind — brand, sklep i automatyzacje, które uwolniły firmę od telefonu | Karol Wyszyński</title>
+  <meta name="description" content="Case study Power of Mind: branding, strona WordPress z WooCommerce i automatyzacje Google Apps Script dla trenerki oddechu 9D i odporności psychicznej MTQ. Zapisy, płatności i przypomnienia działają bez ręcznej obsługi.">
   <meta name="author" content="Karol Wyszyński">
   <meta name="robots" content="index, follow">
 
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://kwyszynskidesign.github.io/KWdesignnew/projects/power-of-mind.html">
-  <meta property="og:title" content="Case Study: Power of Mind | Karol Wyszyński">
-  <meta property="og:description" content="Brand, platforma WordPress i automatyzacje Google Apps Script dla trenerki oddechu 9D. Logo, sklep, system zapisów, przypomnienia 12h.">
+  <meta property="og:title" content="Power of Mind — brand, sklep i automatyzacje bez ręcznej obsługi">
+  <meta property="og:description" content="Branding, platforma WordPress i automatyzacje Google Apps Script dla trenerki oddechu 9D. Zapisy, płatności i przypomnienia 12h działają same.">
   <meta property="og:image" content="https://kwyszynskidesign.github.io/KWdesignnew/assets/images/power-of-mind/POWEROFMIND_FRONT.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -23,8 +23,8 @@
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:url" content="https://kwyszynskidesign.github.io/KWdesignnew/projects/power-of-mind.html">
-  <meta name="twitter:title" content="Case Study: Power of Mind | Karol Wyszyński">
-  <meta name="twitter:description" content="Brand, platforma WordPress i automatyzacje Google Apps Script dla trenerki oddechu 9D.">
+  <meta name="twitter:title" content="Power of Mind — brand, sklep i automatyzacje bez ręcznej obsługi">
+  <meta name="twitter:description" content="Branding, platforma WordPress i automatyzacje Google Apps Script dla trenerki oddechu 9D.">
   <meta name="twitter:image" content="https://kwyszynskidesign.github.io/KWdesignnew/assets/images/power-of-mind/POWEROFMIND_FRONT.png">
 
   <link rel="icon" type="image/png" sizes="32x32" href="../assets/images/favicon-32x32.png">
@@ -50,50 +50,68 @@
         Portfolio
       </a>
       <span class="kwcs-breadcrumb-sep">/</span>
-      <span class="kwcs-breadcrumb-current">Power of Mind — Platforma sprzedażowa</span>
+      <span class="kwcs-breadcrumb-current">Power of Mind — brand, sklep i automatyzacje</span>
     </div>
   </nav>
 
-  <section class="kwcs" id="case-powerofmind" aria-label="Case Study: Power of Mind — WordPress, automatyzacje i branding">
+  <section class="kwcs" id="case-power-of-mind-pelne" aria-label="Pełne Case Study: Power of Mind — brand, WordPress i automatyzacje">
 
+    <!-- ============================================================
+         Chapter rail — sticky TOC z internal anchors
+    ============================================================ -->
     <nav class="razdwa-chapter-rail" id="pom-chapter-rail" aria-label="Spis treści case study">
       <div class="razdwa-chapter-rail-label">Rozdziały</div>
       <ul class="razdwa-chapter-rail-list">
-        <li><a class="razdwa-chapter-link" href="#pom-problem" data-rail-target="pom-problem" title="Problem biznesowy" aria-label="Problem biznesowy">Problem</a></li>
-        <li><a class="razdwa-chapter-link" href="#pom-kontekst" data-rail-target="pom-kontekst" title="Kontekst i zakres" aria-label="Kontekst i zakres">Zakres</a></li>
-        <li><a class="razdwa-chapter-link" href="#pom-platforma" data-rail-target="pom-platforma" title="Wybór platformy" aria-label="Wybór platformy">Platforma</a></li>
-        <li><a class="razdwa-chapter-link" href="#pom-branding" data-rail-target="pom-branding" title="Branding i identyfikacja wizualna" aria-label="Branding i identyfikacja wizualna">Branding</a></li>
-        <li><a class="razdwa-chapter-link" href="#pom-showcase" data-rail-target="pom-showcase" title="Realizacja strony" aria-label="Realizacja strony">Realizacja</a></li>
-        <li><a class="razdwa-chapter-link" href="#pom-automatyzacje" data-rail-target="pom-automatyzacje" title="Automatyzacje Google Apps Script" aria-label="Automatyzacje Google Apps Script">Automatyzacje</a></li>
-        <li><a class="razdwa-chapter-link" href="#pom-rezultat" data-rail-target="pom-rezultat" title="Rezultat projektu" aria-label="Rezultat projektu">Rezultat</a></li>
-        <li><a class="razdwa-chapter-link" href="#pom-wnioski" data-rail-target="pom-wnioski" title="Czego się nauczyłem" aria-label="Czego się nauczyłem">Wnioski</a></li>
+        <li><a class="razdwa-chapter-link" href="#pom-summary" data-rail-target="pom-summary" title="W skrócie" aria-label="W skrócie">W skrócie</a></li>
+        <li><a class="razdwa-chapter-link" href="#pom-problem" data-rail-target="pom-problem" title="Zapisy zależały od właścicielki" aria-label="Zapisy zależały od właścicielki">Problem</a></li>
+        <li><a class="razdwa-chapter-link" href="#pom-rola" data-rail-target="pom-rola" title="Od marki po automatyzacje" aria-label="Od marki po automatyzacje">Moja rola</a></li>
+        <li><a class="razdwa-chapter-link" href="#pom-decyzje" data-rail-target="pom-decyzje" title="Trzy platformy, jedna decyzja" aria-label="Trzy platformy, jedna decyzja">Kluczowe decyzje</a></li>
+        <li><a class="razdwa-chapter-link" href="#pom-branding" data-rail-target="pom-branding" title="Marka, która uspokaja" aria-label="Marka, która uspokaja">Branding</a></li>
+        <li><a class="razdwa-chapter-link" href="#pom-showcase" data-rail-target="pom-showcase" title="Strona, która prowadzi do zapisu" aria-label="Strona, która prowadzi do zapisu">Realizacja</a></li>
+        <li><a class="razdwa-chapter-link" href="#pom-automatyzacje" data-rail-target="pom-automatyzacje" title="Zapisy ruszyły bez ręcznego chaosu" aria-label="Zapisy ruszyły bez ręcznego chaosu">Automatyzacje</a></li>
+        <li><a class="razdwa-chapter-link" href="#pom-wnioski" data-rail-target="pom-wnioski" title="Projektowanie pod realne ograniczenia" aria-label="Projektowanie pod realne ograniczenia">Wnioski</a></li>
+        <li><a class="razdwa-chapter-link" href="#pom-rezultat" data-rail-target="pom-rezultat" title="Co zmieniło się w firmie" aria-label="Co zmieniło się w firmie">Rezultat</a></li>
       </ul>
     </nav>
 
+    <!-- Hero Head -->
     <div class="kwcs-hero-head">
       <div class="wrap">
-        <p class="eyebrow">Case Study · Wellness Brand · WordPress & Automatyzacje</p>
-        <h1>Power of Mind — brand, sklep i automatyzacje dla trenerki oddechu 9D</h1>
-        <p class="sub">Branding + WordPress + WooCommerce + Google Apps Script. Trzy platformy testowane, jedna wdrożona.</p>
+        <p class="eyebrow">Case Study · Wellness Brand · WordPress &amp; Automatyzacje</p>
+        <h1>Power of Mind<br>brand, sklep i automatyzacje, które uwolniły firmę od telefonu</h1>
+        <p class="sub">
+          Zastąpiłem telefoniczne zapisy i ręczne przypomnienia platformą, która sprzedaje, potwierdza i przypomina sama — bez stałych opłat za SaaS i bez oddawania danych uczestników na zewnątrz.
+        </p>
         <div class="pm-hero-meta">
-          <span><strong>Rola</strong> Digital Product Designer</span>
+          <span><strong>Rola</strong> Digital Product Designer, branding, wdrożenie</span>
           <span class="pm-meta-sep">·</span>
-          <span><strong>Czas</strong> ~10 tygodni</span>
+          <span><strong>Czas</strong> ok. 10 tygodni</span>
           <span class="pm-meta-sep">·</span>
-          <span><strong>Typ</strong> Branding · WordPress · Automatyzacje</span>
+          <span><strong>Zakres</strong> branding, WordPress, WooCommerce, automatyzacje</span>
           <span class="pm-meta-sep">·</span>
-          <span><strong>Stack</strong> Elementor · WooCommerce · Przelewy24 · GAS</span>
+          <span><strong>Efekt</strong> zapisy, płatności i przypomnienia bez ręcznej obsługi</span>
         </div>
       </div>
     </div>
 
     <div class="kwcs-hero-body">
       <div class="wrap inner">
-        <div class="hero-image">
-          <img class="cover" src="../assets/images/power-of-mind/POWEROFMIND_HERO_1.webp" alt="Strona główna Power of Mind — platforma sesji oddechu 9D i testów MTQ" fetchpriority="high" decoding="async" width="1200" height="630" data-caption="Platforma Power of Mind — widok desktop">
+        <div class="hero-content-grid">
+          <div class="hero-image">
+            <img
+              class="cover"
+              src="../assets/images/power-of-mind/POWEROFMIND_HERO_1.webp"
+              alt="Strona główna Power of Mind — platforma sesji oddechu 9D i testów odporności psychicznej MTQ"
+              fetchpriority="high"
+              decoding="async"
+              width="1573"
+              height="1383"
+              data-caption="Platforma Power of Mind — strona główna z propozycją wartości i CTA do zapisu">
+          </div>
         </div>
-        <a class="hero-image-cta" href="https://ewabugaj-powerofmind.pl" target="_blank" rel="noopener noreferrer" aria-label="Zobacz projekt Power of Mind">
-          Obejrzyj stronę
+
+        <a class="hero-image-cta" href="https://kwyszynskidesign.github.io/Powerofmind/" target="_blank" rel="noopener noreferrer" aria-label="Zobacz stronę Power of Mind na żywo">
+          Zobacz stronę na żywo
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <polyline points="9 18 15 12 9 6"></polyline>
           </svg>
@@ -101,155 +119,189 @@
       </div>
     </div>
 
-    <div class="kwcs-sec" id="pom-problem" style="background:#f0f9ff;">
+    <!-- ============================================================
+         Executive summary po hero
+    ============================================================ -->
+    <div class="razdwa-summary" id="pom-summary">
       <div class="wrap">
-        <h2>Problem</h2>
-        <div class="context-intro">
-          <p>
-            Ewa Bugaj prowadziła sesje oddechu 9D i testy odporności psychicznej MTQ, ale przyjmowała zapisy przez telefon. Nie miała strony opisującej usługi, możliwości płatności online ani spójnej identyfikacji wizualnej. Każde potwierdzenie zapisu i przypomnienie o sesji wysyłała ręcznie.
-          </p>
-          <p>
-            Potrzebowała platformy, która działa też pod jej nieobecność: automatycznie zbiera zapisy, pobiera płatności, potwierdza uczestnikowi i przypomina o sesji — bez dodatkowych subskrypcji SaaS i bez outsourcingu danych uczestników do zewnętrznych systemów.
-          </p>
+        <h2>W skrócie</h2>
+        <div class="razdwa-summary-grid">
+          <div class="razdwa-summary-cell">
+            <div class="label">Problem</div>
+            <div class="value">Zapisy, potwierdzenia i przypomnienia szły ręcznie i telefonicznie — firma działała tylko wtedy, gdy właścicielka miała czas.</div>
+          </div>
+          <div class="razdwa-summary-cell">
+            <div class="label">Moja rola</div>
+            <div class="value">Prowadziłem projekt od marki, przez wybór i wdrożenie platformy, po logikę zapisów i płatności.</div>
+          </div>
+          <div class="razdwa-summary-cell">
+            <div class="label">Rozwiązanie</div>
+            <div class="value">Spójny brand, sklep WordPress z WooCommerce i automatyzacje Google Apps Script obsługujące cały flow zapisu.</div>
+          </div>
+          <div class="razdwa-summary-cell">
+            <div class="label">Efekt</div>
+            <div class="value">Zapisy, płatności i przypomnienia działają bez ręcznej obsługi — bez stałych kosztów SaaS.</div>
+          </div>
         </div>
+        <p class="kwcs-footnote">Zakres i efekty opisane na podstawie wdrożonego zakresu prac; twardych danych sprzedażowych klientka nie udostępniła publicznie.</p>
       </div>
     </div>
 
-    <div class="kwcs-sec kwcs-context-section" id="pom-kontekst">
+    <h2 class="section-divider" id="pom-problem">Zapisy zależały od właścicielki</h2>
+
+    <div class="kwcs-sec">
       <div class="wrap">
-        <h2>Kontekst i zakres</h2>
-        <div class="context-intro">
-          <p>
-            Power of Mind to marka rozwojowa Ewy Bugaj — certyfikowanej trenerki <strong>oddechu 9D</strong> i <strong>odporności psychicznej MTQ/MTQ+</strong>. Ze względu na intymny charakter usług (praca z emocjami, oddechem, psychiką) priorytetem był spokojny UX, czytelna komunikacja i bezpieczeństwo danych uczestników.
-          </p>
-        </div>
-        <h3 class="scope-heading">Zakres</h3>
-        <div class="scope-grid">
-          <div class="scope-item">
-            <div class="scope-icon">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:1em;height:1em;display:block;margin:0 auto" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
-            </div>
-            <p>Logo i identyfikacja wizualna — 3 rundy iteracji</p>
+        <p class="razdwa-h2-sub">Każde potwierdzenie i przypomnienie o sesji szło ręcznie — nic nie działało bez niej.</p>
+        <p class="kwcs-section-lead">
+          Ewa Bugaj prowadziła sesje oddechu 9D i testy odporności psychicznej MTQ, ale zapisy przyjmowała przez telefon. Nie miała strony opisującej usługi, płatności online ani spójnej identyfikacji — a każde potwierdzenie i przypomnienie wysyłała <strong>osobno, ręcznie</strong>.
+        </p>
+
+        <div class="ux-decision-grid">
+          <div class="ux-decision-box">
+            <h4>Co blokowało rozwój</h4>
+            <p>Brak strony i płatności online oznaczał, że klient nie mógł kupić usługi samodzielnie. Zapis wymagał telefonu w godzinach pracy właścicielki, a każdy krok — potwierdzenie, przypomnienie — obciążał ją ręcznie.</p>
           </div>
-          <div class="scope-item">
-            <div class="scope-icon">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:1em;height:1em;display:block;margin:0 auto" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-            </div>
-            <p>Wybór i wdrożenie platformy (Webflow → Wix → WordPress)</p>
-          </div>
-          <div class="scope-item">
-            <div class="scope-icon">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:1em;height:1em;display:block;margin:0 auto" aria-hidden="true"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"/></svg>
-            </div>
-            <p>Sklep WooCommerce — pakiety sesji 1/6/12 + testy MTQ</p>
-          </div>
-          <div class="scope-item">
-            <div class="scope-icon">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:1em;height:1em;display:block;margin:0 auto" aria-hidden="true"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>
-            </div>
-            <p>Integracja Przelewy24 + konfiguracja RODO</p>
-          </div>
-          <div class="scope-item">
-            <div class="scope-icon">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:1em;height:1em;display:block;margin:0 auto" aria-hidden="true"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
-            </div>
-            <p>Automatyzacje Google Apps Script — zapisy, powiadomienia, przypomnienia</p>
-          </div>
-          <div class="scope-item">
-            <div class="scope-icon">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:1em;height:1em;display:block;margin:0 auto" aria-hidden="true"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-            </div>
-            <p>Poczta na własnej domenie + szkolenie klientki z panelu WP</p>
+          <div class="ux-decision-box">
+            <h4>Dlaczego to było wrażliwe</h4>
+            <p>Praca z oddechem i psychiką to usługi intymne. Priorytetem był spokojny UX, czytelna komunikacja i <strong>bezpieczeństwo danych uczestników</strong> — bez oddawania ich do zewnętrznych systemów SaaS.</p>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="kwcs-sec" id="pom-platforma">
+    <h2 class="section-divider" id="pom-rola">Od marki po automatyzacje</h2>
+
+    <div class="kwcs-sec">
       <div class="wrap">
-        <h2>Wybór platformy</h2>
-        <div class="context-intro">
-          <p>Zanim napisano linię kodu, przetestowano trzy platformy. Decyzja o WordPress zapadła po konkretnych blokadach — nie po preferencji.</p>
+        <p class="razdwa-h2-sub">Jeden wykonawca odpowiedzialny za całość — od logo po logikę zapisów.</p>
+        <p class="kwcs-section-lead">
+          Odpowiadałem za każdy etap — od identyfikacji wizualnej, przez wybór i wdrożenie platformy, po sklep, płatności i automatyzacje obsługujące zapisy.
+        </p>
+
+        <div class="contribution-grid--razdwa">
+          <div class="contribution-cell contribution-cell--solo">
+            <h3><span class="dot"></span>Za co odpowiadałem</h3>
+            <ul>
+              <li>Logo i identyfikacja wizualna — 3 rundy iteracji</li>
+              <li>Wybór i wdrożenie platformy (Webflow → Wix → WordPress)</li>
+              <li>Sklep WooCommerce, pakiety sesji i integracja Przelewy24 + RODO</li>
+              <li>Automatyzacje Google Apps Script: zapisy, powiadomienia, przypomnienia</li>
+              <li>Poczta na własnej domenie i szkolenie klientki z panelu WordPress</li>
+            </ul>
+          </div>
         </div>
-        <div class="kwcs-trio">
-          <article class="kwcs-card">
-            <h3>Webflow — odrzucony</h3>
-            <p>Brak możliwości integracji kursów online i ograniczone CMS nie pokrywały planu skalowania o LMS. Platforma dobra dla stron wizytówkowych, za słaba do e-commerce z rozbudowanym kursami.</p>
-          </article>
-          <article class="kwcs-card">
-            <h3>Wix — odrzucony</h3>
-            <p>Niedopuszczalne warunki regulaminu: po wygaśnięciu subskrypcji premium na stronie pojawia się branding Wix. Ograniczenie odkryto po testowym wdrożeniu, nie wcześniej podczas analizy cennika.</p>
-          </article>
-          <article class="kwcs-card">
-            <h3>WordPress — wybrany</h3>
-            <p>Pełna elastyczność, WooCommerce dla e-commerce, możliwość rozbudowy o LMS i pełna kontrola nad danymi uczestników bez zewnętrznych subskrypcji.</p>
-          </article>
+
+        <div class="razdwa-stats">
+          <div class="razdwa-stat">
+            <div class="razdwa-stat-num">~10 tyg.</div>
+            <div class="razdwa-stat-label">od startu do wdrożenia produkcyjnego platformy</div>
+          </div>
+          <div class="razdwa-stat">
+            <div class="razdwa-stat-num">3 → 1</div>
+            <div class="razdwa-stat-label">platformy przetestowane, jedna wdrożona po konkretnych blokadach</div>
+          </div>
+          <div class="razdwa-stat">
+            <div class="razdwa-stat-num">3 akcje</div>
+            <div class="razdwa-stat-label">automatyczne na każdy zapis — potwierdzenie, powiadomienie, przypomnienie</div>
+          </div>
+          <div class="razdwa-stat">
+            <div class="razdwa-stat-num">0 zł</div>
+            <div class="razdwa-stat-label">miesięcznych kosztów SaaS i serwera za automatyzacje</div>
+          </div>
         </div>
       </div>
     </div>
 
-    <div class="kwcs-sec kwcs-logo-section" id="pom-branding">
+    <h2 class="section-divider" id="pom-decyzje">Trzy platformy, jedna decyzja</h2>
+
+    <div class="kwcs-sec">
       <div class="wrap">
-        <h2>Branding i identyfikacja wizualna</h2>
-        <div class="logo-intro">
+        <p class="razdwa-h2-sub">Wybór WordPressa poparty konkretnymi blokadami, nie preferencją.</p>
+        <p class="kwcs-section-lead">
+          Zanim napisałem linię kodu, przetestowałem trzy platformy. Decyzja o WordPressie zapadła po realnych ograniczeniach — dzięki temu firma nie płaci za przepisywanie gotowej strony ani za funkcje, których nie może rozbudować.
+        </p>
+
+        <div class="ux-decision-grid ux-decision-grid--trio">
+          <div class="ux-decision-box">
+            <div class="ux-label">Webflow — odrzucony</div>
+            <h4>Za słaby pod skalowanie o kursy</h4>
+            <p>Brak sensownej integracji kursów online i ograniczone CMS nie pokrywały planu rozbudowy o LMS. Dobry na wizytówki, za słaby na e-commerce z rozbudowaną ofertą.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">Wix — odrzucony</div>
+            <h4>Branding Wix po wygaśnięciu subskrypcji</h4>
+            <p>Po wygaśnięciu subskrypcji premium na stronie pojawia się branding Wix. To ograniczenie regulaminowe wyszło dopiero przy testowym wdrożeniu — nie z cennika.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">WordPress — wybrany</div>
+            <h4>Pełna kontrola nad danymi i ofertą</h4>
+            <p>WooCommerce pod e-commerce, możliwość rozbudowy o LMS i pełna kontrola nad danymi uczestników — bez zależności od zewnętrznych subskrypcji.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2 class="section-divider" id="pom-branding">Marka, która uspokaja</h2>
+
+    <div class="kwcs-sec kwcs-logo-section">
+      <div class="wrap">
+        <p class="razdwa-h2-sub">Spokojna identyfikacja zamiast krzykliwego wellness — buduje zaufanie do usług intymnych.</p>
+        <p class="kwcs-section-lead">
+          Logo Power of Mind powstawało w <strong>trzech rundach iteracji</strong>. Marka miała kojarzyć się ze spokojem i profesjonalizmem, nie z motywacyjnym, krzykliwym designem typowym dla branży. Dzięki temu pierwszy kontakt z marką buduje zaufanie, zanim klient przeczyta choćby zdanie o usłudze.
+        </p>
+        <p class="kwcs-section-lead">
+          Testowałem warianty typografii (Playfair Display vs. sans-serif), symboliki i kolorystyki. Paleta: głęboki indygo (#4f46e5) jako kolor podstawowy i cyan (#06b6d4) jako akcent — spójna z charakterem usług transformacyjnych. Minimalistyczne rozwiązanie działa online (social media, favicon, nagłówki e-mail) i offline (wizytówki, szablony prezentacji).
+        </p>
+
+        <div class="kwcs-callout">
           <p>
-            Logo Power of Mind powstawało w trzech rundach iteracji. Założenia: prostota, elegancja, symbolika siły umysłu — marka miała kojarzyć się ze spokojem i profesjonalizmem, nie z motywacyjnym krzykliwym designem typowym dla branży wellness.
-          </p>
-          <p>
-            Testowałem warianty typografii (Playfair Display vs. sans-serif), symboliki i kolorystyki. Końcowe rozwiązanie minimalistyczne działa zarówno online (social media, favicon, nagłówki e-mail), jak i offline (wizytówki, szablony prezentacji). Paleta: głęboki indygo (#4f46e5) jako primary, cyan (#06b6d4) jako akcent — spójna z charakterem usług transformacyjnych.
-          </p>
-          <p>
-            Dostarczone materiały: logo + logotyp, paleta kolorów i typografia, wizytówki, szablony social media, favicon, nagłówki e-mail, szablony prezentacji.
+            <strong>Dostarczone materiały:</strong> logo i logotyp, paleta kolorów i typografia, wizytówki, szablony social media, favicon, nagłówki e-mail oraz szablony prezentacji — jeden spójny system dla całej komunikacji marki.
           </p>
         </div>
 
+        <!-- ============================================================
+             SLOT GALERII BRANDINGU (assety w przygotowaniu)
+             Galeria celowo NIEWIDOCZNA do czasu dostarczenia finalnych
+             grafik. Zero broken-image w renderze. Aby aktywować: wgraj
+             pliki do assets/images/power-of-mind/ i usuń znaczniki
+             komentarza. Proponowane nazwy plików już wpisane poniżej.
+        ============================================================
         <div class="kwcs-gallery-grid">
           <div class="gallery-item">
-            <div class="asset-missing" role="img" aria-label="Brakujący asset: power-of-mind-logo.png">
-              <span class="asset-missing-icon" aria-hidden="true">📁</span>
-              <span class="asset-missing-label">Brakujący asset</span>
-              <code class="asset-missing-filename">power-of-mind-logo.png</code>
-            </div>
+            <img class="lightbox-trigger" src="../assets/images/power-of-mind/power-of-mind-logo.webp" alt="Logo i logotyp Power of Mind" loading="lazy" data-caption="Logo i logotyp Power of Mind">
             <p class="img-desc">Logo i logotyp</p>
           </div>
           <div class="gallery-item">
-            <div class="asset-missing" role="img" aria-label="Brakujący asset: power-of-mind-paleta.png">
-              <span class="asset-missing-icon" aria-hidden="true">📁</span>
-              <span class="asset-missing-label">Brakujący asset</span>
-              <code class="asset-missing-filename">power-of-mind-paleta.png</code>
-            </div>
+            <img class="lightbox-trigger" src="../assets/images/power-of-mind/power-of-mind-paleta.webp" alt="Paleta kolorów i typografia Power of Mind" loading="lazy" data-caption="Paleta kolorów i typografia">
             <p class="img-desc">Paleta kolorów i typografia</p>
           </div>
           <div class="gallery-item">
-            <div class="asset-missing" role="img" aria-label="Brakujący asset: power-of-mind-wizytowki.png">
-              <span class="asset-missing-icon" aria-hidden="true">📁</span>
-              <span class="asset-missing-label">Brakujący asset</span>
-              <code class="asset-missing-filename">power-of-mind-wizytowki.png</code>
-            </div>
+            <img class="lightbox-trigger" src="../assets/images/power-of-mind/power-of-mind-wizytowki.webp" alt="Wizytówki i szablon prezentacji Power of Mind" loading="lazy" data-caption="Wizytówki i szablon prezentacji">
             <p class="img-desc">Wizytówki i szablon prezentacji</p>
           </div>
           <div class="gallery-item">
-            <div class="asset-missing" role="img" aria-label="Brakujący asset: power-of-mind-social.png">
-              <span class="asset-missing-icon" aria-hidden="true">📁</span>
-              <span class="asset-missing-label">Brakujący asset</span>
-              <code class="asset-missing-filename">power-of-mind-social.png</code>
-            </div>
+            <img class="lightbox-trigger" src="../assets/images/power-of-mind/power-of-mind-social.webp" alt="Szablony social media Power of Mind" loading="lazy" data-caption="Szablony social media">
             <p class="img-desc">Szablony social media</p>
           </div>
         </div>
+        -->
       </div>
     </div>
 
-    <div class="kwcs-sec kwcs-website-showcase" id="pom-showcase">
+    <h2 class="section-divider" id="pom-showcase">Strona, która prowadzi do zapisu</h2>
+
+    <div class="kwcs-sec kwcs-website-showcase">
       <div class="wrap">
-        <h2>Realizacja strony</h2>
-        <p>Trzy kluczowe strony serwisu — strona główna, produkt główny i testy MTQ — projektowane z myślą o konwersji: od pierwszego kontaktu do potwierdzenia płatności.</p>
+        <p class="razdwa-h2-sub">Trzy kluczowe widoki projektowane pod konwersję: od wejścia do płatności.</p>
+        <p class="kwcs-section-lead">
+          Strona główna, produkt główny i testy MTQ prowadzą klienta jedną ścieżką — od pierwszego kontaktu, przez edukację, po potwierdzoną płatność. Dzięki temu klient kupuje sam, a właścicielka nie musi domykać każdej transakcji telefonicznie.
+        </p>
 
         <div class="showcase-stack">
 
           <div class="showcase-section">
             <h3>Strona główna</h3>
-            <p class="tab-description">Hero z propozycją wartości, pop-up z aktualną liczbą miejsc i CTA do zapisu na sesję</p>
+            <p class="tab-description">Hero z propozycją wartości, pop-up z aktualną liczbą wolnych miejsc i CTA do zapisu na sesję.</p>
             <div class="showcase-row">
               <div class="showcase-item">
                 <img class="lightbox-trigger" src="../assets/images/power-of-mind/POWEROFMIND_HERO_1.webp" alt="Strona główna Power of Mind — widok desktop z sekcją hero i CTA" loading="lazy" data-caption="Strona główna — sekcja hero z CTA i licznikiem wolnych miejsc">
@@ -260,16 +312,16 @@
             </div>
             <div class="features-box">
               <ul class="features-list">
-                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Hero z propozycją wartości i CTA do zapisu na sesję</li>
-                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Pop-up z aktualną liczbą dostępnych miejsc (dane z GAS w czasie rzeczywistym)</li>
-                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Responsywny layout, podstawowe SEO, PageSpeed zoptymalizowany</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Hero z propozycją wartości i wyraźnym CTA do zapisu na sesję</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Pop-up z aktualną liczbą wolnych miejsc — dane z automatyzacji w czasie rzeczywistym</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Responsywny layout i podstawowe SEO — strona gotowa do promocji</li>
               </ul>
             </div>
           </div>
 
           <div class="showcase-section">
             <h3>Sesje oddechu 9D</h3>
-            <p class="tab-description">Strona produktu — opis usługi, pakiety 1/6/12 sesji z cennikiem i formularzem zakupu</p>
+            <p class="tab-description">Strona produktu — opis usługi, pakiety 1/6/12 sesji z cennikiem i zakupem online.</p>
             <div class="showcase-row">
               <div class="showcase-item">
                 <img class="lightbox-trigger" src="../assets/images/power-of-mind/POWEROFMIND_HERO_9D.webp" alt="Strona sesji oddechu 9D — widok desktop z pakietami i cenami" loading="lazy" data-caption="Oddech 9D — strona produktu z pakietami i CTA zakupu">
@@ -280,16 +332,16 @@
             </div>
             <div class="features-box">
               <ul class="features-list">
-                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Opis usługi: dla kogo, jak działa, co daje — edukacyjny wstęp przed sprzedażą</li>
-                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Pakiety 1, 6 i 12 sesji z cenami i CTA zakupu przez WooCommerce</li>
-                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Integracja płatności Przelewy24 + formularz zapisu z danymi uczestnika</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Edukacyjny wstęp przed sprzedażą: dla kogo, jak działa, co daje</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Pakiety 1, 6 i 12 sesji z cenami i zakupem przez WooCommerce</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Płatność Przelewy24 i formularz zapisu z danymi uczestnika</li>
               </ul>
             </div>
           </div>
 
           <div class="showcase-section">
             <h3>Testy MTQ / MTQ+</h3>
-            <p class="tab-description">Badanie odporności psychicznej — opis, przebieg testu, różnice między wariantami, zakup</p>
+            <p class="tab-description">Badanie odporności psychicznej — opis, przebieg testu, różnice między wariantami, zakup.</p>
             <div class="showcase-row">
               <div class="showcase-item">
                 <img class="lightbox-trigger" src="../assets/images/power-of-mind/HERO_MTQ.png" alt="Strona testów MTQ odporności psychicznej — widok desktop" loading="lazy" data-caption="Testy MTQ — strona badania odporności psychicznej z wyborem wariantu">
@@ -300,9 +352,9 @@
             </div>
             <div class="features-box">
               <ul class="features-list">
-                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Edukacja: czym jest odporność psychiczna, model MTQ48</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Edukacja: czym jest odporność psychiczna i model MTQ48</li>
                 <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Przebieg testu: czas trwania, raport wyników, sesja omówieniowa</li>
-                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Wybór wariantu: MTQ vs MTQ+ z różnicą zakresu i ceny</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg> Wybór wariantu MTQ vs MTQ+ z jasną różnicą zakresu i ceny</li>
               </ul>
             </div>
           </div>
@@ -311,67 +363,126 @@
       </div>
     </div>
 
-    <div class="kwcs-sec" id="pom-automatyzacje">
+    <h2 class="section-divider" id="pom-automatyzacje">Zapisy ruszyły bez ręcznego chaosu</h2>
+
+    <div class="kwcs-sec">
       <div class="wrap">
-        <h2>Automatyzacje Google Apps Script</h2>
-        <div class="context-intro">
-          <p>System działa bez zewnętrznych subskrypcji SaaS. Każdy zapis na sesję uruchamia sekwencję automatycznych akcji — pełna kontrola nad danymi uczestników w ekosystemie Google.</p>
-        </div>
+        <p class="razdwa-h2-sub">Jeden formularz uruchamia potwierdzenie, powiadomienie i przypomnienie 12h — bez SaaS.</p>
+        <p class="kwcs-section-lead">
+          System działa bez zewnętrznych subskrypcji. Każdy zapis na sesję uruchamia sekwencję automatycznych akcji, a dane uczestników zostają w ekosystemie Google, który klientka już zna. Dzięki temu firma działa też pod nieobecność właścicielki — i nie płaci co miesiąc za pośredników.
+        </p>
+
         <div class="kwcs-trio">
           <article class="kwcs-card">
             <h3>Flow zapisu na sesję</h3>
             <ol style="padding-left:1.25rem;margin:0.75rem 0 0;line-height:2;">
               <li>Uczestnik wypełnia formularz zapisu na stronie</li>
-              <li>10 pól danych trafia do arkusza Google Sheets</li>
-              <li>GAS wysyła e-mail potwierdzenia do uczestnika</li>
-              <li>GAS powiadamia Ewę o nowym zapisie</li>
+              <li>Dane trafiają do arkusza Google Sheets</li>
+              <li>Automat wysyła e-mail potwierdzenia do uczestnika</li>
+              <li>Automat powiadamia właścicielkę o nowym zapisie</li>
               <li>Trigger 12h przed sesją — automatyczne przypomnienie</li>
             </ol>
           </article>
           <article class="kwcs-card">
-            <h3>Pop-up licznika miejsc</h3>
-            <p>Strona główna i strona 9D wyświetlają aktualną liczbę dostępnych miejsc. Dane pobierane w czasie rzeczywistym z arkusza przez endpoint GAS — bez odświeżania strony, bez manualnej aktualizacji treści przez właścicielkę.</p>
+            <h3>Licznik wolnych miejsc na żywo</h3>
+            <p>Strona główna i strona 9D pokazują aktualną liczbę dostępnych miejsc. Dane pobierane w czasie rzeczywistym z arkusza — bez odświeżania strony i bez ręcznej aktualizacji treści przez właścicielkę.</p>
           </article>
           <article class="kwcs-card">
-            <h3>Dlaczego GAS, nie Zapier</h3>
-            <p>Alternatywy (Zapier, Make, ActiveCampaign) dodawałyby stały koszt miesięczny i trzecią stronę w dostępie do danych uczestników sesji psychologicznych. Google Apps Script: bezpłatne, wewnątrz ekosystemu Google, który klientka już używa.</p>
+            <h3>Dlaczego Google Apps Script</h3>
+            <p>Zapier, Make czy ActiveCampaign dodawałyby stały koszt miesięczny i trzecią stronę w dostępie do danych uczestników sesji psychologicznych. GAS jest bezpłatny i działa wewnątrz ekosystemu, którego klientka już używa.</p>
           </article>
         </div>
       </div>
     </div>
 
-    <div class="kwcs-sec" id="pom-rezultat">
+    <h2 class="section-divider" id="pom-wnioski">Projektowanie pod realne ograniczenia</h2>
+
+    <div class="kwcs-sec kwcs-sec--alt">
+      <div class="wrap">
+        <p class="kwcs-section-lead">
+          Ten projekt utwierdził mnie w trzech rzeczach: platformę wybiera się po ograniczeniach, nie po modzie; prywatność danych bywa ważniejsza niż wygoda gotowego narzędzia; a najlepsze rozwiązania wynikają z realnego procesu klienta. Dla klienta oznacza to jedno: pracuję na jego warunkach, a nie na założeniach z briefu.
+        </p>
+
+        <div class="ux-decision-grid ux-decision-grid--trio">
+          <div class="ux-decision-box">
+            <div class="ux-label">Wniosek 1</div>
+            <h4>Wybór platformy to decyzja produktowa</h4>
+            <p>Test trzech platform kosztował czas, ale uchronił przed przepisywaniem gotowej strony. Blokada Wix (branding po wygaśnięciu subskrypcji) wyszła dopiero przy testowym wdrożeniu — analiza narzędzi należy do procesu, nie do etapu wdrożenia.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">Wniosek 2</div>
+            <h4>Zero SaaS = pełna kontrola nad danymi</h4>
+            <p>Google Apps Script zamiast Zapier czy Make: brak miesięcznego kosztu i brak trzeciej strony w dostępie do danych uczestników sesji psychologicznych. W branży, gdzie prywatność jest priorytetem, architektura bez pośredników była właściwym wyborem.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">Wniosek 3</div>
+            <h4>Kryterium akceptacji to pełny flow</h4>
+            <p>UAT nie był listą funkcji, tylko pełną ścieżką z realnym użytkownikiem: od wejścia na stronę do potwierdzenia płatności. Część błędów UX wyszła wyłącznie przez taki test — nie przez testy funkcjonalne.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2 class="section-divider" id="pom-rezultat">Co zmieniło się w firmie</h2>
+
+    <div class="kwcs-sec">
       <div class="wrap">
         <div class="kwcs-result">
-          <h2>Rezultat</h2>
+          <h3 class="kwcs-result-title">Firma, która działa bez telefonu</h3>
+
           <div class="result-lead">
             <p>
-              Platforma wdrożona produkcyjnie po ~10 tygodniach. Ewa zarządza rezerwacjami, produktami i treścią samodzielnie z panelu WordPress. System automatyzacji obsługuje cały flow zapisu — od formularza do przypomnienia — bez interwencji ręcznej.
+              Platforma wdrożona produkcyjnie po ok. 10 tygodniach. Ewa zarządza rezerwacjami, produktami i treścią <strong>samodzielnie z panelu WordPress</strong>, a automatyzacje obsługują cały flow zapisu — od formularza do przypomnienia — bez interwencji ręcznej.
             </p>
           </div>
+
           <div class="result-cards">
             <div class="result-card">
-              <div class="result-icon">✓</div>
-              <h3>Platforma na produkcji</h3>
+              <h4>Platforma na produkcji</h4>
               <p>WordPress + WooCommerce + Przelewy24. Trzy platformy przetestowane, jedna wdrożona — każda decyzja poparta konkretnym ograniczeniem technicznym lub regulaminowym.</p>
             </div>
             <div class="result-card">
-              <div class="result-icon">⚙</div>
-              <h3>3 akcje na każdy zapis</h3>
-              <p>Potwierdzenie dla uczestnika, powiadomienie dla właścicielki i przypomnienie 12h przed sesją — automatyczne, bez żadnej ręcznej obsługi.</p>
+              <h4>Zapisy bez ręcznej obsługi</h4>
+              <p>Potwierdzenie dla uczestnika, powiadomienie dla właścicielki i przypomnienie 12h przed sesją — trzy akcje na każdy zapis, automatycznie i bez SaaS.</p>
             </div>
             <div class="result-card">
-              <div class="result-icon">✓</div>
-              <h3>Samodzielna obsługa</h3>
-              <p>Po szkoleniu z panelu WP klientka dodaje produkty, edytuje treści i monitoruje zapisy bez pomocy technicznej. Cel: niezależność właścicielki od dewelopera.</p>
+              <h4>Samodzielna właścicielka</h4>
+              <p>Po szkoleniu z panelu WordPress klientka dodaje produkty, edytuje treści i monitoruje zapisy bez pomocy technicznej — niezależnie od dewelopera.</p>
             </div>
           </div>
-          <a class="kwcs-cta" href="https://ewabugaj-powerofmind.pl" target="_blank" rel="noopener noreferrer" aria-label="Zobacz projekt Power of Mind">
-            Zobacz projekt na żywo
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <polyline points="9 18 15 12 9 6"></polyline>
-            </svg>
-          </a>
+
+          <!-- ============================================================
+               SLOT NA CYTAT KLIENTA (proof)
+               Celowo NIEWIDOCZNY do czasu uzyskania prawdziwej opinii
+               właścicielki. Zero fikcyjnych cytatów. Aby aktywować: usuń
+               znaczniki komentarza i uzupełnij treść oraz podpis. Style
+               .razdwa-quote gotowe w projects.css (scope #case-power-of-mind-pelne).
+          ============================================================
+          <figure class="razdwa-quote">
+            <blockquote>„TU PRAWDZIWY CYTAT KLIENTKI — np. o zapisach działających bez telefonu albo o samodzielnym zarządzaniu stroną."</blockquote>
+            <figcaption>Ewa Bugaj — Power of Mind</figcaption>
+          </figure>
+          -->
+
+          <div class="result-invite">
+            <h3>Twoja firma stoi jedną osobą? Zbudujmy proces, który działa bez niej.</h3>
+            <p>Jeśli u Ciebie zapisy, płatności albo przypomnienia zależą od tego, czy ktoś ma czas — prawdopodobnie da się to zautomatyzować, tak jak w Power of Mind. Napisz, a podpowiem, od czego zacząć.</p>
+            <div class="result-invite-actions">
+              <a class="kwcs-cta" href="mailto:wyszynski.k@onet.pl?subject=Automatyzacja%20i%20platforma%20dla%20mojej%20firmy" aria-label="Napisz do mnie w sprawie podobnego projektu">
+                Napisz do mnie
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <polyline points="9 18 15 12 9 6"></polyline>
+                </svg>
+              </a>
+              <a class="kwcs-cta kwcs-cta--ghost" href="https://kwyszynskidesign.github.io/Powerofmind/" target="_blank" rel="noopener noreferrer" aria-label="Otwórz stronę Power of Mind na żywo">
+                Zobacz na żywo
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <polyline points="9 18 15 12 9 6"></polyline>
+                </svg>
+              </a>
+            </div>
+          </div>
+
           <div class="result-next">
             <h3>Następny projekt</h3>
             <a class="kwcs-cta" href="/KWdesignnew/projects/KW-Design.html" aria-label="Przejdź do projektu KW Design — logo i identyfikacja wizualna">
@@ -382,39 +493,6 @@
             </a>
           </div>
         </div>
-      </div>
-    </div>
-
-    <div class="kwcs-sec kwcs-sec--alt" id="pom-wnioski">
-      <div class="wrap">
-        <h2>Czego się nauczyłem</h2>
-        <div class="kwcs-trio" style="margin-top:1.5rem;">
-          <article class="kwcs-card">
-            <h3>Wybór platformy to decyzja PM, nie techniczna</h3>
-            <p>Testowanie trzech platform przed startem kosztowało czas, ale uchroniło przed przepisywaniem gotowej strony. Blokady Wix (branding po wygaśnięciu subskrypcji) odkryto dopiero po testowym wdrożeniu — nie podczas analizy cennika. Analiza narzędzi należy do procesu, nie do etapu wdrożenia.</p>
-          </article>
-          <article class="kwcs-card">
-            <h3>Zero SaaS = pełna kontrola nad danymi</h3>
-            <p>Google Apps Script zamiast Zapier lub Make: brak miesięcznego kosztu i brak trzeciej strony w dostępie do danych uczestników sesji psychologicznych. W branży, gdzie prywatność jest priorytetem, architektura bez zewnętrznych pośredników była właściwym wyborem.</p>
-          </article>
-          <article class="kwcs-card">
-            <h3>UAT: "uczestnik zapisze się sam"</h3>
-            <p>Kryterium akceptacji nie było listą funkcji, tylko pełnym flow z realnym użytkownikiem: od landing page do potwierdzenia płatności. Trzy błędy UX wykryto wyłącznie przez user test — nie przez testy funkcjonalne.</p>
-          </article>
-        </div>
-      </div>
-    </div>
-
-    <div class="kwcs-sec">
-      <div class="wrap" style="text-align:center;padding:3rem 1rem;">
-        <h2 style="margin-bottom:0.75rem;">Masz podobny projekt?</h2>
-        <p style="margin-bottom:2rem;color:#64748b;">Napisz — omówimy zakres i możliwości wdrożenia.</p>
-        <a class="kwcs-cta" href="mailto:karol2609@gmail.com" aria-label="Napisz do Karola Wyszyńskiego">
-          Napisz do mnie
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <polyline points="9 18 15 12 9 6"></polyline>
-          </svg>
-        </a>
       </div>
     </div>
 


### PR DESCRIPTION
## Cel

Przebudowa case study **Power of Mind** (`projects/power-of-mind.html`) na wzorzec wdrożony w Raz Dwa Druk (#71) i Karoma (#73/#74). Case study mówi językiem korzyści biznesowych (SB7 + Before/After/Bridge), a nie funkcji.

## Zmiany

**HTML (`projects/power-of-mind.html`)**
- `id="case-powerofmind"` → **`id="case-power-of-mind-pelne"`** (konwencja `case-<slug>-pelne`).
- Nowa kolejność sekcji wg wzorca: Hero → W skrócie → Problem → Moja rola → Kluczowe decyzje → Branding → Realizacja → Automatyzacje → Wnioski → Rezultat.
- H2 przepisane na hooki z korzyścią (3–6 słów) + podtytuły `.razdwa-h2-sub`:
  - „Zapisy zależały od właścicielki", „Od marki po automatyzacje", „Trzy platformy, jedna decyzja", „Marka, która uspokaja", „Strona, która prowadzi do zapisu", „Zapisy ruszyły bez ręcznego chaosu", „Projektowanie pod realne ograniczenia", „Co zmieniło się w firmie".
- `razdwa-summary` (W skrócie), `razdwa-stats` (uczciwe liczby: ~10 tyg., 3→1 platformy, 3 akcje/zapis, 0 zł SaaS), `ux-decision-grid`, `contribution-grid--razdwa`, `kwcs-sec--alt` (Wnioski).
- CTA końcowe `result-invite`: primary `mailto:wyszynski.k@onet.pl?subject=...` + ghost „Zobacz na żywo" → `https://kwyszynskidesign.github.io/Powerofmind/`.
- **Niewidoczny slot cytatu klientki** (`figure.razdwa-quote` w komentarzu — zero zmyślania).
- **Branding jako bezpieczny slot**: narracja + callout widoczne, galeria grafik zakomentowana (brak plików → brak broken-image); gotowe `<img>` z proponowanymi nazwami do odkomentowania po dostarczeniu assetów.
- Hero image: realne wymiary **1573×1383** (było błędne 1200×630).

**CSS (`assets/css/projects.css`)**
- Nowy blok scoped `#case-power-of-mind-pelne` (paleta marki indygo `#4f46e5` / cyan `#06b6d4`): padding-left pod fixed rail, full-bleed teł kolorowych sekcji, `razdwa-h2-sub` wyśrodkowany, hero image (`contain` + shadow), hero CTA `box-sizing`, `result-invite` + `kwcs-cta--ghost` + `razdwa-quote`.

## Weryfikacja
- `docOverflow = 0` na 390 i 1440 px (naprawiony wcześniejszy overflow 834 px na mobile).
- Widok standalone OK; widok w kontekście `portfolio.html#power-of-mind` OK (sekcja doładowana, **0 broken images**, ścieżki `../` przepisane przez `portfolio.js`).

## Do zrobienia po stronie klienta
- Dostarczenie grafik brandingu (`power-of-mind-logo/paleta/wizytowki/social.webp`) → odkomentowanie galerii.
- Ew. realny cytat klientki → odkomentowanie slotu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HabjQagBt7sSddtctHxYbB)_