### PR TITLE
KW-Design: przebudowa case study (SB7, restrukturyzacja, technical fixes)

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3825,3 +3825,146 @@ body { overflow-x: hidden; }
   font-weight: 600;
   color: #334155;
 }
+
+/* ============================================================
+   KW-Design — scoped styles
+   Scope: #case-KW-Design-pelne (nie wpływa na inne case studies)
+   ============================================================ */
+
+/* Rail padding — odsunięcie contentu za fixed sidebar */
+@media (min-width: 1280px) {
+  #case-KW-Design-pelne { padding-left: 216px; --wrap-max: 1240px; }
+}
+@media (min-width: 1101px) and (max-width: 1279px) {
+  #case-KW-Design-pelne { padding-left: 184px; --wrap-max: 1120px; }
+}
+@media (max-width: 1100px) {
+  #case-KW-Design-pelne { padding-left: 0; }
+}
+
+/* Full-bleed tła na sekcjach kolorowych */
+@media (min-width: 1280px) {
+  #case-KW-Design-pelne > .razdwa-summary,
+  #case-KW-Design-pelne > .kwcs-sec--alt {
+    margin-left: -216px;
+    padding-left: calc(216px + 1rem);
+  }
+}
+@media (min-width: 1101px) and (max-width: 1279px) {
+  #case-KW-Design-pelne > .razdwa-summary,
+  #case-KW-Design-pelne > .kwcs-sec--alt {
+    margin-left: -184px;
+    padding-left: calc(184px + 1rem);
+  }
+}
+
+/* Podtytuł pod H2 */
+#case-KW-Design-pelne .razdwa-h2-sub {
+  max-width: 760px;
+  margin: -0.25rem auto 1.25rem;
+  text-align: center;
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 1.15rem;
+  line-height: 1.5;
+}
+
+/* Hero image — proporcje zbliżone do kwadratu (1257×1269) */
+#case-KW-Design-pelne .kwcs-hero-body .hero-image {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+#case-KW-Design-pelne .kwcs-hero-body .hero-image .cover {
+  display: block;
+  width: 100%;
+  max-width: 560px;
+  height: auto;
+  object-fit: contain;
+  border-radius: 14px;
+  box-shadow: 0 24px 60px -28px rgba(15, 23, 42, 0.32);
+}
+
+/* Hero CTA — overflow fix na mobile */
+#case-KW-Design-pelne .hero-image-cta {
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+/* Stat liczby — kolor akcentu */
+#case-KW-Design-pelne .razdwa-stat-num { color: #06b6d4; }
+
+/* Contribution cell solo — pełna szerokość */
+#case-KW-Design-pelne .contribution-cell--solo {
+  grid-column: 1 / -1;
+  max-width: 720px;
+  margin: 0 auto;
+}
+@media (max-width: 768px) {
+  #case-KW-Design-pelne .contribution-cell--solo { max-width: 100%; }
+}
+
+/* Result section */
+#case-KW-Design-pelne .kwcs-result {
+  text-align: center;
+}
+#case-KW-Design-pelne .result-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+  margin: 2rem 0;
+}
+@media (max-width: 768px) {
+  #case-KW-Design-pelne .result-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Result invite (CTA końcowe) */
+#case-KW-Design-pelne .result-invite {
+  margin-top: 2.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.3);
+  text-align: center;
+}
+#case-KW-Design-pelne .result-invite h3 {
+  font-size: 1.5rem;
+  line-height: 1.3;
+  margin: 0 0 0.75rem;
+  color: #0f172a;
+}
+#case-KW-Design-pelne .result-invite p {
+  max-width: 640px;
+  margin: 0 auto 0.5rem;
+  color: #475569;
+}
+#case-KW-Design-pelne .result-invite-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+#case-KW-Design-pelne .result-invite-actions .kw-btn {
+  margin: 0.5rem 0;
+}
+
+/* Slot cytatu klienta */
+#case-KW-Design-pelne .razdwa-quote {
+  margin: 2.5rem auto 0;
+  max-width: 720px;
+  padding: 1.75rem 2rem;
+  border-left: 4px solid #06b6d4;
+  background: rgba(6, 182, 212, 0.07);
+  border-radius: 0 0.75rem 0.75rem 0;
+}
+#case-KW-Design-pelne .razdwa-quote blockquote {
+  margin: 0 0 1rem;
+  font-size: 1.2rem;
+  line-height: 1.6;
+  font-style: italic;
+  color: #0f172a;
+}
+#case-KW-Design-pelne .razdwa-quote figcaption {
+  font-weight: 600;
+  color: #334155;
+}

--- a/projects/KW-Design.html
+++ b/projects/KW-Design.html
@@ -125,12 +125,12 @@
       <div class="razdwa-chapter-rail-label">Rozdziały</div>
       <ul class="razdwa-chapter-rail-list">
         <li><a class="razdwa-chapter-link" href="#kwdesign-summary" data-rail-target="kwdesign-summary" title="W skrócie" aria-label="W skrócie">W skrócie</a></li>
