### PR TITLE
Karoma: full-bleed i spójność również w kontekście portfolio (#case-viewer)

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3574,6 +3574,21 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
   line-height: 1.5;
 }
 
+/* Kontener rozciągnięty na pełną szerokość viewportu w OBU kontekstach
+   (standalone i #case-viewer w portfolio.html, gdzie .project-content ma
+   własny padding). Bez tego full-bleed sekcji sięgał tylko krawędzi
+   kontenera, nie viewportu — w portfolio zostawał biały pas z lewej.
+   margin: calc(50% - 50vw) => kontener [0, vw] niezależnie od kontekstu. */
+#case-karoma-pelne {
+  /* index-styles.css (ładowany w portfolio) ma section{max-width:100%!important;
+     width:100%}, co capuje kontener do szerokości rodzica i blokuje full-bleed.
+     Nadpisujemy: !important + width:auto, żeby marginesy rozciągnęły go do vw. */
+  max-width: none !important;
+  width: auto;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+}
+
 /* Desktop ≥1280px — content odsunięty w prawo za fixed rail, szersza kolumna */
 @media (min-width: 1280px) {
   #case-karoma-pelne { padding-left: 216px; --wrap-max: 1240px; }
@@ -3605,15 +3620,27 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
 
 /* Rezultat bez pływającej karty — zdejmujemy tło/radius/shadow/max-width,
    żeby sekcja była pełnowymiarowa i centrowała treść w tej samej kolumnie
-   .wrap co reszta sekcji (spójne wyśrodkowanie). text-align:center zostaje. */
+   .wrap co reszta sekcji (spójne wyśrodkowanie). text-align:center zostaje.
+   display:block + border/backdrop:none neutralizują kolizję z portfolio.css
+   (.kwcs-result{display:flex;border;backdrop-filter} — inny komponent o tej
+   samej nazwie klasy, ładowany tylko w portfolio, powodował shrink-wrap tytułu). */
 #case-karoma-pelne .kwcs-result {
+  display: block;
   background: none;
+  border: none;
+  backdrop-filter: none;
   border-radius: 0;
   box-shadow: none;
   max-width: none;
   margin: 0;
   padding: 0;
 }
+/* portfolio.css:800 .kwcs-result p{font-weight:600} pogrubiał tekst kart/leada
+   tylko w portfolio — reset do normalnej wagi (jak w standalone). */
+#case-karoma-pelne .kwcs-result p { font-weight: 400; }
+/* portfolio.css .kwcs-card{border;backdrop-filter} dawał kartom Wniosków border
+   i blur tylko w portfolio — neutralizacja do stanu standalone. */
+#case-karoma-pelne .kwcs-card { border: none; backdrop-filter: none; }
 
 /* Hero CTA na mobile ma width:100% + padding — bez border-box padding wychodzi
    poza kontener (~16px overflow na 390px). Fix jak w RazDwa. */


### PR DESCRIPTION
## Problem

Poprzednie poprawki full-bleed/centrowania działały tylko **standalone**. W `portfolio.html` case study jest wstrzykiwany do `#case-viewer > .project-content` (który ma padding) i ładują się dodatkowe arkusze (`index-styles.css`, `portfolio.css`) z regułami kolidującymi z case study. Skutki widoczne tylko w portfolio: tła nie sięgały krawędzi (biały pas z lewej/prawej), a sekcja Rezultat była rozjechana (tytuł „Co zostało wdrożone" do lewej, karty ucięte).

## Przyczyny i naprawy (scope `#case-karoma-pelne`)

1. **`index-styles.css`**: globalne `section{max-width:100%!important; width:100%}` capowało kontener do szerokości rodzica → full-bleed nie sięgał viewportu. Fix: kontener rozciągnięty na pełny viewport marginesami `calc(50% - 50vw)` + `max-width:none!important` + `width:auto` (bije globalny `section`). Działa w obu kontekstach.
2. **`portfolio.css` `.kwcs-result{display:flex;…}`** — inny komponent portfolio o tej samej nazwie klasy → tytuł shrink-wrap do lewej, karty ucięte. Fix: `#case-karoma-pelne .kwcs-result{display:block; border:none; backdrop-filter:none}` + zdjęcie chrome pływającej karty.
3. **`portfolio.css` `.kwcs-result p{font-weight:600}` i `.kwcs-card{border;backdrop-filter}`** — pogrubiony tekst kart + border/blur tylko w portfolio. Reset do stanu standalone.

## Weryfikacja (dokładna, jak proszono)

Standalone i portfolio, szerokości 390/1280/1440/1920:
- tła sekcji (`razdwa-summary`, `kwcs-logo-section`, `kwcs-sec--alt`) = **FULL** `[0, vw]`,
- `resultTitle` = **CENTER**,
- `docOverflow=0`,
- **computed-styles kluczowych elementów identyczne** w obu kontekstach (diff = 0).

Scope ograniczony do `#case-karoma-pelne`. Uwaga: `portfolio.css` zawiera stary, równoległy blok `.kwcs-*`, który analogicznie dotyka pozostałych case studies przy wstrzyknięciu — do rozważenia osobne sprzątnięcie u źródła.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuTGpYHuZtyGfkYJ71DfPe)_