### PR TITLE
Karoma: full-bleed Branding + Rezultat bez pływającej karty

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3581,7 +3581,8 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
      żeby tło sięgało lewej krawędzi treści strony (rail pływa nad tłem).
      Kompensujący padding-left utrzymuje treść w tym samym miejscu. */
   #case-karoma-pelne > .razdwa-summary,
-  #case-karoma-pelne > .kwcs-sec--alt {
+  #case-karoma-pelne > .kwcs-sec--alt,
+  #case-karoma-pelne > .kwcs-logo-section {
     margin-left: -216px;
     padding-left: calc(216px + 1rem);
   }
@@ -3590,7 +3591,8 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
 @media (min-width: 1101px) and (max-width: 1279px) {
   #case-karoma-pelne { padding-left: 184px; --wrap-max: 1120px; }
   #case-karoma-pelne > .razdwa-summary,
-  #case-karoma-pelne > .kwcs-sec--alt {
+  #case-karoma-pelne > .kwcs-sec--alt,
+  #case-karoma-pelne > .kwcs-logo-section {
     margin-left: -184px;
     padding-left: calc(184px + 1rem);
   }
@@ -3599,6 +3601,18 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
    Sekcje są już pełnej szerokości, więc full-bleed nie jest potrzebny. */
 @media (max-width: 1100px) {
   #case-karoma-pelne { padding-left: 0; }
+}
+
+/* Rezultat bez pływającej karty — zdejmujemy tło/radius/shadow/max-width,
+   żeby sekcja była pełnowymiarowa i centrowała treść w tej samej kolumnie
+   .wrap co reszta sekcji (spójne wyśrodkowanie). text-align:center zostaje. */
+#case-karoma-pelne .kwcs-result {
+  background: none;
+  border-radius: 0;
+  box-shadow: none;
+  max-width: none;
+  margin: 0;
+  padding: 0;
 }
 
 /* Hero CTA na mobile ma width:100% + padding — bez border-box padding wychodzi


### PR DESCRIPTION
## Dwa bugi wizualne (zgłoszone po merge)

### 1. Tło Brandingu nie sięgało pełnej szerokości
Sekcja Branding (`.kwcs-logo-section`) ma własny gradient tła, ale nie była objęta wcześniejszą regułą full-bleed (obejmowała tylko `.razdwa-summary` i `.kwcs-sec--alt`) → biały pas z lewej przy railu. Dodano `.kwcs-logo-section` do full-bleed w obu breakpointach (216/184). Tło sięga krawędzi treści strony, rail pływa nad tłem.

### 2. Rezultat = „kontener w kontenerze"
`.kwcs-result` był pływającą zaokrągloną kartą (gradient + `border-radius: 24px` + `max-width: 1100px` + `box-shadow`) wewnątrz białej sekcji, a w środku miał jeszcze karty → efekt pudełka w pudełku. Zdjęto „chrome" karty (scope `#case-karoma-pelne`): tło, radius, shadow, max-width, margin. Rezultat jest teraz zwykłą pełnowymiarową sekcją, a treść centruje się w tej samej kolumnie `.wrap` co reszta sekcji (spójne wyśrodkowanie). Wewnętrzne `result-card` zostają jako właściwa treść.

## Weryfikacja
`docOverflow=0` na 390 i 1440. Geometria: `.kwcs-logo-section` = [8, vw-8] (pełna szerokość), `.kwcs-result` bez tła/radius, wycentrowany symetrycznie w kolumnie. Scope ograniczony do `#case-karoma-pelne` — inne case studies nietknięte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuTGpYHuZtyGfkYJ71DfPe)_