-        <li><a class="razdwa-chapter-link" href="#kwdesign-kontekst" data-rail-target="kwdesign-kontekst" title="Kontekst" aria-label="Kontekst">Kontekst</a></li>
-        <li><a class="razdwa-chapter-link" href="#kwdesign-decyzje" data-rail-target="kwdesign-decyzje" title="Decyzje brandingowe" aria-label="Decyzje brandingowe">Decyzje brandingowe</a></li>
+        <li><a class="razdwa-chapter-link" href="#kwdesign-kontekst" data-rail-target="kwdesign-kontekst" title="Problem" aria-label="Problem">Problem</a></li>
+        <li><a class="razdwa-chapter-link" href="#kwdesign-contribution" data-rail-target="kwdesign-contribution" title="Moja rola" aria-label="Moja rola">Moja rola</a></li>
+        <li><a class="razdwa-chapter-link" href="#kwdesign-decyzje" data-rail-target="kwdesign-decyzje" title="Decyzje" aria-label="Decyzje">Decyzje</a></li>
         <li><a class="razdwa-chapter-link" href="#kwdesign-proces" data-rail-target="kwdesign-proces" title="Proces" aria-label="Proces">Proces</a></li>
         <li><a class="razdwa-chapter-link" href="#kwdesign-ewolucja" data-rail-target="kwdesign-ewolucja" title="Ewolucja" aria-label="Ewolucja">Ewolucja</a></li>
-        <li><a class="razdwa-chapter-link" href="#kwdesign-contribution" data-rail-target="kwdesign-contribution" title="Moja rola" aria-label="Moja rola">Moja rola</a></li>
-        <li><a class="razdwa-chapter-link" href="#kwdesign-potencjal" data-rail-target="kwdesign-potencjal" title="Potencjał reuse" aria-label="Potencjał reuse">Potencjał reuse</a></li>
+        <li><a class="razdwa-chapter-link" href="#kwdesign-potencjal" data-rail-target="kwdesign-potencjal" title="Wnioski" aria-label="Wnioski">Wnioski</a></li>
         <li><a class="razdwa-chapter-link" href="#kwdesign-rezultat" data-rail-target="kwdesign-rezultat" title="Rezultat" aria-label="Rezultat">Rezultat</a></li>
       </ul>
     </nav>
@@ -159,49 +159,87 @@
           </div>
           <div class="razdwa-summary-cell">
             <div class="label">Wynik</div>
-            <div class="value">Spójna identyfikacja gotowa do natychmiastowego wdrożenia w kanałach digital i print.</div>
+            <div class="value">Logo, księga znaku i paczka formatów dostarczone z wdrożeniem na stronę i w materiały marki.</div>
           </div>
         </div>
       </div>
     </div>
 
     <!-- ============================================================
-         KONTEKST PROJEKTU
+         KONTEKST / PROBLEM
     ============================================================ -->
     <div class="kwcs-sec kwcs-context-section" id="kwdesign-kontekst">
       <div class="wrap">
-        <h2>Kontekst projektu</h2>
+        <h2>Projektant bez marki traci wiarygodność</h2>
+        <p class="razdwa-h2-sub">Brak spójnego znaku sprawia, że pierwsze wrażenie przegrywa z mniej doświadczonymi konkurentami</p>
 
         <div class="context-intro">
           <p>
-            KW Design to <strong>moja autorska marka projektanta produktów cyfrowych</strong>. Case study pokazuje, jak prowadziłem proces brandingu od strony klienta i projektanta jednocześnie: bez pośredników, na żywym własnym brandzie.
+            Każdy projektant cyfrowy dostarcza projekt — nie każdy potrafi zaprojektować własną markę. Brak spójnego znaku, nieczytelnego w faviconie i na materiałach drukowanych jednocześnie, to jeden z najczęstszych powodów, dla których doświadczony specjalista jest oceniany niżej niż wynika z jakości jego pracy.
           </p>
           <p>
-            Wyzwaniem było połączenie <strong>minimalizmu</strong> ze znakiem, który <strong>działa w faviconie 16×16</strong> i jednocześnie czyta się czysto na materiałach prezentacyjnych. Sygnet musiał być rozpoznawalny solo, logotyp — pełnić rolę pełnej sygnatury w stopkach, ofertach i podpisach maili.
+            KW Design to projekt identyfikacji wizualnej mojej własnej marki projektanta cyfrowego. Case study dokumentuje pełny proces — od analizy i koncepcji po kompletną paczkę plików i wdrożenie. Prowadząc projekt jednocześnie jako klient i projektant, mogłem przetestować każdy etap procesu na sobie, zanim zaproponuję ten standard klientom.
           </p>
         </div>
 
         <h3 class="scope-heading">Zakres projektu</h3>
-        <div class="scope-grid">
-          <div class="scope-item">
-            <div class="scope-icon">🔤</div>
-            <p>Zaprojektowanie <strong>logo i logotypu</strong></p>
+        <ul class="kwcs-prose">
+          <li>Zaprojektowanie <strong>logo i sygnetu</strong> — dwa warianty jednego systemu</li>
+          <li>Przygotowanie <strong>księgi znaku</strong> z zasadami użycia</li>
+          <li>Dostarczenie <strong>plików wektorowych i rastrowych</strong> (AI · EPS · SVG · PNG)</li>
+          <li>Wdrożenie logo <strong>na stronę internetową</strong></li>
+          <li>Mockupy <strong>zastosowań</strong> w kanałach digital i print</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- ============================================================
+         MOJA ROLA W PROJEKCIE
+    ============================================================ -->
+    <h2 class="section-divider" id="kwdesign-contribution">Cały proces w jednych rękach</h2>
+
+    <div class="kwcs-sec">
+      <div class="wrap">
+        <p class="razdwa-h2-sub">Od strategii przez wektory po wdrożenie — bez rozjazdu informacji między etapami</p>
+
+        <div class="context-intro">
+          <p>
+            KW Design to projekt w całości solo — rola klienta i projektanta połączone w jednej osobie, bez pośredników. Taki układ eliminuje problem utraty kontekstu między etapami: decyzja podjęta przy analizie marki jest obecna przy każdej późniejszej iteracji wektorowej.
+          </p>
+        </div>
+
+        <div class="contribution-grid--razdwa">
+          <div class="contribution-cell contribution-cell--solo">
+            <h3><span class="dot"></span>Za co odpowiadałem</h3>
+            <ul>
+              <li>Strategia marki i analiza branży kreatywnej</li>
+              <li>Koncepcje znaku — od szkiców po iteracje wektorowe</li>
+              <li>Dobór typografii i palety kolorów</li>
+              <li>Testowanie znaku w docelowych kontekstach (favicon, social, druk)</li>
+              <li>Mockupy zastosowań</li>
+              <li>Księga znaku (PDF)</li>
+              <li>Paczka plików dostawcza (AI · EPS · SVG · PNG)</li>
+              <li>Wdrożenie na stronę portfolio</li>
+            </ul>
           </div>
