### PR TITLE
Case studies: nawigacja między projektami → tryb doładowywany (portfolio.html#slug)

### DIFF
--- a/projects/KW-Design.html
+++ b/projects/KW-Design.html
@@ -526,14 +526,14 @@
 
   <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
     <div class="wrap">
-      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="power-of-mind.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="/KWdesignnew/portfolio.html#power-of-mind">
         <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
         <span class="kwcs-project-nav__text">
           <small>Poprzedni projekt</small>
           <strong>Power of Mind</strong>
         </span>
       </a>
-      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="razdwa_aplikacja.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="/KWdesignnew/portfolio.html#RazDwa">
         <span class="kwcs-project-nav__text">
           <small>Następny projekt</small>
           <strong>Raz Dwa Druk</strong>

--- a/projects/cyfradruk.html
+++ b/projects/cyfradruk.html
@@ -623,14 +623,14 @@
 
   <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
     <div class="wrap">
-      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="voucher-salon-magdy.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="/KWdesignnew/portfolio.html#voucher-magdy">
         <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
         <span class="kwcs-project-nav__text">
           <small>Poprzedni projekt</small>
           <strong>Voucher Salon u Magdy</strong>
         </span>
       </a>
-      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="karoma.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="/KWdesignnew/portfolio.html#karoma">
         <span class="kwcs-project-nav__text">
           <small>Następny projekt</small>
           <strong>Karoma</strong>

--- a/projects/karoma.html
+++ b/projects/karoma.html
@@ -450,7 +450,7 @@
 
           <div class="result-next">
             <h3>Następny projekt</h3>
-            <a class="kwcs-cta" href="/KWdesignnew/projects/power-of-mind.html" aria-label="Przejdź do projektu Power of Mind — brand, sklep i automatyzacje">
+            <a class="kwcs-cta" href="/KWdesignnew/portfolio.html#power-of-mind" aria-label="Przejdź do projektu Power of Mind — brand, sklep i automatyzacje">
               Power of Mind — brand, sklep i automatyzacje
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <polyline points="9 18 15 12 9 6"></polyline>
@@ -465,14 +465,14 @@
 
   <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
     <div class="wrap">
-      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="cyfradruk.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="/KWdesignnew/portfolio.html#cyfradruk">
         <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
         <span class="kwcs-project-nav__text">
           <small>Poprzedni projekt</small>
           <strong>CyfraDruk</strong>
         </span>
       </a>
-      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="power-of-mind.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="/KWdesignnew/portfolio.html#power-of-mind">
         <span class="kwcs-project-nav__text">
           <small>Następny projekt</small>
           <strong>Power of Mind</strong>

--- a/projects/power-of-mind.html
+++ b/projects/power-of-mind.html
@@ -485,7 +485,7 @@
 
           <div class="result-next">
             <h3>Następny projekt</h3>
-            <a class="kwcs-cta" href="/KWdesignnew/projects/KW-Design.html" aria-label="Przejdź do projektu KW Design — logo i identyfikacja wizualna">
+            <a class="kwcs-cta" href="/KWdesignnew/portfolio.html#KW-Design" aria-label="Przejdź do projektu KW Design — logo i identyfikacja wizualna">
               KW Design — logo i identyfikacja wizualna
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <polyline points="9 18 15 12 9 6"></polyline>
@@ -500,14 +500,14 @@
 
   <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
     <div class="wrap">
-      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="karoma.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="/KWdesignnew/portfolio.html#karoma">
         <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
         <span class="kwcs-project-nav__text">
           <small>Poprzedni projekt</small>
           <strong>Karoma</strong>
         </span>
       </a>
-      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="KW-Design.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="/KWdesignnew/portfolio.html#KW-Design">
         <span class="kwcs-project-nav__text">
           <small>Następny projekt</small>
           <strong>KW Design</strong>

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -562,7 +562,7 @@
 
       <div class="result-next">
         <h3>Następny projekt</h3>
-        <a class="kwcs-cta" href="/KWdesignnew/projects/karoma.html" aria-label="Przejdź do projektu Karoma — identyfikacja wizualna i sklep B2B">
+        <a class="kwcs-cta" href="/KWdesignnew/portfolio.html#karoma" aria-label="Przejdź do projektu Karoma — identyfikacja wizualna i sklep B2B">
           Karoma — identyfikacja wizualna i sklep B2B
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <polyline points="9 18 15 12 9 6"></polyline>
@@ -577,14 +577,14 @@
 
   <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
     <div class="wrap">
-      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="KW-Design.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="/KWdesignnew/portfolio.html#KW-Design">
         <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
         <span class="kwcs-project-nav__text">
           <small>Poprzedni projekt</small>
           <strong>KW Design</strong>
         </span>
       </a>
-      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="sir-roger.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="/KWdesignnew/portfolio.html#sir-roger">
         <span class="kwcs-project-nav__text">
           <small>Następny projekt</small>
           <strong>Sir Roger</strong>

--- a/projects/sir-roger.html
+++ b/projects/sir-roger.html
@@ -422,14 +422,14 @@
 
   <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
     <div class="wrap">
-      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="savage.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="/KWdesignnew/portfolio.html#RazDwa">
         <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
         <span class="kwcs-project-nav__text">
           <small>Poprzedni projekt</small>
-          <strong>Savage</strong>
+          <strong>Raz Dwa Druk</strong>
         </span>
       </a>
-      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="voucher-salon-magdy.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="/KWdesignnew/portfolio.html#voucher-magdy">
         <span class="kwcs-project-nav__text">
           <small>Następny projekt</small>
           <strong>Voucher Salon u Magdy</strong>

--- a/projects/voucher-salon-magdy.html
+++ b/projects/voucher-salon-magdy.html
@@ -634,14 +634,14 @@
 
   <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
     <div class="wrap">
-      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="sir-roger.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="/KWdesignnew/portfolio.html#sir-roger">
         <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
         <span class="kwcs-project-nav__text">
           <small>Poprzedni projekt</small>
           <strong>Sir Roger</strong>
         </span>
       </a>
-      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="cyfradruk.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="/KWdesignnew/portfolio.html#cyfradruk">
         <span class="kwcs-project-nav__text">
           <small>Następny projekt</small>
           <strong>CyfraDruk</strong>


### PR DESCRIPTION
## Problem

Linki „Następny projekt" (`result-next`) oraz dolna nawigacja `kwcs-project-nav` (prev/next) we wszystkich case studies wskazywały na **strony standalone** (`projects/<plik>.html`). Klik z widoku doładowanego w portfolio wyrzucał użytkownika z kontekstu portfolio (bez menu witryny) do gołej strony standalone — niespójny „przód".

## Rozwiązanie

Wszystkie linki między-projektowe → `/KWdesignnew/portfolio.html#<slug>`. Ścieżka absolutna działa i z portfolio (hashchange → `portfolio.js` wstrzykuje projekt do `#case-viewer`), i ze standalone (nawigacja na portfolio + wstrzyknięcie po loadzie).

- Slug brany z mapy `portfolio.js` (np. `razdwa_aplikacja.html` → `#RazDwa`, `voucher-salon-magdy.html` → `#voucher-magdy`).
- `sir-roger` prev wskazywał na wykluczony projekt **savage** → przekierowany na **Raz Dwa Druk** (spójny prev, bo `razdwa.next = sir-roger`) + zmiana etykiety. `savage.html` (poza publicznym flow, brak w mapie/karcie) — nietknięty.
- Zmiana obejmuje 7 plików, 18 linków. `razdwa_aplikacja.html` zachowuje oryginalne BOM+CRLF (tylko 3 zmienione linie).

## Weryfikacja

- Klik „Następny projekt" z portfolio: zostaje w kontekście doładowanym (menu witryny obecne), `url → portfolio.html#power-of-mind`, sekcja wstrzyknięta.
- Wejście na `portfolio.html#<slug>`: wstrzykuje właściwy case study (`case-<slug>-pelne`), `docOverflow=0`.
- Kontrola: brak pozostałych linków standalone poza wewnętrznymi `savage.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuTGpYHuZtyGfkYJ71DfPe)_