### PR TITLE
Power of Mind: fix full-bleed teł kolorowych sekcji

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3779,11 +3779,28 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
   line-height: 1.5;
 }
 
+/* Kontener rozciągnięty na pełną szerokość viewportu w OBU kontekstach
+   (standalone i #case-viewer w portfolio.html, gdzie .project-content ma
+   własny padding). Bez tego full-bleed sekcji sięgał tylko krawędzi
+   kontenera, nie viewportu — zostawał biały pas i efekt "kontener w
+   kontenerze". margin: calc(50% - 50vw) => kontener [0, vw] niezależnie
+   od kontekstu. Wzorzec z #case-karoma-pelne. */
+#case-power-of-mind-pelne {
+  /* index-styles.css (ładowany w portfolio) ma section{max-width:100%!important;
+     width:100%}, co capuje kontener do szerokości rodzica i blokuje full-bleed.
+     Nadpisujemy: !important + width:auto, żeby marginesy rozciągnęły go do vw. */
+  max-width: none !important;
+  width: auto;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+}
+
 /* Desktop ≥1280px — content odsunięty za fixed rail + full-bleed teł */
 @media (min-width: 1280px) {
   #case-power-of-mind-pelne { padding-left: 216px; --wrap-max: 1240px; }
   #case-power-of-mind-pelne > .razdwa-summary,
-  #case-power-of-mind-pelne > .kwcs-sec--alt {
+  #case-power-of-mind-pelne > .kwcs-sec--alt,
+  #case-power-of-mind-pelne > .kwcs-logo-section {
     margin-left: -216px;
     padding-left: calc(216px + 1rem);
   }
@@ -3792,7 +3809,8 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
 @media (min-width: 1101px) and (max-width: 1279px) {
   #case-power-of-mind-pelne { padding-left: 184px; --wrap-max: 1120px; }
   #case-power-of-mind-pelne > .razdwa-summary,
-  #case-power-of-mind-pelne > .kwcs-sec--alt {
+  #case-power-of-mind-pelne > .kwcs-sec--alt,
+  #case-power-of-mind-pelne > .kwcs-logo-section {
     margin-left: -184px;
     padding-left: calc(184px + 1rem);
   }


### PR DESCRIPTION
## Problem

W Power of Mind tła kolorowych sekcji nie dochodziły do pełnej szerokości viewportu — szczególnie w kontekście `portfolio.html#power-of-mind`, gdzie `.project-content` ma własny padding. Efekt: „kontener w kontenerze" i biały pas przy sekcjach z kolorowym tłem.

## Przyczyna

1. Brakowało **bazowej reguły rozciągającej** całą sekcję case do pełnej szerokości viewportu w obu kontekstach. Bez niej negatywne marginesy full-bleed sięgały tylko krawędzi kontenera-rodzica, nie viewportu.
2. Sekcja **Branding** (`.kwcs-logo-section`) ma kolorowy gradient, ale nie była ujęta w regułach full-bleed (obok `.razdwa-summary` i `.kwcs-sec--alt`).

## Zmiana (`assets/css/projects.css`, scope `#case-power-of-mind-pelne`)

- Dodana bazowa reguła: `max-width: none !important; width: auto; margin: 0 calc(50% - 50vw)` — rozciąga kontener do `[0, vw]` niezależnie od kontekstu (nadpisuje `section{max-width:100%!important}` z `index-styles.css` ładowanego w portfolio).
- Dodano `> .kwcs-logo-section` do selektorów full-bleed w breakpointach ≥1280 i 1101–1279.
- Wzorzec spójny z `#case-karoma-pelne` (PR #82).

## Weryfikacja
Zmierzone krawędzie kolorowych pasów = `left:0 / right:vw` w każdym przypadku:

| Kontekst / szerokość | overflow | W skrócie | Branding | Wnioski |
|---|---|---|---|---|
| standalone 1440 | 0 | 0→1440 | 0→1440 | 0→1440 |
| portfolio 1440 | 0 | 0→1440 | 0→1440 | 0→1440 |
| portfolio 1200 | 0 | 0→1200 | 0→1200 | 0→1200 |
| mobile 390 (oba konteksty) | 0 | pełna szer. | pełna szer. | pełna szer. |

`docOverflow=0` wszędzie, 0 broken images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HabjQagBt7sSddtctHxYbB)_