-          <div class="scope-item">
-            <div class="scope-icon">📘</div>
-            <p>Przygotowanie <strong>księgi znaku</strong></p>
+        </div>
+
+        <div class="razdwa-stats">
+          <div class="razdwa-stat">
+            <div class="razdwa-stat-num">5–7</div>
+            <div class="razdwa-stat-label">kierunków koncepcyjnych wstępnie opracowanych — wybrany 1</div>
           </div>
-          <div class="scope-item">
-            <div class="scope-icon">📦</div>
-            <p>Dostarczenie <strong>plików wektorowych i rastrowych</strong></p>
+          <div class="razdwa-stat">
+            <div class="razdwa-stat-num">3</div>
+            <div class="razdwa-stat-label">etapy procesu: analiza, iteracje wektorowe, przekazanie</div>
           </div>
-          <div class="scope-item">
-            <div class="scope-icon">🌐</div>
-            <p>Wdrożenie logo <strong>na stronę internetową</strong></p>
+          <div class="razdwa-stat">
+            <div class="razdwa-stat-num">4</div>
+            <div class="razdwa-stat-label">kluczowe reguły znaku — żadna nie ma wyjątków</div>
           </div>
-          <div class="scope-item">
-            <div class="scope-icon">📱</div>
-            <p>Mockupy <strong>social media</strong> i materiałów drukowanych</p>
+          <div class="razdwa-stat">
+            <div class="razdwa-stat-num">4+</div>
+            <div class="razdwa-stat-label">formaty dostawy gotowe do użycia bez dodatkowych pytań</div>
           </div>
         </div>
       </div>
@@ -210,13 +248,14 @@
     <!-- ============================================================
          DECYZJE BRANDINGOWE
     ============================================================ -->
-    <h2 class="section-divider" id="kwdesign-decyzje">Decyzje brandingowe</h2>
+    <h2 class="section-divider" id="kwdesign-decyzje">Cztery reguły chroniące znak przed rozjazdem</h2>
 
     <div class="kwcs-sec">
       <div class="wrap">
+        <p class="razdwa-h2-sub">Każda redukuje liczbę decyzji przy kolejnych materiałach marki</p>
         <div class="context-intro">
           <p>
-            Zanim powstała pierwsza wersja znaku, ustaliłem cztery zasady, które kierowały całym procesem. Każda decyzja miała wymierną konsekwencję — w formie znaku, w paczce plików i w sposobie wdrożenia.
+            Zanim powstała pierwsza wersja znaku, ustaliłem cztery zasady, które kierowały całym procesem. Nie są to wytyczne estetyczne — każda ma wymierną konsekwencję: mniejsza powierzchnia decyzyjna przy każdym nowym artefakcie marki.
           </p>
         </div>
 
@@ -224,26 +263,26 @@
           <div class="ux-decision-box">
             <div class="ux-label">Decyzja 1 · Forma znaku</div>
             <h4>Logotyp + sygnet jako dwie spójne wersje</h4>
-            <p><strong>Dlaczego:</strong> sam logotyp jest za szeroki na favicon i avatar w social media; sam sygnet — za mało rozpoznawalny w kontekście długich materiałów (oferta, prezentacja). Zaprojektowałem oba jako warianty jednego systemu — ze wspólną typografią i siatką.</p>
-            <p class="ux-context"><strong>Kontekst decyzji:</strong> w praktyce projektanta cyfrowego najczęstszy kontakt z marką ma postać avatara — favicon, profil LinkedIn, podpis maila. Sygnet musi działać samodzielnie, bez logotypu obok.</p>
+            <p><strong>Dlaczego:</strong> sam logotyp jest za szeroki na favicon i avatar w social media; sam sygnet — za mało rozpoznawalny w kontekście długich materiałów (oferta, prezentacja). Oba warianty wywodzą się z tej samej siatki i typografii.</p>
+            <p class="ux-context"><strong>Dzięki temu:</strong> do każdego nowego kanału komunikacji jest gotowy właściwy wariant — bez zamawiania osobnej adaptacji znaku.</p>
           </div>
           <div class="ux-decision-box">
             <div class="ux-label">Decyzja 2 · Paleta</div>
             <h4>Monochromatyczna baza + niebieskie akcenty jako drugi poziom</h4>
