### PR TITLE
System przycisków .kw-btn v1.1 + migracja homepage (etap 1–2)

### DIFF
--- a/assets/css/kw-buttons.css
+++ b/assets/css/kw-buttons.css
@@ -60,6 +60,11 @@
   --kw-btn-glow-soft:   rgba(103, 232, 249, 0.28);  /* miękkie rozejście */
   --kw-btn-text-glow:   0 0 12px rgba(224, 252, 255, 0.55);  /* rozbłysk napisu na hover */
 
+  /* Wariant --inverse (CTA na ciemnym/teal tle): biały fill + teal tekst */
+  --kw-btn-inverse-bg:        #ffffff;
+  --kw-btn-inverse-color:     #0a4f63;   /* mocny teal na białym (kontrast) */
+  --kw-btn-inverse-bg-hover:  #ecfeff;   /* cyan-50 na hover */
+
   /* Kolor akcentu (obrys/tekst dla secondary/tertiary) — pinowany do palety B,
      żeby secondary/tertiary też były głębokie i premium, niezależnie od strony */
   --kw-btn-accent:       #0e7490;
@@ -135,7 +140,8 @@
 .kw-btn.btn-hero-cta::before, .kw-btn.submit-btn::before, .kw-btn.lm-btn::before,
 .kw-btn--secondary::before, .kw-btn.btn-secondary::before,
 .kw-btn.kwcs-cta--ghost::before, .kw-btn.btn-large::before,