-            <p><strong>Dlaczego:</strong> projektant cyfrowy pracuje na bardzo różnych tłach (ciemny tryb IDE, jasna prezentacja klienta, druk). Baza w czerni i bieli gwarantuje czytelność wszędzie. Niebieskie akcenty pełnią rolę sygnałową — używane oszczędnie, tam, gdzie mają wzmacniać CTA lub kluczowy element.</p>
-            <p class="ux-context"><strong>Kontekst decyzji:</strong> drugi poziom palety (niebieskie akcenty) jest opisany w księdze znaku jako element do wdrożenia w kolejnym etapie. Case study dokumentuje docelowy system, a nie tylko stan na dzień zakończenia projektu logo.</p>
+            <p><strong>Dlaczego:</strong> projektant cyfrowy pracuje na bardzo różnych tłach — ciemny tryb IDE, jasna prezentacja klienta, druk. Baza w czerni i bieli gwarantuje czytelność wszędzie; niebieskie akcenty pełnią rolę sygnałową, używane oszczędnie.</p>
+            <p class="ux-context"><strong>Dzięki temu:</strong> każdy nowy materiał marki można przygotować bez konsultacji z projektantem — paleta jest opisana jako zasada, nie propozycja.</p>
           </div>
           <div class="ux-decision-box">
             <div class="ux-label">Decyzja 3 · Typografia</div>
             <h4>Jeden krój nośny, hierarchia przez wagi i interlinię</h4>
-            <p><strong>Dlaczego:</strong> system z 2–3 krojami komplikuje wdrożenie (licencje, fallbacki webowe, sprawdzanie kerningu w każdym nowym materiale). Wybrałem jeden krój i zbudowałem hierarchię na wagach i interlinii — mniejsza powierzchnia decyzyjna dla każdego nowego artefaktu marki.</p>
-            <p class="ux-context"><strong>Kontekst decyzji:</strong> docelowy krój i hierarchia są opisane w księdze znaku jako sztywne zasady, nie sugestie — ma to ograniczyć rozjazd stylu między materiałami tworzonymi w różnym czasie.</p>
+            <p><strong>Dlaczego:</strong> system z 2–3 krojami komplikuje wdrożenie — licencje, fallbacki webowe, sprawdzanie kerningu w każdym nowym materiale. Jeden krój z hierarchią wagową daje przewidywalny efekt niezależnie od osoby tworzącej materiał.</p>
+            <p class="ux-context"><strong>Dzięki temu:</strong> styl pisma jest spójny we wszystkich materiałach — od stopki maila po ofertę PDF — bez dodatkowych decyzji przy każdym dokumencie.</p>
           </div>
           <div class="ux-decision-box">
             <div class="ux-label">Decyzja 4 · Format dostawy</div>
             <h4>Paczka plików gotowa do wdrożenia bez pytania o szczegóły</h4>
-            <p><strong>Dlaczego:</strong> w wielu projektach klient dostaje samo logo w PNG i utyka przy pierwszym materiale wymagającym wektora. Zaprojektowałem komplet: AI/EPS/SVG na wektor, PNG w kilku rozmiarach z przezroczystością na raster, plus księga znaku jako PDF — żeby każdy nowy materiał można było wykonać bez kontaktu z projektantem.</p>
-            <p class="ux-context"><strong>Kontekst decyzji:</strong> ten sam format dostawy zamierzam stosować dla każdego kolejnego brandingu klienckiego. KW Design był testem polowym tego standardu na własnej marce.</p>
+            <p><strong>Dlaczego:</strong> w wielu projektach klient dostaje samo logo w PNG i utyka przy pierwszym materiale wymagającym wektora. Komplet: AI/EPS/SVG na wektor, PNG w kilku rozmiarach z przezroczystością, plus księga znaku jako PDF.</p>
+            <p class="ux-context"><strong>Dzięki temu:</strong> każdy nowy materiał marki można wykonać bez kontaktu z projektantem. Ten sam format stosuję dla każdego brandingu klienckiego.</p>
           </div>
         </div>
       </div>
@@ -254,11 +293,12 @@
     ============================================================ -->
     <div class="kwcs-sec kwcs-logo-section" id="kwdesign-proces">
       <div class="wrap">
-        <h2>Proces powstawania logo</h2>
+        <h2>Od briefu do gotowej paczki plików</h2>
+        <p class="razdwa-h2-sub">Trzy etapy: analiza, iteracje wektorowe, przekazanie — w tej kolejności</p>
 
         <div class="logo-intro">
           <p>
-            Proces został podzielony na <strong>3 etapy</strong> — od analizy i koncepcji, przez iteracje projektowe, aż po przekazanie kompletnej paczki plików i księgi znaku. Każdy etap był konsultowany (w przypadku własnej marki — z samym sobą, ale w roli klienta), co pozwoliło precyzyjnie dopasować znak do wizji marki.
+            Proces podzieliłem na <strong>3 etapy</strong> — od analizy i koncepcji, przez iteracje projektowe, aż po przekazanie kompletnej paczki plików i księgi znaku. Każdy etap był zamykany przed rozpoczęciem następnego, co ogranicza konieczność wracania do wcześniejszych decyzji.
           </p>
         </div>
 
@@ -279,11 +319,11 @@
               id="content-marka-d-1"
               role="region"
               aria-labelledby="header-marka-d-1">
-              <p><strong>Research i strategia:</strong> Zrozumienie branży kreatywnej, wartości marki KW Design i grupy docelowej (klienci szukający projektanta cyfrowego). Analiza konkurencji, identyfikacja luk i konwencji w logo design dla freelancerów i małych studiów.</p>
+              <p><strong>Research i strategia:</strong> Analiza branży kreatywnej, wartości marki KW Design i grupy docelowej. Identyfikacja luk i konwencji w logo design dla freelancerów i małych studiów.</p>
               <ul>
-                <li>Definicja wartości marki — czego nie pokazuje sam portfolio.</li>
+                <li>Definicja wartości marki — czego nie pokazuje samo portfolio.</li>
                 <li>Moodboardy i inspiracje — referencje typograficzne, kolorystyczne i stylistyczne.</li>
-                <li>Wstępne szkice — 5–7 kierunków projektowych (od minimalistycznego po odważniejszy).</li>
+                <li>Wstępne szkice — 5–7 kierunków projektowych, od minimalistycznego po odważniejszy.</li>
               </ul>
             </div>
           </div>
@@ -308,7 +348,7 @@
               <ul>
                 <li>Praca nad detalami typografii — kerning, spacing, balans optyczny.</li>
                 <li>Paleta kolorów — wersja kolorowa, monochromatyczna i odwrócona.</li>
-                <li>Testowanie skalowania — od faviconu po duże formaty outdoor.</li>
+                <li>Testowanie skalowania — od faviconu po duże formaty.</li>
                 <li>Mockupy — wizytówki, papier firmowy, social media, strona WWW.</li>
               </ul>
             </div>
@@ -330,7 +370,7 @@
               id="content-marka-d-3"
               role="region"
               aria-labelledby="header-marka-d-3">
-              <p><strong>Kompletna paczka plików:</strong> Przygotowanie wszystkich formatów do druku i digitalu wraz z księgą znaku w formacie PDF.</p>
+              <p><strong>Kompletna paczka plików:</strong> Wszystkie formaty do druku i digitalu wraz z księgą znaku w formacie PDF.</p>
               <ul>
                 <li>Wektory: AI, EPS, SVG.</li>
                 <li>Rastery: PNG z przezroczystością w kilku rozmiarach.</li>
@@ -347,84 +387,45 @@
     <!-- ============================================================
          EWOLUCJA PROJEKTU
     ============================================================ -->
-    <h2 class="section-divider" id="kwdesign-ewolucja">Ewolucja projektu</h2>
+    <h2 class="section-divider" id="kwdesign-ewolucja">Favicon, avatar, druk — ten sam znak</h2>
 
     <div class="kwcs-sec">
       <div class="wrap">
+        <p class="razdwa-h2-sub">Czytelność weryfikowana w każdym kontekście przed finalizacją</p>
         <div class="context-intro">
           <p>
-            Logo przeszło przez <strong>kilka iteracji</strong>, aby osiągnąć balans między charakterem a uniwersalnością. Każdy etap był testowany w docelowych kontekstach — favicon, social media avatar, stopka maila, duży format prezentacyjny.
+            Logo przeszło przez kilka iteracji, każda testowana w docelowych kontekstach — nie tylko na białym tle w Illustratorze. Wyzwanie polegało na tym, że sygnet musiał być czytelny w 16×16 px jako favicon i jednocześnie wyrazisty na dużych formatach prezentacyjnych.
+          </p>
+          <p>
+            Finalny znak spełnia oba warunki: proporcje sygnetu zostały zoptymalizowane pod kątem małych rozmiarów (mocny kontur, prosty kształt, brak cienkich dekoracyjnych elementów), a logotyp — pod kątem materiałów wymagających pełnej sygnatury.
           </p>
         </div>
 
-        <p>
-          Finalny znak ma <strong>wysoką czytelność</strong> w małych rozmiarach oraz <strong>wyrazisty charakter wizualny</strong>, który wyróżnia markę w branży kreatywnej.
-        </p>
-
-        <!-- KSIĘGA ZNAKU / ZASTOSOWANIA -->
         <div class="kwcs-mockups-section">
-          <h3>Księga znaku i zastosowania</h3>
-          <p>
-            Logo zostało przetestowane na <strong>wielu nośnikach</strong>: wizytówkach, papeterii firmowej, materiałach social media i w środowisku webowym. Dzięki temu zachowuje spójność i rozpoznawalność w każdym kontekście.
-          </p>
-
+          <h3>Konteksty testowania znaku</h3>
+          <ul class="kwcs-prose">
+            <li><strong>Favicon 16×16 i 32×32 px</strong> — czytelność sygnetu w przeglądarce i zakładce</li>
+            <li><strong>Avatar social media</strong> — kwadratowy kadr, różne tła platform</li>
+            <li><strong>Stopka maila</strong> — poziomy logotyp na białym i szarym tle</li>
+            <li><strong>Strona portfolio</strong> — sygnet w nawigacji, logotyp w stopce</li>
+            <li><strong>Materiały drukowane</strong> — wizytówki, papier firmowy (skala A4–A5)</li>
+            <li><strong>Prezentacja ofertowa</strong> — duży format, wersja jasna i ciemna</li>
+          </ul>
         </div>
       </div>
     </div>
 
     <!-- ============================================================
-         MOJA ROLA W PROJEKCIE
+         WNIOSKI / POTENCJAŁ POZA PROJEKTEM
     ============================================================ -->
-    <h2 class="section-divider" id="kwdesign-contribution">Moja rola w projekcie</h2>
+    <h2 class="section-divider" id="kwdesign-potencjal">Własna marka jako poligon procesu</h2>
 
     <div class="kwcs-sec">
       <div class="wrap">