-.kw-btn--icon::before {
+.kw-btn--icon::before,
+.kw-btn.kw-btn--inverse::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -154,7 +160,8 @@
 .kw-btn.btn-hero-cta:hover::before, .kw-btn.submit-btn:hover::before, .kw-btn.lm-btn:hover::before,
 .kw-btn--secondary:hover:not(:disabled):not(.is-disabled)::before, .kw-btn.btn-secondary:hover::before,
 .kw-btn.kwcs-cta--ghost:hover::before, .kw-btn.btn-large:hover::before,
-.kw-btn--icon:hover:not(:disabled):not(.is-disabled)::before {
+.kw-btn--icon:hover:not(:disabled):not(.is-disabled)::before,
+.kw-btn.kw-btn--inverse:hover:not(:disabled):not(.is-disabled)::before {
   opacity: 1;
 }
 
@@ -282,12 +289,14 @@
 
 /* =============================================================================
    TYP 3 — TERTIARY (link-akcja)
-   Aliasy opt-in: service-btn, card-cta, lm-teaser-cta, kwcs-cta-link
+   Aliasy opt-in: service-btn, card-cta, kwcs-cta-link
+   UWAGA: lm-teaser-cta USUNIĘTY z tertiary (2026-07-11) — na homepage to
+   prominentne, wypełnione CTA na ciemnej sekcji → obsługiwane wariantem
+   --inverse, nie jako link tertiary.
    ============================================================================= */
 .kw-btn--tertiary,
 .kw-btn.service-btn,
 .kw-btn.card-cta,
-.kw-btn.lm-teaser-cta,
 .kw-btn.kwcs-cta-link {
   background: transparent;
   color: var(--kw-btn-accent);
@@ -301,7 +310,6 @@
 .kw-btn--tertiary:hover:not(:disabled):not(.is-disabled),
 .kw-btn.service-btn:hover:not(:disabled),
 .kw-btn.card-cta:hover:not(:disabled),
-.kw-btn.lm-teaser-cta:hover:not(:disabled),
 .kw-btn.kwcs-cta-link:hover:not(:disabled) {
   color: var(--kw-btn-accent-dark);
   background: var(--kw-btn-accent-tint);
@@ -310,7 +318,6 @@
 .kw-btn--tertiary:active,
 .kw-btn.service-btn:active,
 .kw-btn.card-cta:active,
-.kw-btn.lm-teaser-cta:active,
 .kw-btn.kwcs-cta-link:active {
   background: var(--kw-btn-accent-tint-strong);
 }
@@ -359,6 +366,35 @@
 .kw-btn--icon.kw-btn--ghost:hover:not(:disabled) {
   color: var(--kw-btn-accent-dark);
   background: transparent;
+}
+
+/* =============================================================================
+   MODYFIKATOR --inverse — CTA na CIEMNYM / TEAL tle (v1.1, 2026-07-11)
+   -----------------------------------------------------------------------------
+   Tokeny v1.0 (primary/tertiary) są strojone pod JASNE tło. Na sekcjach
+   ciemnych (granat) lub teal potrzebny jest odwrócony wariant: biały fill +
+   teal tekst = mocny kontrast i prominencja (tak jak oryginalne białe/jasne
+   CTA na tych sekcjach). Świadoma decyzja projektowa, nie regresja.
+
+   Specyficzność .kw-btn.kw-btn--inverse (0,2,0) + pozycja PO blokach aliasów
+   => wygrywa z aliasami primary/tertiary (np. .kw-btn.submit-btn,
+   .kw-btn.lm-teaser-cta), więc element z aliasem + --inverse dostaje inverse.
+   ============================================================================= */
+.kw-btn.kw-btn--inverse {
+  background: var(--kw-btn-inverse-bg);
+  color: var(--kw-btn-inverse-color);
+  border-color: transparent;
+  box-shadow: var(--kw-btn-shadow);
+}
+.kw-btn.kw-btn--inverse:hover:not(:disabled):not(.is-disabled) {
+  background: var(--kw-btn-inverse-bg-hover);
+  color: var(--kw-btn-inverse-color);
+  transform: translateY(var(--kw-btn-hover-lift));
+  box-shadow: var(--kw-btn-shadow-hover);
+}
+.kw-btn.kw-btn--inverse:active {
+  transform: translateY(0);
+  box-shadow: var(--kw-btn-shadow);
 }
 
 /* -----------------------------------------------------------------------------

--- a/assets/css/kw-buttons.css
+++ b/assets/css/kw-buttons.css
@@ -23,16 +23,19 @@
    TOKENY
    -------------------------------------------------------------------------- */
 :root {
-  /* Radius systemowy dla wszystkich przycisków CTA */
-  --kw-btn-radius: 0.5rem;
+  /* Radius systemowy — miększe, mniej „techniczne" krawędzie (~11px) */
+  --kw-btn-radius: 0.7rem;
 
-  /* WARIANT B (premium) — JEDYNE ŹRÓDŁO PRAWDY dla wyglądu przycisków.
-     Głęboki, prawie flat teal (nie jasny "SaaS cyan"): pewność + premium.
-     Gradient bardzo subtelny (pionowy, kilka % różnicy), nie glossy. */
-  --kw-btn-primary-from:        #0e7490;  /* cyan-700 */
-  --kw-btn-primary-to:          #0c5f77;  /* subtelnie ciemniejszy = near-flat */
-  --kw-btn-primary-from-hover:  #0c5f77;
-  --kw-btn-primary-to-hover:    #0a4f63;
+  /* WARIANT B (premium, zmiękczony) — JEDYNE ŹRÓDŁO PRAWDY.
+     Głęboki teal, ale z leciutkim niuansem tonalnym (kilka % jasności,
+     góra jaśniejsza od dołu) + wewnętrzny highlight na górnej krawędzi
+     = odczucie głębi, nie płaskiej naklejki. Wciąż NIE glossy/kolorowy. */
+  --kw-btn-primary-from:        #10809d;  /* góra: odrobinę jaśniej/cieplej */
+  --kw-btn-primary-to:          #0c6076;  /* dół: głębszy teal */
+  --kw-btn-primary-from-hover:  #0d6d86;
+  --kw-btn-primary-to-hover:    #0a5265;
+  /* Wewnętrzny highlight górnej krawędzi (miękka głębia) */
+  --kw-btn-primary-highlight:   inset 0 1px 0 rgba(255, 255, 255, 0.16);
 
   /* Kolor akcentu (obrys/tekst dla secondary/tertiary) — pinowany do palety B,
      żeby secondary/tertiary też były głębokie i premium, niezależnie od strony */
@@ -41,16 +44,17 @@
   --kw-btn-accent-tint:  rgba(14, 116, 144, 0.08);  /* delikatne tło hover tertiary */
   --kw-btn-accent-tint-strong: rgba(14, 116, 144, 0.14);
 
-  /* Cienie — eleganckie, NEUTRALNE (slate), niska rozpiętość, bez kolorowej poświaty.
-     Premium: cień „unosi" powierzchnię, nie świeci. */
-  --kw-btn-shadow:        0 1px 2px rgba(15, 23, 42, 0.08), 0 2px 6px rgba(15, 23, 42, 0.06);
-  --kw-btn-shadow-hover:  0 2px 4px rgba(15, 23, 42, 0.10), 0 6px 16px rgba(15, 23, 42, 0.12);
+  /* Cienie — eleganckie, NEUTRALNE (slate), miękkie, bez kolorowej poświaty.
+     Premium: cień „unosi" powierzchnię, nie świeci. Hover = wyraźniejsza,
+     miękka głębia (większy blur), żeby ruch był widoczny. */
+  --kw-btn-shadow:        0 1px 2px rgba(15, 23, 42, 0.08), 0 3px 8px rgba(15, 23, 42, 0.07);
+  --kw-btn-shadow-hover:  0 2px 4px rgba(15, 23, 42, 0.10), 0 10px 24px rgba(15, 23, 42, 0.15);
 
   /* Focus ring — czytelny, harmonijny z paletą (jaśniejszy teal) */
   --kw-btn-focus-ring:    #0891b2;
 
-  /* Subtelny ruch hover (premium = powściągliwy, nie „bouncy") */
-  --kw-btn-hover-lift:    -1px;
+  /* Ruch hover — lekki, ale wyczuwalny lift */
+  --kw-btn-hover-lift:    -2px;
 
   /* Typografia / stan disabled */
   --kw-btn-font:              var(--font-primary, 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
@@ -156,7 +160,7 @@
   background: linear-gradient(180deg, var(--kw-btn-primary-from) 0%, var(--kw-btn-primary-to) 100%);
   color: #ffffff;
   border-color: transparent;
-  box-shadow: var(--kw-btn-shadow);
+  box-shadow: var(--kw-btn-shadow), var(--kw-btn-primary-highlight);
 }
 .kw-btn--primary:hover:not(:disabled):not(.is-disabled),
 .kw-btn.hero-cta:hover:not(:disabled),
@@ -171,7 +175,7 @@
   background: linear-gradient(180deg, var(--kw-btn-primary-from-hover) 0%, var(--kw-btn-primary-to-hover) 100%);
   color: #ffffff;
   transform: translateY(var(--kw-btn-hover-lift));
-  box-shadow: var(--kw-btn-shadow-hover);
+  box-shadow: var(--kw-btn-shadow-hover), var(--kw-btn-primary-highlight);
 }
 .kw-btn--primary:active,
 .kw-btn.hero-cta:active,

--- a/assets/css/kw-buttons.css
+++ b/assets/css/kw-buttons.css
@@ -1,0 +1,306 @@
+/* =============================================================================
+   KW BUTTONS — system przycisków (Etap 1: fundament)
+   -----------------------------------------------------------------------------
+   Jeden komponent bazowy .kw-btn + 4 typy + 3 rozmiary + spójne stany.
+   Plik SAMOWYSTARCZALNY: definiuje własne tokeny --kw-* z fallbackami,
+   więc działa niezależnie od tego, czy strona ładuje index-styles.css,
+   style.css czy projects.css.
+
+   BEZPIECZEŃSTWO / BRAK BIG-BANG:
+   - Wszystkie reguły komponentu wymagają klasy bazowej .kw-btn.
+   - ALIASY starych klas są OPT-IN — działają tylko, gdy element ma
+     JEDNOCZEŚNIE .kw-btn (np. class="kw-btn hero-cta"). Same stare klasy
+     (bez .kw-btn), używane dziś w całym serwisie, pozostają NIETKNIĘTE.
+   - Dopóki żaden produkcyjny element nie dostanie .kw-btn (etap 2+),
+     ten plik nie zmienia wyglądu żadnej strony.
+
+   Migracja (etap 2+): do elementu dodajemy .kw-btn — stara nazwa klasy
+   automatycznie mapuje się na właściwy typ. Potem można podmienić nazwę na
+   .kw-btn--primary/... i usunąć starą. Krok jest odwracalny (usuń .kw-btn).
+   ============================================================================= */
+
+/* -----------------------------------------------------------------------------
+   TOKENY
+   -------------------------------------------------------------------------- */
+:root {
+  /* Radius systemowy dla wszystkich przycisków CTA */
+  --kw-btn-radius: 0.5rem;
+
+  /* Jedna paleta CTA (cyan) — spójna z .ui-demo-btn i większością projektów */
+  --kw-btn-primary-from:        #06b6d4;
+  --kw-btn-primary-to:          #0284c7;
+  --kw-btn-primary-from-hover:  #0284c7;
+  --kw-btn-primary-to-hover:    #0369a1;
+
+  /* Kolor akcentu (obrys/tekst dla secondary/tertiary) z fallbackiem */
+  --kw-btn-accent:       var(--color-primary, #06b6d4);
+  --kw-btn-accent-dark:  var(--color-primary-dark, #0284c7);
+
+  /* Cienie */
+  --kw-btn-shadow:        0 4px 12px rgba(6, 182, 212, 0.30);
+  --kw-btn-shadow-hover:  0 8px 20px rgba(6, 182, 212, 0.40);
+
+  /* Focus ring */
+  --kw-btn-focus-ring:    #2563eb;
+
+  /* Typografia / stan disabled */
+  --kw-btn-font:              var(--font-primary, 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+  --kw-btn-font-weight:       600;
+  --kw-btn-disabled-opacity:  0.5;
+
+  /* Utility / icon */
+  --kw-btn-icon-bg:        #ffffff;
+  --kw-btn-icon-color:     #334155;
+  --kw-btn-icon-border:    #e2e8f0;
+  --kw-btn-icon-bg-hover:  #f1f5f9;
+}
+
+/* -----------------------------------------------------------------------------
+   KOMPONENT BAZOWY
+   -------------------------------------------------------------------------- */
+.kw-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-family: var(--kw-btn-font);
+  font-weight: var(--kw-btn-font-weight);
+  line-height: 1;
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+  border: 2px solid transparent;
+  border-radius: var(--kw-btn-radius);
+  cursor: pointer;
+  user-select: none;
+  position: relative;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, color 0.25s ease, border-color 0.25s ease;
+  /* domyślny rozmiar = md */
+  padding: 0.85rem 2rem;
+  font-size: 1rem;
+  min-height: 48px;
+}
+
+.kw-btn svg {
+  width: 1.15em;
+  height: 1.15em;
+  flex-shrink: 0;
+}
+
+/* Wspólny stan FOCUS-VISIBLE (wszystkie typy) */
+.kw-btn:focus-visible {
+  outline: 3px solid var(--kw-btn-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Wspólny stan DISABLED (wszystkie typy) */
+.kw-btn:disabled,
+.kw-btn.is-disabled,
+.kw-btn[aria-disabled="true"] {
+  opacity: var(--kw-btn-disabled-opacity);
+  cursor: not-allowed;
+  transform: none !important;
+  box-shadow: none !important;
+  pointer-events: none;
+}
+
+/* Modyfikator: pełna szerokość (np. przyciski w kartach cennika) */
+.kw-btn--block {
+  display: flex;
+  width: 100%;
+}
+
+/* -----------------------------------------------------------------------------
+   ROZMIARY (sm / md / lg)
+   -------------------------------------------------------------------------- */
+.kw-btn--sm {
+  padding: 0.55rem 1.25rem;
+  font-size: 0.875rem;
+  min-height: 40px;
+}
+.kw-btn--md {
+  padding: 0.85rem 2rem;
+  font-size: 1rem;
+  min-height: 48px;
+}
+.kw-btn--lg {
+  padding: 1rem 2.5rem;
+  font-size: 1.125rem;
+  min-height: 56px;
+}
+
+/* =============================================================================
+   TYP 1 — PRIMARY
+   Aliasy opt-in: hero-cta, hero-image-cta, kwcs-cta, btn-cta, btn-case,
+                  btn-primary, submit-btn, lm-btn, btn-hero-cta
+   ============================================================================= */
+.kw-btn--primary,
+.kw-btn.hero-cta,
+.kw-btn.hero-image-cta,
+.kw-btn.kwcs-cta,
+.kw-btn.btn-cta,
+.kw-btn.btn-case,
+.kw-btn.btn-primary,
+.kw-btn.btn-hero-cta,
+.kw-btn.submit-btn,
+.kw-btn.lm-btn {
+  background: linear-gradient(135deg, var(--kw-btn-primary-from) 0%, var(--kw-btn-primary-to) 100%);
+  color: #ffffff;
+  border-color: transparent;
+  box-shadow: var(--kw-btn-shadow);
+}
+.kw-btn--primary:hover:not(:disabled):not(.is-disabled),
+.kw-btn.hero-cta:hover:not(:disabled),
+.kw-btn.hero-image-cta:hover:not(:disabled),
+.kw-btn.kwcs-cta:hover:not(:disabled),
+.kw-btn.btn-cta:hover:not(:disabled),
+.kw-btn.btn-case:hover:not(:disabled),
+.kw-btn.btn-primary:hover:not(:disabled),
+.kw-btn.btn-hero-cta:hover:not(:disabled),
+.kw-btn.submit-btn:hover:not(:disabled),
+.kw-btn.lm-btn:hover:not(:disabled) {
+  background: linear-gradient(135deg, var(--kw-btn-primary-from-hover) 0%, var(--kw-btn-primary-to-hover) 100%);
+  color: #ffffff;
+  transform: translateY(-2px);
+  box-shadow: var(--kw-btn-shadow-hover);
+}
+.kw-btn--primary:active,
+.kw-btn.hero-cta:active,
+.kw-btn.hero-image-cta:active,
+.kw-btn.kwcs-cta:active,
+.kw-btn.btn-cta:active,
+.kw-btn.btn-case:active,
+.kw-btn.btn-primary:active,
+.kw-btn.btn-hero-cta:active,
+.kw-btn.submit-btn:active,
+.kw-btn.lm-btn:active {
+  transform: translateY(0);
+  box-shadow: var(--kw-btn-shadow);
+}
+
+/* =============================================================================
+   TYP 2 — SECONDARY (obrys / ghost)
+   Aliasy opt-in: btn-secondary, kwcs-cta--ghost, btn-large
+   ============================================================================= */
+.kw-btn--secondary,
+.kw-btn.btn-secondary,
+.kw-btn.kwcs-cta--ghost,
+.kw-btn.btn-large {
+  background: transparent;
+  color: var(--kw-btn-accent);
+  border-color: var(--kw-btn-accent);
+  box-shadow: none;
+}
+.kw-btn--secondary:hover:not(:disabled):not(.is-disabled),
+.kw-btn.btn-secondary:hover:not(:disabled),
+.kw-btn.kwcs-cta--ghost:hover:not(:disabled),
+.kw-btn.btn-large:hover:not(:disabled) {
+  background: var(--kw-btn-accent);
+  color: #ffffff;
+  transform: translateY(-2px);
+  box-shadow: var(--kw-btn-shadow);
+}
+.kw-btn--secondary:active,
+.kw-btn.btn-secondary:active,
+.kw-btn.kwcs-cta--ghost:active,
+.kw-btn.btn-large:active {
+  transform: translateY(0);
+}
+
+/* =============================================================================
+   TYP 3 — TERTIARY (link-akcja)
+   Aliasy opt-in: service-btn, card-cta, lm-teaser-cta, kwcs-cta-link
+   ============================================================================= */
+.kw-btn--tertiary,
+.kw-btn.service-btn,
+.kw-btn.card-cta,
+.kw-btn.lm-teaser-cta,
+.kw-btn.kwcs-cta-link {
+  background: transparent;
+  color: var(--kw-btn-accent);
+  border-color: transparent;
+  box-shadow: none;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  min-height: 0;
+  font-weight: 600;
+}
+.kw-btn--tertiary:hover:not(:disabled):not(.is-disabled),
+.kw-btn.service-btn:hover:not(:disabled),
+.kw-btn.card-cta:hover:not(:disabled),
+.kw-btn.lm-teaser-cta:hover:not(:disabled),
+.kw-btn.kwcs-cta-link:hover:not(:disabled) {
+  color: var(--kw-btn-accent-dark);
+  background: rgba(6, 182, 212, 0.08);
+  border-radius: 0.375rem;
+}
+.kw-btn--tertiary:active,
+.kw-btn.service-btn:active,
+.kw-btn.card-cta:active,
+.kw-btn.lm-teaser-cta:active,
+.kw-btn.kwcs-cta-link:active {
+  background: rgba(6, 182, 212, 0.14);
+}
+/* Strzałka „→" w tertiary lekko przesuwa się na hover */
+.kw-btn--tertiary:hover .kw-btn__arrow,
+.kw-btn.service-btn:hover .kw-btn__arrow {
+  transform: translateX(3px);
+}
+.kw-btn__arrow { transition: transform 0.25s ease; display: inline-block; }
+
+/* =============================================================================
+   TYP 4 — UTILITY / ICON (nie-marketingowe: hamburger, scroll-top,
+   strzałki karuzeli, lightbox-close, back)
+   Aliasy opt-in: (świadomie wąskie — utility zwykle ma własny layout)
+   ============================================================================= */
+.kw-btn--icon {
+  padding: 0;
+  min-height: 44px;
+  width: 44px;
+  height: 44px;
+  border-radius: 0.5rem;
+  background: var(--kw-btn-icon-bg);
+  color: var(--kw-btn-icon-color);
+  border-color: var(--kw-btn-icon-border);
+  box-shadow: var(--kw-btn-shadow-hover);
+  font-size: 1.25rem;
+}
+.kw-btn--icon:hover:not(:disabled):not(.is-disabled) {
+  background: var(--kw-btn-icon-bg-hover);
+  transform: translateY(-1px);
+}
+.kw-btn--icon:active {
+  transform: translateY(0);
+}
+/* Wariant „ghost icon" — do back/breadcrumb (bez tła i cienia) */
+.kw-btn--icon.kw-btn--ghost {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  color: var(--kw-btn-accent);
+  width: auto;
+  padding: 0 0.25rem;
+}
+.kw-btn--icon.kw-btn--ghost:hover:not(:disabled) {
+  color: var(--kw-btn-accent-dark);
+  background: transparent;
+}
+
+/* -----------------------------------------------------------------------------
+   Loader dla przycisków formularzy (spójny mechanizm)
+   Użycie: <button class="kw-btn kw-btn--primary kw-btn--lg is-loading">
+             <span class="kw-btn__text">Wyślij</span>
+             <span class="kw-btn__loader">Wysyłam…</span>
+           </button>
+   -------------------------------------------------------------------------- */
+.kw-btn__loader { display: none; }
+.kw-btn.is-loading .kw-btn__text { display: none; }
+.kw-btn.is-loading .kw-btn__loader { display: inline; }
+
+/* -----------------------------------------------------------------------------
+   Redukcja ruchu
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .kw-btn { transition: none; }
+  .kw-btn:hover { transform: none !important; }
+}

--- a/assets/css/kw-buttons.css
+++ b/assets/css/kw-buttons.css
@@ -1,5 +1,22 @@
 /* =============================================================================
-   KW BUTTONS — system przycisków (Etap 1: fundament)
+   KW BUTTONS — system przycisków · WERSJA v1.0 (zatwierdzona 2026-07-11)
+   =============================================================================
+   FINALNE USTALENIA WIZUALNE (Wariant B, premium, zmiękczony) — punkt
+   odniesienia dla etapu 2+. Każda zmiana poniższych tokenów to ŚWIADOMA
+   decyzja projektowa, nie przypadkowa regresja.
+
+     • Paleta:   głęboki teal (primary #10809d → #0c6076), akcent #0e7490.
+                 Bez jasnego „SaaS cyan", bez kolorowego glossy gradientu.
+     • Radius:   0.7rem (~11px) — miękkie, nie techniczne krawędzie.
+     • Gradient: subtelny, pionowy (near-flat) + wewnętrzny highlight
+                 górnej krawędzi (głębia, nie płaska naklejka).
+     • Cień:     neutralny (slate), miękki; hover = głębszy, większy blur.
+     • Hover:    lift -2px + pogłębienie cienia.
+     • Poświata: radialny JASNY CYJAN „zapalający się" ze środka na hover
+                 (intensywność 0.70), na primary, secondary i icon/utility.
+     • Tekst:    rozbłysk/podświetlenie napisu na hover.
+     • Typy (4): primary / secondary / tertiary / icon.
+     • Rozmiary: sm / md / lg. Stany: hover / active / focus-visible / disabled.
    -----------------------------------------------------------------------------
    Jeden komponent bazowy .kw-btn + 4 typy + 3 rozmiary + spójne stany.
    Plik SAMOWYSTARCZALNY: definiuje własne tokeny --kw-* z fallbackami,
@@ -41,6 +58,7 @@
      Radialny highlight nad tłem; jaśniejszy rdzeń + miękka otoczka. */
   --kw-btn-glow:        rgba(103, 232, 249, 0.70);  /* cyan-300, jasny rdzeń */
   --kw-btn-glow-soft:   rgba(103, 232, 249, 0.28);  /* miękkie rozejście */
+  --kw-btn-text-glow:   0 0 12px rgba(224, 252, 255, 0.55);  /* rozbłysk napisu na hover */
 
   /* Kolor akcentu (obrys/tekst dla secondary/tertiary) — pinowany do palety B,
      żeby secondary/tertiary też były głębokie i premium, niezależnie od strony */
@@ -216,6 +234,7 @@
   color: #ffffff;
   transform: translateY(var(--kw-btn-hover-lift));
   box-shadow: var(--kw-btn-shadow-hover), var(--kw-btn-primary-highlight);
+  text-shadow: var(--kw-btn-text-glow);
 }
 .kw-btn--primary:active,
 .kw-btn.hero-cta:active,
@@ -252,6 +271,7 @@
   color: #ffffff;
   transform: translateY(var(--kw-btn-hover-lift));
   box-shadow: var(--kw-btn-shadow);
+  text-shadow: var(--kw-btn-text-glow);
 }
 .kw-btn--secondary:active,
 .kw-btn.btn-secondary:active,

--- a/assets/css/kw-buttons.css
+++ b/assets/css/kw-buttons.css
@@ -39,8 +39,8 @@
 
   /* Poświata hover — jasny, błyszczący cyjan „zapalający się" ze środka.
      Radialny highlight nad tłem; jaśniejszy rdzeń + miękka otoczka. */
-  --kw-btn-glow:        rgba(103, 232, 249, 0.65);  /* cyan-300, jasny rdzeń */
-  --kw-btn-glow-soft:   rgba(103, 232, 249, 0.25);  /* miękkie rozejście */
+  --kw-btn-glow:        rgba(103, 232, 249, 0.70);  /* cyan-300, jasny rdzeń */
+  --kw-btn-glow-soft:   rgba(103, 232, 249, 0.28);  /* miękkie rozejście */
 
   /* Kolor akcentu (obrys/tekst dla secondary/tertiary) — pinowany do palety B,
      żeby secondary/tertiary też były głębokie i premium, niezależnie od strony */

--- a/assets/css/kw-buttons.css
+++ b/assets/css/kw-buttons.css
@@ -26,33 +26,42 @@
   /* Radius systemowy dla wszystkich przycisków CTA */
   --kw-btn-radius: 0.5rem;
 
-  /* Jedna paleta CTA (cyan) — spójna z .ui-demo-btn i większością projektów */
-  --kw-btn-primary-from:        #06b6d4;
-  --kw-btn-primary-to:          #0284c7;
-  --kw-btn-primary-from-hover:  #0284c7;
-  --kw-btn-primary-to-hover:    #0369a1;
+  /* WARIANT B (premium) — JEDYNE ŹRÓDŁO PRAWDY dla wyglądu przycisków.
+     Głęboki, prawie flat teal (nie jasny "SaaS cyan"): pewność + premium.
+     Gradient bardzo subtelny (pionowy, kilka % różnicy), nie glossy. */
+  --kw-btn-primary-from:        #0e7490;  /* cyan-700 */
+  --kw-btn-primary-to:          #0c5f77;  /* subtelnie ciemniejszy = near-flat */
+  --kw-btn-primary-from-hover:  #0c5f77;
+  --kw-btn-primary-to-hover:    #0a4f63;
 
-  /* Kolor akcentu (obrys/tekst dla secondary/tertiary) z fallbackiem */
-  --kw-btn-accent:       var(--color-primary, #06b6d4);
-  --kw-btn-accent-dark:  var(--color-primary-dark, #0284c7);
+  /* Kolor akcentu (obrys/tekst dla secondary/tertiary) — pinowany do palety B,
+     żeby secondary/tertiary też były głębokie i premium, niezależnie od strony */
+  --kw-btn-accent:       #0e7490;
+  --kw-btn-accent-dark:  #0a4f63;
+  --kw-btn-accent-tint:  rgba(14, 116, 144, 0.08);  /* delikatne tło hover tertiary */
+  --kw-btn-accent-tint-strong: rgba(14, 116, 144, 0.14);
 
-  /* Cienie */
-  --kw-btn-shadow:        0 4px 12px rgba(6, 182, 212, 0.30);
-  --kw-btn-shadow-hover:  0 8px 20px rgba(6, 182, 212, 0.40);
+  /* Cienie — eleganckie, NEUTRALNE (slate), niska rozpiętość, bez kolorowej poświaty.
+     Premium: cień „unosi" powierzchnię, nie świeci. */
+  --kw-btn-shadow:        0 1px 2px rgba(15, 23, 42, 0.08), 0 2px 6px rgba(15, 23, 42, 0.06);
+  --kw-btn-shadow-hover:  0 2px 4px rgba(15, 23, 42, 0.10), 0 6px 16px rgba(15, 23, 42, 0.12);
 
-  /* Focus ring */
-  --kw-btn-focus-ring:    #2563eb;
+  /* Focus ring — czytelny, harmonijny z paletą (jaśniejszy teal) */
+  --kw-btn-focus-ring:    #0891b2;
+
+  /* Subtelny ruch hover (premium = powściągliwy, nie „bouncy") */
+  --kw-btn-hover-lift:    -1px;
 
   /* Typografia / stan disabled */
   --kw-btn-font:              var(--font-primary, 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
   --kw-btn-font-weight:       600;
-  --kw-btn-disabled-opacity:  0.5;
+  --kw-btn-disabled-opacity:  0.45;
 
-  /* Utility / icon */
+  /* Utility / icon — neutralne, premium (nie kolorowa poświata) */
   --kw-btn-icon-bg:        #ffffff;
-  --kw-btn-icon-color:     #334155;
+  --kw-btn-icon-color:     #1e293b;   /* slate-800: mocniejszy kontrast */
   --kw-btn-icon-border:    #e2e8f0;
-  --kw-btn-icon-bg-hover:  #f1f5f9;
+  --kw-btn-icon-bg-hover:  #f8fafc;
 }
 
 /* -----------------------------------------------------------------------------
@@ -144,7 +153,7 @@
 .kw-btn.btn-hero-cta,
 .kw-btn.submit-btn,
 .kw-btn.lm-btn {
-  background: linear-gradient(135deg, var(--kw-btn-primary-from) 0%, var(--kw-btn-primary-to) 100%);
+  background: linear-gradient(180deg, var(--kw-btn-primary-from) 0%, var(--kw-btn-primary-to) 100%);
   color: #ffffff;
   border-color: transparent;
   box-shadow: var(--kw-btn-shadow);
@@ -159,9 +168,9 @@
 .kw-btn.btn-hero-cta:hover:not(:disabled),
 .kw-btn.submit-btn:hover:not(:disabled),
 .kw-btn.lm-btn:hover:not(:disabled) {
-  background: linear-gradient(135deg, var(--kw-btn-primary-from-hover) 0%, var(--kw-btn-primary-to-hover) 100%);
+  background: linear-gradient(180deg, var(--kw-btn-primary-from-hover) 0%, var(--kw-btn-primary-to-hover) 100%);
   color: #ffffff;
-  transform: translateY(-2px);
+  transform: translateY(var(--kw-btn-hover-lift));
   box-shadow: var(--kw-btn-shadow-hover);
 }
 .kw-btn--primary:active,
@@ -197,7 +206,7 @@
 .kw-btn.btn-large:hover:not(:disabled) {
   background: var(--kw-btn-accent);
   color: #ffffff;
-  transform: translateY(-2px);
+  transform: translateY(var(--kw-btn-hover-lift));
   box-shadow: var(--kw-btn-shadow);
 }
 .kw-btn--secondary:active,
@@ -231,7 +240,7 @@
 .kw-btn.lm-teaser-cta:hover:not(:disabled),
 .kw-btn.kwcs-cta-link:hover:not(:disabled) {
   color: var(--kw-btn-accent-dark);
-  background: rgba(6, 182, 212, 0.08);
+  background: var(--kw-btn-accent-tint);
   border-radius: 0.375rem;
 }
 .kw-btn--tertiary:active,
@@ -239,7 +248,7 @@
 .kw-btn.card-cta:active,
 .kw-btn.lm-teaser-cta:active,
 .kw-btn.kwcs-cta-link:active {
-  background: rgba(6, 182, 212, 0.14);
+  background: var(--kw-btn-accent-tint-strong);
 }
 /* Strzałka „→" w tertiary lekko przesuwa się na hover */
 .kw-btn--tertiary:hover .kw-btn__arrow,
@@ -262,12 +271,14 @@
   background: var(--kw-btn-icon-bg);
   color: var(--kw-btn-icon-color);
   border-color: var(--kw-btn-icon-border);
-  box-shadow: var(--kw-btn-shadow-hover);
+  box-shadow: var(--kw-btn-shadow);
   font-size: 1.25rem;
 }
 .kw-btn--icon:hover:not(:disabled):not(.is-disabled) {
   background: var(--kw-btn-icon-bg-hover);
-  transform: translateY(-1px);
+  border-color: #cbd5e1;
+  transform: translateY(var(--kw-btn-hover-lift));
+  box-shadow: var(--kw-btn-shadow-hover);
 }
 .kw-btn--icon:active {
   transform: translateY(0);

--- a/assets/css/kw-buttons.css
+++ b/assets/css/kw-buttons.css
@@ -37,6 +37,11 @@
   /* Wewnętrzny highlight górnej krawędzi (miękka głębia) */
   --kw-btn-primary-highlight:   inset 0 1px 0 rgba(255, 255, 255, 0.16);
 
+  /* Poświata hover — jasny, błyszczący cyjan „zapalający się" ze środka.
+     Radialny highlight nad tłem; jaśniejszy rdzeń + miękka otoczka. */
+  --kw-btn-glow:        rgba(103, 232, 249, 0.65);  /* cyan-300, jasny rdzeń */
+  --kw-btn-glow-soft:   rgba(103, 232, 249, 0.25);  /* miękkie rozejście */
+
   /* Kolor akcentu (obrys/tekst dla secondary/tertiary) — pinowany do palety B,
      żeby secondary/tertiary też były głębokie i premium, niezależnie od strony */
   --kw-btn-accent:       #0e7490;
@@ -87,6 +92,8 @@
   cursor: pointer;
   user-select: none;
   position: relative;
+  overflow: hidden;          /* przycina poświatę hover do zaokrąglenia */
+  isolation: isolate;        /* poświata (z-index:-1) zostaje w obrębie przycisku */
   transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, color 0.25s ease, border-color 0.25s ease;
   /* domyślny rozmiar = md */
   padding: 0.85rem 2rem;
@@ -98,6 +105,39 @@
   width: 1.15em;
   height: 1.15em;
   flex-shrink: 0;
+}
+
+/* -----------------------------------------------------------------------------
+   POŚWIATA HOVER — jasny cyjan „zapala się" ze środka (typy wypełnione)
+   Radialny highlight nad tłem, pod tekstem; wchodzi płynnie na hover.
+   -------------------------------------------------------------------------- */
+.kw-btn--primary::before,
+.kw-btn.hero-cta::before, .kw-btn.hero-image-cta::before, .kw-btn.kwcs-cta::before,
+.kw-btn.btn-cta::before, .kw-btn.btn-case::before, .kw-btn.btn-primary::before,
+.kw-btn.btn-hero-cta::before, .kw-btn.submit-btn::before, .kw-btn.lm-btn::before,
+.kw-btn--secondary::before, .kw-btn.btn-secondary::before,
+.kw-btn.kwcs-cta--ghost::before, .kw-btn.btn-large::before,
+.kw-btn--icon::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: radial-gradient(circle at 50% 45%,
+              var(--kw-btn-glow) 0%,
+              var(--kw-btn-glow-soft) 35%,
+              transparent 68%);
+  opacity: 0;
+  transition: opacity 0.35s ease;
+  pointer-events: none;
+}
+.kw-btn--primary:hover:not(:disabled):not(.is-disabled)::before,
+.kw-btn.hero-cta:hover::before, .kw-btn.hero-image-cta:hover::before, .kw-btn.kwcs-cta:hover::before,
+.kw-btn.btn-cta:hover::before, .kw-btn.btn-case:hover::before, .kw-btn.btn-primary:hover::before,
+.kw-btn.btn-hero-cta:hover::before, .kw-btn.submit-btn:hover::before, .kw-btn.lm-btn:hover::before,
+.kw-btn--secondary:hover:not(:disabled):not(.is-disabled)::before, .kw-btn.btn-secondary:hover::before,
+.kw-btn.kwcs-cta--ghost:hover::before, .kw-btn.btn-large:hover::before,
+.kw-btn--icon:hover:not(:disabled):not(.is-disabled)::before {
+  opacity: 1;
 }
 
 /* Wspólny stan FOCUS-VISIBLE (wszystkie typy) */

--- a/docs/button-system-demo.html
+++ b/docs/button-system-demo.html
@@ -17,8 +17,8 @@
   </style>
 </head>
 <body>
-  <h1>KW Buttons — demo systemu przycisków</h1>
-  <p class="note">Etap 1 — fundament. 4 typy × 3 rozmiary + stany hover/active/focus-visible/disabled. Paleta cyan, radius 0.5rem.</p>
+  <h1>KW Buttons — system przycisków (żywa dokumentacja)</h1>
+  <p class="note">Finalny, jedyny obowiązujący styl: <strong>Wariant B (premium)</strong> — głęboki teal, prawie flat/subtelny gradient, elegancki neutralny cień, powściągliwy hover. 4 typy × 3 rozmiary + stany hover/active/focus-visible/disabled. Radius 0.5rem. Źródło prawdy: <code>assets/css/kw-buttons.css</code>.</p>
 
   <h2>1. Primary</h2>
   <div class="row"><span class="label">Rozmiary</span>

--- a/docs/button-system-demo.html
+++ b/docs/button-system-demo.html
@@ -7,34 +7,46 @@
   <link rel="stylesheet" href="../assets/css/kw-buttons.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; }
-    body { font-family: 'Inter', system-ui, sans-serif; margin: 0; padding: 2rem; background: #f8fafc; color: #0f172a; }
-    h1 { font-size: 1.6rem; } h2 { margin-top: 2.5rem; font-size: 1.2rem; border-bottom: 1px solid #e2e8f0; padding-bottom: .4rem; }
-    .row { display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; margin: 1rem 0; }
-    .label { width: 100%; font-size: .8rem; color: #64748b; text-transform: uppercase; letter-spacing: .04em; }
-    .note { color:#64748b; font-size:.85rem; }
-    .card-demo { width:100%; max-width: 320px; padding:1.5rem; background:#fff; border:1px solid #e2e8f0; border-radius:1rem; }
-    .dark { background:#0f172a; color:#fff; padding:1.5rem; border-radius:1rem; }
+    body { font-family: 'Inter', system-ui, sans-serif; margin: 0; padding: 3rem 2rem 4rem; background: #fbfcfd; color: #0f172a; max-width: 980px; }
+    h1 { font-size: 1.7rem; letter-spacing: -0.01em; }
+    /* Rytm edytorski: dużo światła, bez twardych linii pod każdą sekcją */
+    h2 { margin-top: 4rem; margin-bottom: 0.25rem; font-size: 1.15rem; letter-spacing: -0.01em; color:#0f172a; }
+    h2 .eyebrow { display:block; font-size:.72rem; font-weight:600; letter-spacing:.12em; text-transform:uppercase; color:#0e7490; margin-bottom:.35rem; }
+    .row { display: flex; flex-wrap: wrap; gap: 1.1rem; align-items: center; margin: 1.25rem 0; }
+    .label { width: 100%; font-size: .72rem; color: #94a3b8; text-transform: uppercase; letter-spacing: .08em; margin-bottom:-.25rem; }
+    .note { color:#64748b; font-size:.9rem; line-height:1.6; }
+    /* Delikatny separator TYLKO tam, gdzie naprawdę zmienia się temat */
+    .soft-sep { border:0; border-top:1px solid #eef2f6; margin:3.5rem 0 0; }
+    .card-demo { width:100%; max-width: 320px; padding:1.5rem; background:#fff; border:1px solid #eef2f6; border-radius:1rem; box-shadow:0 1px 3px rgba(15,23,42,.04); }
+    /* Statyczny podgląd stanu hover (screenshot nie łapie :hover na żywo) */
+    .demo-hover.kw-btn--primary {
+      background: linear-gradient(180deg, var(--kw-btn-primary-from-hover) 0%, var(--kw-btn-primary-to-hover) 100%);
+      transform: translateY(var(--kw-btn-hover-lift));
+      box-shadow: var(--kw-btn-shadow-hover), var(--kw-btn-primary-highlight);
+    }
+    .state-tag { font-size:.72rem; color:#94a3b8; margin-left:.15rem; }
   </style>
 </head>
 <body>
   <h1>KW Buttons — system przycisków (żywa dokumentacja)</h1>
-  <p class="note">Finalny, jedyny obowiązujący styl: <strong>Wariant B (premium)</strong> — głęboki teal, prawie flat/subtelny gradient, elegancki neutralny cień, powściągliwy hover. 4 typy × 3 rozmiary + stany hover/active/focus-visible/disabled. Radius 0.5rem. Źródło prawdy: <code>assets/css/kw-buttons.css</code>.</p>
+  <p class="note">Finalny, jedyny obowiązujący styl: <strong>Wariant B (premium, zmiękczony)</strong> — głęboki teal z leciutkim niuansem tonalnym i miękkim highlightem górnej krawędzi, elegancki neutralny cień, wyczuwalny lift na hover. 4 typy × 3 rozmiary + stany hover/active/focus-visible/disabled. Radius ~11px. Źródło prawdy: <code>assets/css/kw-buttons.css</code>.</p>
 
-  <h2>1. Primary</h2>
-  <div class="row"><span class="label">Rozmiary</span>
+  <h2><span class="eyebrow">Typ 1</span>Primary</h2>
+  <div class="row"><span class="label">Rozmiary — sm / md / lg</span>
     <a href="#" class="kw-btn kw-btn--primary kw-btn--sm">Umów konsultację</a>
     <a href="#" class="kw-btn kw-btn--primary kw-btn--md">Umów konsultację</a>
     <a href="#" class="kw-btn kw-btn--primary kw-btn--lg">Umów konsultację</a>
   </div>
   <div class="row"><span class="label">Stany</span>
     <button class="kw-btn kw-btn--primary kw-btn--md">Default</button>
+    <button class="kw-btn kw-btn--primary kw-btn--md demo-hover">Hover <span class="state-tag">(lift + głębszy cień)</span></button>
     <button class="kw-btn kw-btn--primary kw-btn--md is-disabled">Disabled</button>
     <button class="kw-btn kw-btn--primary kw-btn--md">Z ikoną
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
     </button>
   </div>
 
-  <h2>2. Secondary (ghost / obrys)</h2>
+  <h2><span class="eyebrow">Typ 2</span>Secondary <span style="font-weight:400;color:#94a3b8;font-size:.9rem">— ghost / obrys</span></h2>
   <div class="row">
     <a href="#" class="kw-btn kw-btn--secondary kw-btn--sm">Zobacz więcej</a>
     <a href="#" class="kw-btn kw-btn--secondary kw-btn--md">Zobacz więcej</a>
@@ -42,14 +54,14 @@
     <button class="kw-btn kw-btn--secondary kw-btn--md is-disabled">Disabled</button>
   </div>
 
-  <h2>3. Tertiary (link-akcja)</h2>
+  <h2><span class="eyebrow">Typ 3</span>Tertiary <span style="font-weight:400;color:#94a3b8;font-size:.9rem">— link-akcja</span></h2>
   <div class="row">
     <a href="#" class="kw-btn kw-btn--tertiary kw-btn--sm">Więcej informacji <span class="kw-btn__arrow">→</span></a>
     <a href="#" class="kw-btn kw-btn--tertiary kw-btn--md">Więcej informacji <span class="kw-btn__arrow">→</span></a>
     <a href="#" class="kw-btn kw-btn--tertiary kw-btn--lg">Pobierz za darmo <span class="kw-btn__arrow">→</span></a>
   </div>
 
-  <h2>4. Utility / Icon</h2>
+  <h2><span class="eyebrow">Typ 4</span>Utility / Icon</h2>
   <div class="row">
     <button class="kw-btn kw-btn--icon" aria-label="Wróć na górę">↑</button>
     <button class="kw-btn kw-btn--icon" aria-label="Poprzednie">←</button>
@@ -77,7 +89,8 @@
     </button>
   </div>
 
-  <h2>7. Aliasy opt-in (stara nazwa + .kw-btn = auto-mapowanie)</h2>
+  <hr class="soft-sep">
+  <h2><span class="eyebrow">Migracja</span>Aliasy opt-in <span style="font-weight:400;color:#94a3b8;font-size:.9rem">— stara nazwa + .kw-btn = auto-mapowanie</span></h2>
   <p class="note">Migracja etap 2: do elementu dodajemy tylko <code>.kw-btn</code>, stara klasa mapuje typ.</p>
   <div class="row">
     <a href="#" class="kw-btn hero-cta">.kw-btn.hero-cta → primary</a>

--- a/docs/button-system-demo.html
+++ b/docs/button-system-demo.html
@@ -24,12 +24,13 @@
       transform: translateY(var(--kw-btn-hover-lift));
       box-shadow: var(--kw-btn-shadow-hover), var(--kw-btn-primary-highlight);
     }
+    .demo-hover.kw-btn--primary::before { opacity: 1; }  /* pokaż poświatę na żywo */
     .state-tag { font-size:.72rem; color:#94a3b8; margin-left:.15rem; }
   </style>
 </head>
 <body>
   <h1>KW Buttons — system przycisków (żywa dokumentacja)</h1>
-  <p class="note">Finalny, jedyny obowiązujący styl: <strong>Wariant B (premium, zmiękczony)</strong> — głęboki teal z leciutkim niuansem tonalnym i miękkim highlightem górnej krawędzi, elegancki neutralny cień, wyczuwalny lift na hover. 4 typy × 3 rozmiary + stany hover/active/focus-visible/disabled. Radius ~11px. Źródło prawdy: <code>assets/css/kw-buttons.css</code>.</p>
+  <p class="note">Finalny, jedyny obowiązujący styl: <strong>Wariant B (premium, zmiękczony)</strong> — głęboki teal z leciutkim niuansem tonalnym i miękkim highlightem górnej krawędzi, elegancki neutralny cień, wyczuwalny lift na hover oraz jasna cyjanowa poświata „zapalająca się" ze środka na hover. 4 typy × 3 rozmiary + stany hover/active/focus-visible/disabled. Radius ~11px. Źródło prawdy: <code>assets/css/kw-buttons.css</code>.</p>
 
   <h2><span class="eyebrow">Typ 1</span>Primary</h2>
   <div class="row"><span class="label">Rozmiary — sm / md / lg</span>

--- a/docs/button-system-demo.html
+++ b/docs/button-system-demo.html
@@ -38,6 +38,7 @@
     <li><strong>Hover:</strong> lift −2px + głębszy, miękki cień; subtelny highlight górnej krawędzi.</li>
     <li><strong>Poświata:</strong> jasny cyjan „zapalający się" ze środka (0.70) — primary, secondary, icon.</li>
     <li><strong>Rozbłysk tekstu:</strong> delikatne podświetlenie napisu na hover (typy wypełnione).</li>
+    <li><strong>Wariant kontekstowy <code>--inverse</code></strong> (v1.1): CTA na ciemnym/teal tle — biały fill + teal tekst.</li>
   </ul>
 
   <h2><span class="eyebrow">Typ 1</span>Primary</h2>
@@ -96,6 +97,14 @@
       <span class="kw-btn__text">Wyślij wiadomość</span>
       <span class="kw-btn__loader">Wysyłam…</span>
     </button>
+  </div>
+
+  <h2><span class="eyebrow">Wariant kontekstowy</span>--inverse <span style="font-weight:400;color:#94a3b8;font-size:.9rem">— CTA na ciemnym / teal tle</span></h2>
+  <p class="note">Tokeny v1.0 są strojone pod jasne tło. Na sekcjach ciemnych/teal <code>.kw-btn--inverse</code> daje biały fill + teal tekst (mocny kontrast). Łączy się z aliasami (wygrywa specyficznością).</p>
+  <div class="dark" style="display:flex;gap:1.1rem;flex-wrap:wrap;align-items:center;margin-top:1rem;">
+    <a href="#" class="kw-btn kw-btn--inverse kw-btn--sm">Pobierz za darmo →</a>
+    <a href="#" class="kw-btn kw-btn--inverse kw-btn--md">Pobierz za darmo →</a>
+    <button class="kw-btn kw-btn--inverse kw-btn--lg">Umów pierwszy krok</button>
   </div>
 
   <hr class="soft-sep">

--- a/docs/button-system-demo.html
+++ b/docs/button-system-demo.html
@@ -29,8 +29,16 @@
   </style>
 </head>
 <body>
-  <h1>KW Buttons — system przycisków (żywa dokumentacja)</h1>
-  <p class="note">Finalny, jedyny obowiązujący styl: <strong>Wariant B (premium, zmiękczony)</strong> — głęboki teal z leciutkim niuansem tonalnym i miękkim highlightem górnej krawędzi, elegancki neutralny cień, wyczuwalny lift na hover oraz jasna cyjanowa poświata „zapalająca się" ze środka na hover. 4 typy × 3 rozmiary + stany hover/active/focus-visible/disabled. Radius ~11px. Źródło prawdy: <code>assets/css/kw-buttons.css</code>.</p>
+  <h1>KW Buttons — system przycisków · v1.0 <span style="font-weight:400;color:#94a3b8;font-size:.9rem">(żywa dokumentacja)</span></h1>
+  <p class="note"><strong>Wersja v1.0 — zatwierdzona 2026-07-11.</strong> Jedyny obowiązujący styl systemu <code>.kw-btn</code>. Źródło prawdy: <code>assets/css/kw-buttons.css</code>.</p>
+  <ul class="note" style="margin-top:.5rem;padding-left:1.1rem;line-height:1.9">
+    <li><strong>Paleta:</strong> głęboki teal (primary #10809d → #0c6076, akcent #0e7490) — premium, nie „SaaS cyan".</li>
+    <li><strong>Radius:</strong> ~11px (miękkie krawędzie). <strong>Typy:</strong> primary / secondary / tertiary / icon. <strong>Rozmiary:</strong> sm / md / lg.</li>
+    <li><strong>Stany:</strong> hover / active / focus-visible / disabled.</li>
+    <li><strong>Hover:</strong> lift −2px + głębszy, miękki cień; subtelny highlight górnej krawędzi.</li>
+    <li><strong>Poświata:</strong> jasny cyjan „zapalający się" ze środka (0.70) — primary, secondary, icon.</li>
+    <li><strong>Rozbłysk tekstu:</strong> delikatne podświetlenie napisu na hover (typy wypełnione).</li>
+  </ul>
 
   <h2><span class="eyebrow">Typ 1</span>Primary</h2>
   <div class="row"><span class="label">Rozmiary — sm / md / lg</span>

--- a/docs/button-system-demo.html
+++ b/docs/button-system-demo.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>KW Buttons — demo systemu (Etap 1)</title>
+  <link rel="stylesheet" href="../assets/css/kw-buttons.css">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body { font-family: 'Inter', system-ui, sans-serif; margin: 0; padding: 2rem; background: #f8fafc; color: #0f172a; }
+    h1 { font-size: 1.6rem; } h2 { margin-top: 2.5rem; font-size: 1.2rem; border-bottom: 1px solid #e2e8f0; padding-bottom: .4rem; }
+    .row { display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; margin: 1rem 0; }
+    .label { width: 100%; font-size: .8rem; color: #64748b; text-transform: uppercase; letter-spacing: .04em; }
+    .note { color:#64748b; font-size:.85rem; }
+    .card-demo { width:100%; max-width: 320px; padding:1.5rem; background:#fff; border:1px solid #e2e8f0; border-radius:1rem; }
+    .dark { background:#0f172a; color:#fff; padding:1.5rem; border-radius:1rem; }
+  </style>
+</head>
+<body>
+  <h1>KW Buttons — demo systemu przycisków</h1>
+  <p class="note">Etap 1 — fundament. 4 typy × 3 rozmiary + stany hover/active/focus-visible/disabled. Paleta cyan, radius 0.5rem.</p>
+
+  <h2>1. Primary</h2>
+  <div class="row"><span class="label">Rozmiary</span>
+    <a href="#" class="kw-btn kw-btn--primary kw-btn--sm">Umów konsultację</a>
+    <a href="#" class="kw-btn kw-btn--primary kw-btn--md">Umów konsultację</a>
+    <a href="#" class="kw-btn kw-btn--primary kw-btn--lg">Umów konsultację</a>
+  </div>
+  <div class="row"><span class="label">Stany</span>
+    <button class="kw-btn kw-btn--primary kw-btn--md">Default</button>
+    <button class="kw-btn kw-btn--primary kw-btn--md is-disabled">Disabled</button>
+    <button class="kw-btn kw-btn--primary kw-btn--md">Z ikoną
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+    </button>
+  </div>
+
+  <h2>2. Secondary (ghost / obrys)</h2>
+  <div class="row">
+    <a href="#" class="kw-btn kw-btn--secondary kw-btn--sm">Zobacz więcej</a>
+    <a href="#" class="kw-btn kw-btn--secondary kw-btn--md">Zobacz więcej</a>
+    <a href="#" class="kw-btn kw-btn--secondary kw-btn--lg">Zobacz więcej</a>
+    <button class="kw-btn kw-btn--secondary kw-btn--md is-disabled">Disabled</button>
+  </div>
+
+  <h2>3. Tertiary (link-akcja)</h2>
+  <div class="row">
+    <a href="#" class="kw-btn kw-btn--tertiary kw-btn--sm">Więcej informacji <span class="kw-btn__arrow">→</span></a>
+    <a href="#" class="kw-btn kw-btn--tertiary kw-btn--md">Więcej informacji <span class="kw-btn__arrow">→</span></a>
+    <a href="#" class="kw-btn kw-btn--tertiary kw-btn--lg">Pobierz za darmo <span class="kw-btn__arrow">→</span></a>
+  </div>
+
+  <h2>4. Utility / Icon</h2>
+  <div class="row">
+    <button class="kw-btn kw-btn--icon" aria-label="Wróć na górę">↑</button>
+    <button class="kw-btn kw-btn--icon" aria-label="Poprzednie">←</button>
+    <button class="kw-btn kw-btn--icon" aria-label="Następne">→</button>
+    <button class="kw-btn kw-btn--icon" aria-label="Zamknij">×</button>
+    <a href="#" class="kw-btn kw-btn--icon kw-btn--ghost">← Wróć do portfolio</a>
+  </div>
+
+  <h2>5. Block (pełna szerokość — karta cennika)</h2>
+  <div class="card-demo">
+    <a href="#" class="kw-btn kw-btn--primary kw-btn--md kw-btn--block">Zobacz szczegóły →</a>
+    <div style="height:.75rem"></div>
+    <a href="#" class="kw-btn kw-btn--secondary kw-btn--md kw-btn--block">Zobacz szczegóły →</a>
+  </div>
+
+  <h2>6. Loader (formularz)</h2>
+  <div class="row">
+    <button class="kw-btn kw-btn--primary kw-btn--lg">
+      <span class="kw-btn__text">Wyślij wiadomość</span>
+      <span class="kw-btn__loader">Wysyłam…</span>
+    </button>
+    <button class="kw-btn kw-btn--primary kw-btn--lg is-loading">
+      <span class="kw-btn__text">Wyślij wiadomość</span>
+      <span class="kw-btn__loader">Wysyłam…</span>
+    </button>
+  </div>
+
+  <h2>7. Aliasy opt-in (stara nazwa + .kw-btn = auto-mapowanie)</h2>
+  <p class="note">Migracja etap 2: do elementu dodajemy tylko <code>.kw-btn</code>, stara klasa mapuje typ.</p>
+  <div class="row">
+    <a href="#" class="kw-btn hero-cta">.kw-btn.hero-cta → primary</a>
+    <a href="#" class="kw-btn kwcs-cta">.kw-btn.kwcs-cta → primary</a>
+    <a href="#" class="kw-btn kwcs-cta--ghost">.kwcs-cta--ghost → secondary</a>
+    <a href="#" class="kw-btn service-btn">.service-btn → tertiary</a>
+  </div>
+</body>
+</html>

--- a/docs/mapa-ujednolicenia-przyciskow.md
+++ b/docs/mapa-ujednolicenia-przyciskow.md
@@ -7,6 +7,14 @@
 
 ---
 
+> ✅ **Styl wizualny zatwierdzony jako v1.0 (2026-07-11)** — punkt odniesienia dla etapu 2+.
+> Finalne tokeny i komponent: [`assets/css/kw-buttons.css`](../assets/css/kw-buttons.css)
+> (paleta teal, radius ~11px, poświata hover 0.70, rozbłysk tekstu). Żywa dokumentacja:
+> [`docs/button-system-demo.html`](./button-system-demo.html). Każda zmiana tokenów =
+> świadoma decyzja, nie regresja.
+
+---
+
 ## 1. Decyzja systemowa
 
 Wprowadzamy **jeden komponent bazowy** `.kw-btn` z modyfikatorami. Wszystkie przyciski i linki-CTA w projekcie sprowadzamy do **4 typów**:

--- a/docs/mapa-ujednolicenia-przyciskow.md
+++ b/docs/mapa-ujednolicenia-przyciskow.md
@@ -1,0 +1,120 @@
+# Mapa ujednolicenia przycisków — KW Design
+
+> Dokument decyzyjny (nie kod). Bazuje na `docs/spis-przyciskow.md`.
+> Cel: zredukować ~20 wariantów do **4 typów × 3 rozmiary** ze spójnymi stanami.
+>
+> Data: 2026-07-11 · Status: do akceptacji przed wdrożeniem
+
+---
+
+## 1. Decyzja systemowa
+
+Wprowadzamy **jeden komponent bazowy** `.kw-btn` z modyfikatorami. Wszystkie przyciski i linki-CTA w projekcie sprowadzamy do **4 typów**:
+
+| Typ | Rola | Wygląd bazowy |
+|---|---|---|
+| **Primary** | główna akcja na ekranie (jedna na sekcję) | wypełniony gradient CTA |
+| **Secondary** | akcja drugorzędna / „ghost" | obrys w kolorze primary, tło transparentne |
+| **Tertiary** | akcja tekstowa / link-akcja | tekst + strzałka/ikona, bez tła, opcjonalny underline |
+| **Utility / Icon** | sterowanie UI, nie-marketingowe | neutralne, kwadratowe/okrągłe, ikona bez marketingowego CTA |
+
+**Ustalenia bazowe (systemowe):**
+- **Jedna paleta CTA:** gradient cyan `#06b6d4 → #0284c7` (dominuje w projektach + zgodny z istniejącym `.ui-demo-btn`). Niebieski `#175bf7→#1d4ed8` z `.btn-case` **wycofujemy**.
+- **Jeden radius systemowy:** token `--kw-radius-btn: 0.5rem` (8px). Ujednolica dzisiejsze 10px/12px/0.5rem.
+- **Stany dla wszystkich typów:** `hover` (translateY(-2px) + cień), `active` (translateY(0)), `focus-visible` (outline 3px + offset), `disabled` (opacity + `cursor:not-allowed`).
+- **Rozmiary:** `--sm` (min-h 40px), `--md` (min-h 48px, domyślny), `--lg` (min-h 56px).
+- **Nomenklatura (BEM):** `.kw-btn`, `.kw-btn--primary/--secondary/--tertiary/--icon`, `.kw-btn--sm/--md/--lg`.
+- **Strategia migracji:** wprowadzamy `.kw-btn` obok istniejących klas; stare klasy zostają **tymczasowo jako aliasy** (te same reguły CSS), potem podmieniamy w HTML etapami, na końcu usuwamy stare definicje. Zero „big-bang".
+
+---
+
+## 2. Tabela mapowania
+
+| Stara klasa / element | Gdzie | Docelowy typ | Rozmiar | Alias tymczasowy czy podmiana | Uwagi |
+|---|---|---|---|---|---|
+| `.btn` (bazowa) | index-styles.css, style.css | baza → `.kw-btn` | — | **scal** w bazę | Trzy różne definicje bazy → jedna |
+| `.btn-primary` | index-styles.css:314 | Primary | md | podmiana → `--primary` | Kanoniczna definicja Primary |
+| `.btn-primary` | style.css:130 | Primary | md | **usuń** (duplikat) | Inny wygląd tej samej klasy — źródło niespójności |
+| `.btn-primary` | services-page.css:581 | Primary | md | **usuń** (duplikat, gradient) | Gradient przenosimy do bazy Primary |
+| `.btn-secondary` | index-styles.css:333 | Secondary | md | podmiana → `--secondary` | Kanoniczna definicja Secondary |
+| `.btn-secondary` | style.css:132, services-page.css:592 | Secondary | md | **usuń** (duplikaty) | — |
+| `.btn-sm` | index-styles.css:347 | modyfikator | sm | podmiana → `--sm` | — |
+| `.btn-lg` | index-styles.css:353 | modyfikator | lg | podmiana → `--lg` | — |
+| `.btn.btn-hero-cta` | index.html:141 | Primary | lg | podmiana → `--primary --lg` | Nadpisanie znika, staje się rozmiarem |
+| `.hero-cta` | uslugi.html:122 | Primary | md/lg | alias → podmiana | Gradient już zgodny |
+| `.hero-image-cta` | projects/*.html (hero) | Primary | md | alias → podmiana | Gradient cyan = baza Primary |
+| `.kwcs-cta` | projects/*.html (wyniki) | Primary | lg | alias → podmiana | Font 1.125rem = rozmiar lg |
+| `.kwcs-cta--ghost` | karoma/power-of-mind/razdwa | Secondary | lg | alias → podmiana | Ghost = Secondary |
+| `.kwcs-cta-link` | projects/wizualizacje.html:88 | Tertiary | md | alias → podmiana | Lżejszy link-CTA |
+| `.btn-cta` | portfolio.html:278 | Primary | md | alias → podmiana | — |
+| `.btn-case` | portfolio.css:739 | Primary | md | podmiana + zmiana koloru | **Zmiana palety** na cyan |
+| `.btn-large` | services-page.css:754 | Secondary | lg | alias → podmiana | Białe tło/tekst primary → wariant Secondary lg |
+| `.card-btn` + `.btn-primary` | uslugi.html:155 | Primary | md (full-width) | podmiana → `--primary --block` | Dodać modyfikator `--block` (width:100%) |
+| `.card-btn` + `.btn-secondary` | uslugi.html:143,166 | Secondary | md (full-width) | podmiana → `--secondary --block` | jw. |
+| `.service-btn` | index.html:291,313,332 | Tertiary | md | alias → podmiana | „Więcej informacji →" |
+| `.card-cta` | index.html, portfolio.html | Tertiary | sm/md | alias → podmiana | „Zobacz projekt" + ikona; wewnątrz klikalnej karty |
+| `.lm-teaser-cta` | index.html:655 | Tertiary | md | alias → podmiana | „Pobierz za darmo →" |
+| `.submit-btn` (+`.btn-text`/`.btn-loader`) | index/uslugi/kontakt (formularze) | Primary | lg | podmiana → `--primary --lg` | Zachować mechanikę loadera (spany) |
+| `.lm-btn` (+`.lm-btn-text`/`.lm-btn-loader`) | narzedzie.html:134 | Primary | lg | podmiana → `--primary --lg` | jw. |
+| `.ui-demo-btn` (`.is-primary/-secondary/-tertiary`) | voucher-salon-magdy.html | **wzorzec** | — | zostawić jako demo | To referencja design-systemu; docelowo re-mapować na `.kw-btn` w prezentacji |
+| `.hamburger` | wszystkie strony | **Utility/Icon** | — | **wyjątek** | NIE styl CTA (patrz §3) |
+| `.scroll-to-top` (`#scrollToTop`) | index/portfolio/uslugi | **Utility/Icon** | — | **wyjątek** | jw. |
+| `.testimonials-nav` (`--prev/--next`) | index.html:535,540 | **Utility/Icon** | — | **wyjątek** | Strzałki karuzeli |
+| `#carousel-prev/-next` | projects/wizualizacje.html | **Utility/Icon** | — | **wyjątek** | Strzałki karuzeli |
+| `.lightbox-close` (`role=button`) | wszystkie lightboxy | **Utility/Icon** | — | **wyjątek** | Zamknięcie `&times;` |
+| `.kwcs-back-btn` | wszystkie projects/*.html | **Utility/Icon** (link-back) | sm | **wyjątek** | Breadcrumb-back, nie CTA |
+| `.faq-question` (+`.faq-icon`) | index.html:602–633 | **Utility** (akordeon) | — | **wyjątek** | Kontrolka akordeonu, nie przycisk akcji |
+| `.kwcs-header` | projects/*.html (akordeony) | **Utility** (akordeon) | — | **wyjątek** | jw. |
+| `.portfolio-new-card` (`role=button`) | portfolio.html:122–225 | **nie-przycisk** | — | bez zmian | Klikalna karta — zostaje kartą, nie stylujemy jak `.kw-btn` |
+| `.service-cta` / `.card-cta` (wrappery `div`) | index/uslugi | **nie-przycisk** | — | bez zmian | Kontenery layoutu, nie same przyciski |
+
+---
+
+## 3. Lista wyjątków (NIE używają stylu marketingowego CTA)
+
+Te elementy dostają typ **Utility/Icon** (neutralny, funkcjonalny) — nigdy gradientu CTA:
+
+1. `.hamburger` — otwieranie menu mobilnego
+2. `.scroll-to-top` — powrót na górę
+3. `.testimonials-nav` (`--prev` / `--next`) — nawigacja karuzeli opinii
+4. `#carousel-prev` / `#carousel-next` — strzałki karuzeli wizualizacji
+5. `.lightbox-close` — zamknięcie lightboxa
+6. `.kwcs-back-btn` — powrót breadcrumb
+7. `.faq-question` — kontrolka akordeonu FAQ (zachowuje własny layout pytania)
+8. `.kwcs-header` — kontrolka akordeonu case study
+
+Dodatkowo **nie są przyciskami** i zostają bez zmian: `.portfolio-new-card` (klikalna karta), wrappery `.service-cta` / `div.card-cta`.
+
+---
+
+## 4. Kolejność wdrożenia
+
+**Etap 1 — Tokeny + klasy bazowe** (fundament, bez zmian w HTML)
+- Nowy plik `assets/css/kw-buttons.css`: tokeny (`--kw-radius-btn`, gradient CTA, kolory stanów) + `.kw-btn` i modyfikatory typów/rozmiarów/stanów.
+- Stare klasy → aliasy wskazujące na nowe reguły (żeby nic się nie zepsuło).
+
+**Etap 2 — Homepage** (`index.html`)
+- Podmiana: hero CTA, `.service-btn`, `.card-cta`, `.lm-teaser-cta`, `.submit-btn`, `.faq-question` (jako utility).
+
+**Etap 3 — Portfolio** (`portfolio.html`, `uslugi.html`)
+- `.btn-cta`, `.btn-case` (zmiana koloru!), `.card-cta`, `.card-btn`, `.hero-cta`, `.service-cta`.
+
+**Etap 4 — Case studies** (`projects/*.html`)
+- `.hero-image-cta`, `.kwcs-cta`, `.kwcs-cta--ghost`, `.kwcs-cta-link`, `.kwcs-back-btn` (utility), `.kwcs-header` (utility). Aktualizacja demo `.ui-demo-btn`.
+
+**Etap 5 — Formularze + utility** (`kontakt.html`, `narzedzie.html` + globalnie)
+- `.submit-btn`, `.lm-btn` (z loaderem), `.hamburger`, `.scroll-to-top`, `.testimonials-nav`, `#carousel-*`, `.lightbox-close`.
+- Na końcu: usunięcie martwych, zduplikowanych definicji `.btn-primary`/`.btn-secondary` z `style.css` i `services-page.css`.
+
+---
+
+## 5. Definition of Done
+
+- [ ] **Max 4 typy** przycisków: Primary / Secondary / Tertiary / Utility-Icon
+- [ ] **Max 3 rozmiary**: `--sm` / `--md` / `--lg`
+- [ ] **Jedna paleta CTA**: gradient cyan `#06b6d4 → #0284c7` (niebieski `.btn-case` wycofany)
+- [ ] **Jeden radius systemowy**: `--kw-radius-btn` (0.5rem) na wszystkich przyciskach CTA
+- [ ] **Spójne stany**: `hover` / `active` / `focus-visible` / `disabled` identyczne dla wszystkich typów
+- [ ] Zero zduplikowanych, rozjeżdżających się definicji `.btn-primary` / `.btn-secondary`
+- [ ] Wyjątki (utility/icon, akordeony) nie używają stylu marketingowego CTA
+- [ ] Wszystkie strony wizualnie spójne (homepage, portfolio, uslugi, case studies, formularze)

--- a/docs/spis-przyciskow.md
+++ b/docs/spis-przyciskow.md
@@ -1,0 +1,100 @@
+# Spis przycisków w projekcie KW Design
+
+> Inwentaryzacja wszystkich przycisków i elementów działających jak przyciski (buttons, linki-CTA, elementy z `role="button"`).
+> Cel: najpierw wyciągnąć **wszystkie** istniejące warianty, żeby w kolejnym kroku ujednolicić je do kilku spójnych komponentów.
+>
+> Data: 2026-07-11
+
+---
+
+## 1. Główne przyciski akcji / CTA
+
+| Klasa | Element | Gdzie występuje | Tekst / funkcja | Wygląd |
+|---|---|---|---|---|
+| `.btn` + `.btn-primary` | `<a>` | index.html (hero, proces), portfolio.html | „Umów konsultację", „Zobacz wybrane projekty" | Wypełniony, `--color-primary`, radius `--radius-lg`, min-height 48px |
+| `.btn` + `.btn-secondary` | `<a>` | index-styles.css (zdefiniowany, warianty) | — | Obrys `--color-primary`, tło transparentne |
+| `.btn-sm` / `.btn-lg` | modyfikatory | index-styles.css | rozmiary | padding + min-height 40/56px |
+| `.btn.btn-hero-cta` | `<a>` | index.html:141 | „Umów konsultację" (hero) | Osobne nadpisanie w index-styles.css:4437 |
+| `.hero-cta` | `<a>` | uslugi.html:122 | „Zapytaj o wycenę →" | Gradient `135deg primary→primary-dark`, radius 10px |
+| `.hero-image-cta` | `<a>` | wszystkie projects/*.html (hero) | „Zobacz stronę na żywo" itd. | Gradient cyan `#06b6d4→#0284c7`, radius 0.5rem |
+| `.kwcs-cta` | `<a>` | projects/*.html (sekcja wyników) | „Napisz do mnie", „Otwórz stronę" | Gradient cyan, padding 1rem 2rem, font 1.125rem |
+| `.kwcs-cta--ghost` | modyfikator | projects/karoma, power-of-mind, razdwa | wariant „ghost" | Obrysowy wariant `.kwcs-cta` |
+| `.kwcs-cta-link` | `<a>` | projects/wizualizacje.html:88 | „Skontaktuj się" | Osobny lżejszy wariant link-CTA |
+| `.btn-cta` | `<a>` | portfolio.html:278 | „Napisz wiadomość" | Zdefiniowany w portfolio.css:1257 |
+| `.btn-case` | `<a>` | portfolio.css:739 | link do case study | Gradient niebieski `#175bf7→#1d4ed8` |
+| `.btn-large` | `<a>` | services-page.css:754 | duży CTA | Białe tło, tekst primary |
+| `.card-btn` (+`.btn-primary`/`.btn-secondary`) | `<span>` | uslugi.html:143,155,166 | „Zobacz szczegóły →" | Przycisk w karcie cennika (full-width) |
+| `.service-btn` | `<a>` | index.html:291,313,332 | „Więcej informacji →" | Link-przycisk w kartach usług |
+| `.service-cta` | `<div>` wrapper | uslugi.html:245,325,404 | kontener CTA | — |
+| `.card-cta` | `<span>`/`<div>` | index.html, portfolio.html | „Zobacz projekt" (+ ikona SVG) | Element CTA w kartach portfolio |
+| `.lm-teaser-cta` | `<a>` | index.html:655 | „Pobierz za darmo →" | CTA lead-magnet |
+
+## 2. Przyciski formularzy (submit)
+
+| Klasa | Gdzie | Tekst / stany |
+|---|---|---|
+| `.submit-btn` (+ `.btn-text`, `.btn-loader`) | index.html:705, uslugi.html:558, kontakt.html:122 | „Wyślij wiadomość" / „Umów pierwszy krok" + stan „Wysyłam..." |
+| `.lm-btn` (+ `.lm-btn-text`, `.lm-btn-loader`) | narzedzie.html:134 | „Wyślij mi PDF" + „Wysyłam…" |
+
+## 3. Przyciski nawigacyjne / UI
+
+| Klasa | Element | Gdzie | Funkcja |
+|---|---|---|---|
+| `.hamburger` | `<button>` | uslugi.html:84 + hamburgery w innych plikach | Otwieranie menu mobilnego |
+| `.scroll-to-top` (`#scrollToTop`) | `<button>` | index.html:95, portfolio.html:88, uslugi.html:598 | „Wróć na górę" |
+| `.kwcs-back-btn` | `<a>` | wszystkie projects/*.html | Powrót do portfolio (breadcrumb) |
+| `.testimonials-nav` (`.testimonials-prev`/`.next`) | `<button>` | index.html:535,540 | Nawigacja karuzeli opinii |
+| `#carousel-prev` / `#carousel-next` | `<button>` | projects/wizualizacje.html:77,78 | Strzałki karuzeli ← → |
+| `.faq-question` (+ `.faq-icon`) | `<button>` | index.html:602–633 | Rozwijanie FAQ (akordeon) |
+| `.kwcs-header` | `<button>` | projects/*.html (akordeony case study) | Rozwijane sekcje `aria-expanded` |
+
+## 4. Elementy z `role="button"` (klikalne, nie-`<button>`)
+
+| Element | Gdzie | Funkcja |
+|---|---|---|
+| `.portfolio-new-card[role="button"]` | portfolio.html:122–225 (7 kart) | Wejście w projekt (klik/Enter) |
+| `.lightbox-close[role="button"]` | wszystkie strony z lightboxem | Zamknięcie lightboxa (`&times;`) |
+
+## 5. Sekcja demonstracyjna „design system" (już istniejący wzorzec!)
+
+W `projects/voucher-salon-magdy.html:565–623` jest **gotowa tabela stanów przycisków** — to najbliższe temu, co chcemy ujednolicić:
+
+| Klasa | Warianty (kind) | Stany |
+|---|---|---|
+| `.ui-demo-btn` | `.is-primary`, `.is-secondary`, `.is-tertiary` | `.is-hover`, `.is-active`, `.is-disabled` |
+
+Teksty demo: „Kup voucher" (primary), „Zarezerwuj wizytę" (secondary), „Cennik usług" (tertiary).
+Definicje: `assets/css/projects.css:2147`.
+
+---
+
+## 6. Kluczowe niespójności do ujednolicenia
+
+1. **`.btn-primary` / `.btn-secondary` są zdefiniowane w 3 różnych plikach z różnym wyglądem:**
+   - `index-styles.css:314` — pełny kolor `--color-primary`, radius `--radius-lg`
+   - `style.css:130` — inne wartości
+   - `services-page.css:581` — **gradient** `135deg primary→primary-dark`
+   → ta sama nazwa klasy = różny wygląd na różnych stronach.
+
+2. **Wiele nazw dla tej samej roli „główne CTA":** `.btn-primary`, `.hero-cta`, `.hero-image-cta`, `.kwcs-cta`, `.btn-cta`, `.btn-case`, `.btn-large`, `.card-btn` — wszystkie to warianty wypełnionego przycisku akcji, ale z osobnymi definicjami, kolorami i radiusami (0.5rem / 10px / 12px).
+
+3. **Dwie palety gradientów:**
+   - cyan `#06b6d4 → #0284c7` (projects, services)
+   - niebieski `#175bf7 → #1d4ed8` (portfolio `.btn-case`)
+
+4. **Różne wartości radius:** `--radius-lg`, `10px`, `12px`, `0.5rem` — brak jednego tokena.
+
+5. **Rozbieżne focus/hover:** część ma `:focus-visible` z outline, część nie; `translateY(-1px)` vs `(-2px)`.
+
+---
+
+## 7. Propozycja docelowego zestawu (do decyzji)
+
+Sugerowana redukcja do **4 komponentów** + rozmiary i stany:
+
+- **Primary** — główna akcja (dziś: `btn-primary`, `hero-cta`, `hero-image-cta`, `kwcs-cta`, `btn-cta`, `btn-case`)
+- **Secondary** — akcja drugorzędna / ghost (dziś: `btn-secondary`, `kwcs-cta--ghost`, `btn-large`)
+- **Tertiary / link** — akcja tekstowa (dziś: `service-btn`, `kwcs-cta-link`, `card-cta`, `lm-teaser-cta`)
+- **Icon / utility** — `scroll-to-top`, `hamburger`, `testimonials-nav`, `carousel-prev/next`, `lightbox-close`, `kwcs-back-btn`
+
+Każdy z rozmiarami (`sm`/`md`/`lg`) i stanami (`hover`/`active`/`disabled`/`focus-visible`) — wzorzec już istnieje jako `.ui-demo-btn` w voucher-salon-magdy.html.

--- a/index.html
+++ b/index.html
@@ -654,7 +654,7 @@
                     <h2 class="lm-teaser-title">Nie wiesz, czy Twój proces nadaje się do automatyzacji?</h2>
                     <p class="lm-teaser-desc">Przygotowałem krótką checklistę diagnostyczną — 7 konkretnych sygnałów, po których rozpoznasz, co warto usprawnić i od czego zacząć.</p>
                 </div>
-                <a href="narzedzie.html" class="lm-teaser-cta" data-track="cta_leadmagnet">Pobierz za darmo →</a>
+                <a href="narzedzie.html" class="lm-teaser-cta kw-btn kw-btn--inverse kw-btn--md" data-track="cta_leadmagnet">Pobierz za darmo →</a>
             </div>
         </div>
     </section>
@@ -704,7 +704,7 @@
                         <textarea id="message" name="message" rows="5" placeholder="Napisz, co dziś nie działa, co chcesz uprościć i jaki efekt chcesz osiągnąć." required></textarea>
                     </div>
 
-                    <button type="submit" class="submit-btn">
+                    <button type="submit" class="submit-btn kw-btn kw-btn--inverse kw-btn--lg">
                         <span class="btn-text">Umów pierwszy krok</span>
                         <span class="btn-loader">Wysyłam...</span>
                     </button>

--- a/index.html
+++ b/index.html
@@ -66,6 +66,8 @@
     
     <!-- Main CSS -->
     <link rel="stylesheet" href="assets/css/index-styles.css" />
+    <!-- KW Buttons — system przycisków v1.0 (po index-styles.css, żeby aliasy .kw-btn wygrywały w kaskadzie) -->
+    <link rel="stylesheet" href="assets/css/kw-buttons.css" />
 
 
 </head>
@@ -138,7 +140,7 @@
                 </ul>
 
                 <div class="hero-actions">
-                    <a href="#contact" class="btn btn-primary btn-hero-cta smooth" data-track="cta_hero_contact">Umów konsultację</a>
+                    <a href="#contact" class="btn btn-primary btn-hero-cta smooth kw-btn kw-btn--lg" data-track="cta_hero_contact">Umów konsultację</a>
                     <a href="portfolio.html" class="hero-secondary-link">Zobacz, jak pracuję <span aria-hidden="true">→</span></a>
                 </div>
             </div>
@@ -426,7 +428,7 @@
     </div>
 
     <div class="process-cta">
-        <a href="#contact" class="btn btn-primary smooth">
+        <a href="#contact" class="btn btn-primary smooth kw-btn kw-btn--lg">
             <span class="highlight">Porozmawiajmy o Twoim procesie</span>
         </a>
     </div>


### PR DESCRIPTION
## Cel

Pierwszy krok do ujednolicenia przycisków: **wyciągnięcie wszystkich** istniejących wariantów w projekcie. Docelowo zredukujemy je do kilku spójnych komponentów.

## Co zawiera

Nowy dokument `docs/spis-przyciskow.md` z pełnym spisem, pogrupowanym na:

1. **Główne przyciski akcji / CTA** — `.btn-primary`, `.hero-cta`, `.hero-image-cta`, `.kwcs-cta`, `.btn-cta`, `.btn-case`, `.btn-large`, `.card-btn`, `.service-btn`, `.card-cta`, `.lm-teaser-cta`
2. **Przyciski formularzy** — `.submit-btn`, `.lm-btn` (ze stanami loadera)
3. **Przyciski nawigacyjne / UI** — `.hamburger`, `.scroll-to-top`, `.kwcs-back-btn`, `.testimonials-nav`, `#carousel-prev/next`, `.faq-question`, `.kwcs-header`
4. **Elementy `role="button"`** — karty portfolio, `.lightbox-close`
5. **Istniejący wzorzec design-system** — `.ui-demo-btn` (primary/secondary/tertiary + stany) w `voucher-salon-magdy.html`

## Zidentyfikowane niespójności

- `.btn-primary`/`.btn-secondary` zdefiniowane w **3 plikach** z różnym wyglądem (pełny kolor vs gradient)
- ~8 różnych nazw klas dla tej samej roli „główne CTA"
- dwie palety gradientów (cyan vs niebieski)
- różne wartości radius (0.5rem / 10px / 12px / token)
- rozbieżne stany hover/focus

## Propozycja docelowa

Redukcja do 4 komponentów (Primary / Secondary / Tertiary-link / Icon-utility) z rozmiarami i stanami — do decyzji w kolejnym kroku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxKqjQC7nnCYVGTCZk4rq8

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxKqjQC7nnCYVGTCZk4rq8)_