+        <p class="razdwa-h2-sub">Zanim zaproponuję ten standard klientom, sprawdziłem każdy krok na własnym projekcie</p>
         <div class="context-intro">
           <p>
-            KW Design to projekt mojej własnej marki — rola klienta i projektanta są połączone w jednej osobie. Projekt zrealizowałem w całości <strong>solo</strong>, bez zewnętrznych współpracowników i bez zewnętrznych zasobów.
-          </p>
-        </div>
-
-        <div class="contribution-grid--razdwa">
-          <div class="contribution-cell contribution-cell--solo">
-            <h4><span class="dot"></span>Solo — ja</h4>
-            <ul>
-              <li>Strategia marki i analiza branży kreatywnej</li>
-              <li>Koncepcje znaku i iteracje wektorowe</li>
-              <li>Dobór typografii i palety</li>
-              <li>Testowanie znaku w docelowych kontekstach</li>
-              <li>Mockupy zastosowań (wizytówki, social, papeteria, WWW)</li>
-              <li>Księga znaku (PDF)</li>
-              <li>Paczka plików dostawcza (AI / EPS / SVG / PNG)</li>
-              <li>Wdrożenie na stronę portfolio</li>
-            </ul>
-          </div>
-          <div class="contribution-cell contribution-cell--shared">
-            <h4><span class="dot"></span>Wspólnie z klientem</h4>
-            <ul>
-              <li>Nie dotyczy — klient i projektant to ta sama osoba.</li>
-            </ul>
-          </div>
-          <div class="contribution-cell contribution-cell--external">
-            <h4><span class="dot"></span>Zasoby klienta</h4>
-            <ul>
-              <li>Brak zasobów zewnętrznych — projekt w pełni in-house.</li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- ============================================================
-         POTENCJAŁ POZA PROJEKTEM / WNIOSKI (reuse)
-    ============================================================ -->
-    <h2 class="section-divider" id="kwdesign-potencjal">Potencjał poza projektem</h2>
-
-    <div class="kwcs-sec">
-      <div class="wrap">
-        <div class="context-intro">
-          <p>
-            KW Design to identyfikacja jednej, konkretnej marki — ale <strong>proces</strong> i <strong>format dostawy</strong> są uniwersalne. Większość warstw projektu da się zastosować do każdego brandingu klienckiego po podmianie pola wartości marki i wstępnych założeń estetycznych.
+            KW Design to identyfikacja jednej, konkretnej marki — ale <strong>proces</strong> i <strong>format dostawy</strong> są uniwersalne. Większość warstw projektu da się zastosować do każdego brandingu klienckiego po podmianie wartości marki i założeń estetycznych.
           </p>
         </div>
 
@@ -432,7 +433,7 @@
         <ul class="kwcs-prose">
           <li>Sygnet zbudowany wokół inicjałów <strong>K</strong> i <strong>W</strong></li>
           <li>Niebieski akcent powiązany z dyscypliną digital design</li>
-          <li>Monochromatyczna baza wynikająca z wielokontekstowego użycia w portfolio i materiałach prezentacyjnych projektanta</li>
+          <li>Monochromatyczna baza wynikająca z wielokontekstowego użycia w portfolio i materiałach projektanta</li>
         </ul>
 
         <h3 class="kwcs-text-center">Co jest uniwersalne i gotowe do reuse</h3>
@@ -440,7 +441,7 @@
           <article class="kwcs-card">
             <h3>Proces</h3>
             <ul>
-              <li>Analiza marki i wywiad z klientem (lub własną wizją)</li>
+              <li>Analiza marki i wywiad z klientem</li>
               <li>Moodboard + 5–7 kierunków wstępnych</li>
               <li>3–4 cykle iteracji wektorowych</li>
               <li>Testowanie w docelowych kontekstach (favicon, social, druk)</li>
@@ -453,22 +454,22 @@
               <li>AI / EPS / SVG — wektory do druku i webu</li>
               <li>PNG w 3 rozmiarach z przezroczystością</li>
               <li>Księga znaku PDF: safe zone, minimalne rozmiary, paleta, przykłady złego użycia</li>
-              <li>Wsparcie 30 dni przy wdrożeniu</li>
+              <li>Wsparcie przy wdrożeniu</li>
             </ul>
           </article>
           <article class="kwcs-card">
-            <h3>Branże, w których ma sens</h3>
+            <h3>Dla kogo ma sens</h3>
             <ul>
-              <li>Marki osobiste freelancerów (designerzy, konsultanci, copywriterzy)</li>
+              <li>Marki osobiste freelancerów — designerzy, konsultanci, copywriterzy</li>
               <li>Małe studia kreatywne potrzebujące jasnej księgi znaku</li>
-              <li>B2B SaaS we wczesnej fazie — gdy księga znaku wzmacnia wiarygodność u inwestorów</li>
-              <li>Marki lokalne (kawiarnie, gabinety, butiki) szukające jednego źródła identyfikacji</li>
+              <li>Startupy B2B we wczesnej fazie — gdy spójna tożsamość wzmacnia wiarygodność</li>
+              <li>Marki lokalne szukające jednego źródła identyfikacji</li>
             </ul>
           </article>
         </div>
 
         <p class="kwcs-note-italic">
-          Wzorzec procesu i paczki dostawczej nie jest hipotezą — wynika z tego, że na własnej marce sprawdziłem każdy krok, zanim zacznę proponować ten standard klientom.
+          Wzorzec procesu i paczki dostawczej nie jest hipotezą — każdy krok przeszedł próbę na własnej marce, zanim stał się elementem oferty dla klientów.
         </p>
       </div>
     </div>
@@ -476,47 +477,62 @@
     <!-- ============================================================
          REZULTAT
     ============================================================ -->
-    <h2 class="section-divider" id="kwdesign-rezultat">Rezultat</h2>
+    <h2 class="section-divider" id="kwdesign-rezultat">Marka gotowa na każdy nośnik</h2>
 
     <div class="kwcs-sec">
       <div class="wrap">
         <div class="kwcs-result">
 
+          <p class="razdwa-h2-sub">Logo, księga znaku i pełna paczka plików w jednej dostawie — bez dodatkowych pytań</p>
+
           <div class="result-lead">
             <p>
-              Marka KW Design ma <strong>unikalne, profesjonalne logo</strong> z kompletną księgą znaku, gotowe do zastosowania na wszystkich nośnikach – od druku po digital. Identyfikacja jest spójna dzięki <strong>nowoczesnej typografii</strong> i konsekwentnemu zastosowaniu palety i siatki.
+              KW Design ma unikalne, profesjonalne logo z kompletną księgą znaku, gotowe do zastosowania na wszystkich nośnikach — od druku po digital. Identyfikacja jest spójna dzięki konsekwentnemu zastosowaniu jednej palety, jednego kroju i czterech reguł projektowych opisanych w księdze znaku.
             </p>
           </div>
 
           <div class="result-cards">
             <div class="result-card">
-              <div class="result-icon">✓</div>
               <h3>Spójna identyfikacja</h3>
-              <p>Jasne zasady użycia logo i kolorów w różnych kanałach komunikacji.</p>
+              <p>Jasne reguły użycia logo i kolorów we wszystkich kanałach komunikacji — bez wyjątków.</p>
             </div>
             <div class="result-card">
-              <div class="result-icon">🎯</div>
               <h3>Gotowość do wdrożenia</h3>
-              <p>Komplet plików wektorowych i rastrowych przygotowanych pod druk i web.</p>
+              <p>Komplet formatów wektorowych i rastrowych przygotowanych pod druk i web — od razu do użycia.</p>
             </div>
             <div class="result-card">
-              <div class="result-icon">🤝</div>
               <h3>Standard do reuse</h3>
-              <p>Proces i paczka plików przetestowane na własnej marce — gotowe do zastosowania u klientów.</p>
+              <p>Proces i paczka plików przetestowane na własnej marce — sprawdzone, zanim trafią do klientów.</p>
             </div>
           </div>
 
-          <a class="kwcs-cta" href="mailto:wyszynski.k@onet.pl" target="_blank" rel="noopener noreferrer" aria-label="Skontaktuj się w sprawie projektu logo">
-            Zapytaj o podobny projekt
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <polyline points="9 18 15 12 9 6"></polyline>
-            </svg>
-          </a>
+          <!-- Slot cytatu klienta — projekt własnej marki, brak zewnętrznego cytatu -->
+          <!--
+          <figure class="razdwa-quote">
+            <blockquote>
+              <p>„[cytat klienta]"</p>
+            </blockquote>
+            <figcaption>[Imię Nazwisko, stanowisko]</figcaption>
+          </figure>
+          -->
+
+          <div class="result-invite">
+            <h3>Twoja marka potrzebuje spójnego znaku?</h3>
+            <p>Przeprowadzę Cię przez ten sam proces — od analizy, przez iteracje, po gotową paczkę plików i księgę znaku.</p>
+            <div class="result-invite-actions">
+              <a href="mailto:wyszynski.k@onet.pl?subject=Branding%20KW%20Design" class="kw-btn kw-btn--lg" rel="noopener noreferrer" aria-label="Napisz do Karola w sprawie projektu brandingu">
+                Napisz do mnie
+              </a>
+              <a href="https://kwyszynskidesign.github.io/KWdesignnew/" class="kw-btn kw-btn--lg kwcs-cta--ghost" target="_blank" rel="noopener noreferrer" aria-label="Zobacz stronę KW Design na żywo">
+                Zobacz stronę
+              </a>
+            </div>
+          </div>
 
           <div class="result-next">
             <h3>Co dalej?</h3>
             <p>
-              Kolejny krok to <strong>mini brand system</strong>: szablony prezentacji, ofert i materiałów social media, oraz wdrożenie drugiego poziomu palety (niebieskie akcenty) w komunikacji marki — żeby jeszcze mocniej wykorzystać potencjał nowego logo.
+              Kolejny krok to <strong>mini brand system</strong>: szablony prezentacji, ofert i materiałów social media, oraz wdrożenie drugiego poziomu palety (niebieskie akcenty) — żeby jeszcze mocniej wykorzystać potencjał nowego logo.
             </p>
           </div>
         </div>

--- a/projects/KW-Design.html
+++ b/projects/KW-Design.html
@@ -29,6 +29,7 @@
   <link rel="shortcut icon" href="/KWdesignnew/favicon.ico">
   <link rel="canonical" href="https://kwyszynskidesign.github.io/KWdesignnew/projects/KW-Design.html">
   <link rel="stylesheet" href="/KWdesignnew/assets/css/projects.css">
+  <link rel="stylesheet" href="/KWdesignnew/assets/css/kw-buttons.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
@@ -47,7 +48,7 @@
   </nav>
 
   <!-- Case Study Content -->
-  <section class="kwcs" id="case-kw-design" aria-label="Case Study: KW Design — logo i identyfikacja wizualna">
+  <section class="kwcs" id="case-KW-Design-pelne" aria-label="Case Study: KW Design — logo i identyfikacja wizualna">
 
     <!-- Hero Head -->
     <div class="kwcs-hero-head">
@@ -100,8 +101,8 @@
               loading="eager"
               fetchpriority="high"
               decoding="async"
-              width="1200"
-              height="630"
+              width="1257"
+              height="1269"
               data-caption="KW Design — logo i identyfikacja wizualna">
           </div>
         </div>
@@ -384,7 +385,7 @@
           </p>
         </div>
 
-        <div class="contribution-grid">
+        <div class="contribution-grid--razdwa">
           <div class="contribution-cell contribution-cell--solo">
             <h4><span class="dot"></span>Solo — ja</h4>
             <ul>
@@ -415,7 +416,7 @@
     </div>
 
     <!-- ============================================================
-         POTENCJAŁ POZA PROJEKTEM (reuse)
+         POTENCJAŁ POZA PROJEKTEM / WNIOSKI (reuse)
     ============================================================ -->
     <h2 class="section-divider" id="kwdesign-potencjal">Potencjał poza projektem</h2>
 
@@ -526,14 +527,14 @@
 
   <nav class="kwcs-project-nav" aria-label="Nawigacja między projektami">
     <div class="wrap">
-      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="power-of-mind.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__prev" href="/KWdesignnew/portfolio.html#power-of-mind">
         <svg class="kwcs-project-nav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
         <span class="kwcs-project-nav__text">
           <small>Poprzedni projekt</small>
           <strong>Power of Mind</strong>
         </span>
       </a>
-      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="razdwa_aplikacja.html">
+      <a class="kwcs-project-nav__link kwcs-project-nav__next" href="/KWdesignnew/portfolio.html#RazDwa">
         <span class="kwcs-project-nav__text">
           <small>Następny projekt</small>
           <strong>Raz Dwa Druk</strong>


### PR DESCRIPTION
## Co zmienia ten PR

Pełna przebudowa case study KW-Design.html wg wzorca SB7 i systemu v1.1.
Dwie fazy w jednym PR, identyczny proces jak Karoma (#73/#74).

## Faza A — Technical fixes

- `id="case-kw-design"` → `id="case-KW-Design-pelne"` (konwencja -pelne)
- `kw-buttons.css` podpięty w `<head>`
- Hero image: `width/height` 1200×630 → 1257×1269 (realne wymiary PNG)
- Nav prev/next: standalone HTML → `portfolio.html#power-of-mind` / `#RazDwa`
- `contribution-grid` → `contribution-grid--razdwa`
- `projects.css`: nowy scope `#case-KW-Design-pelne` — rail padding, full-bleed tła, `.razdwa-h2-sub`, hero `object-fit:contain`, contribution solo, result-invite, slot cytatu

## Faza B — Treść i restrukturyzacja SB7

**Nowa kolejność sekcji** (Moja rola przeniesiona przed Decyzje — Guide authority przed Planem):
W skrócie → Problem → Moja rola → Decyzje → Proces → Ewolucja → Wnioski → Rezultat

**H2** (wszystkie zatwierdzone przez autora):
- Projektant bez marki traci wiarygodność
- Cały proces w jednych rękach
- Cztery reguły chroniące znak przed rozjazdem
- Od briefu do gotowej paczki plików
- Favicon, avatar, druk — ten sam znak
- Własna marka jako poligon procesu
- Marka gotowa na każdy nośnik

**Pozostałe zmiany:**
- Każdy H2 z `.razdwa-h2-sub` (zatwierdzonym przed wdrożeniem)
- `razdwa-stats` w sekcji Moja rola (5–7 / 3 / 4 / 4+) — uczciwe liczby z procesu
- `contribution-grid--razdwa` z jedną komórką solo (puste "Wspólnie"/"Zasoby" usunięte)
- Emoji dekoracyjne usunięte (scope-icon, result-icon)
- Ewolucja + Księga znaku: wersja tekstowa (brak materiałów wizualnych — bez placeholderów)
- `result-invite` z `.kw-btn` primary + `.kwcs-cta--ghost` "Zobacz stronę"
- Slot cytatu klienta jako HTML comment (własna marka — brak zewnętrznego cytatu)
- Rail: nowa kolejność, etykiety skrócone

## Checklist

- [x] Wszystkie referowane obrazy fizycznie istnieją w repo
- [x] `id="case-KW-Design-pelne"` na `section.kwcs`
- [x] Slug poprawnie w `projectPages` (portfolio.js) + karta `portfolio-new-card`
- [x] Chapter rail: wpis na każdą sekcję, kolejność zgodna z DOM
- [x] CSS scoped: padding-left, full-bleed tła, h2-sub, hero image, hero CTA, result-invite, slot cytatu
- [x] Hero: realne wymiary 1257×1269
- [x] H2 3–6 słów z korzyścią + h2-sub; liczby uczciwe i matematycznie spójne; slot cytatu; CTA `.kw-btn` v1.1
- [x] Brak emoji jako dekoracji
- [x] `docOverflow=0` — 390px i 1440px
- [x] Linki prev/next → `portfolio.html#power-of-mind` / `#RazDwa`
- [x] result-invite CTA: mailto z `?subject=Branding%20KW%20Design` + `kwyszynskidesign.github.io/KWdesignnew/`
- [x] Render standalone + portfolio.html#KW-Design