### PR TITLE
Power of Mind: fix sekcji Rezultat — centrowanie + spójne przyciski

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -3826,6 +3826,29 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
   max-width: 100%;
 }
 
+/* Rezultat bez pływającej karty — zdejmujemy tło/radius/shadow/border,
+   żeby sekcja centrowała treść w tej samej kolumnie .wrap co reszta.
+   display:block neutralizuje kolizję z portfolio.css (.kwcs-result{
+   display:flex;border;backdrop-filter} — inny komponent o tej samej nazwie
+   klasy, ładowany tylko w portfolio, shrink-wrapował tytuł do lewej). */
+#case-power-of-mind-pelne .kwcs-result {
+  display: block;
+  background: none;
+  border: none;
+  backdrop-filter: none;
+  border-radius: 0;
+  box-shadow: none;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+}
+/* portfolio.css .kwcs-result p{font-weight:600} pogrubiał lead/karty tylko
+   w portfolio — reset do normalnej wagi (jak w standalone). */
+#case-power-of-mind-pelne .kwcs-result p { font-weight: 400; }
+/* portfolio.css .kwcs-card{border;backdrop-filter} dawał kartom Rezultatu
+   border i blur tylko w portfolio — neutralizacja do stanu standalone. */
+#case-power-of-mind-pelne .kwcs-card { border: none; backdrop-filter: none; }
+
 /* Blok zaproszenia (CTA końcowe) + ghost CTA + slot cytatu */
 #case-power-of-mind-pelne .result-invite {
   margin-top: 2.5rem;
@@ -3854,14 +3877,16 @@ body.lightbox-open .kwcs-chapter-rail { display: none; }
 #case-power-of-mind-pelne .result-invite-actions .kwcs-cta {
   margin: 0.5rem 0;
 }
+/* Ghost CTA — spójny z niebieskim standardem CTA w całym projekcie
+   (razdwa/karoma używają #0284c7), nie brandowe indygo POM. */
 #case-power-of-mind-pelne .kwcs-cta--ghost {
   background: transparent;
-  color: #4f46e5;
+  color: #0284c7;
   box-shadow: none;
-  border: 1px solid #4f46e5;
+  border: 1px solid #0284c7;
 }
 #case-power-of-mind-pelne .kwcs-cta--ghost:hover {
-  background: rgba(79, 70, 229, 0.08);
+  background: rgba(2, 132, 199, 0.08);
   box-shadow: none;
 }
 


### PR DESCRIPTION
## Problem

W sekcji końcowej (Rezultat) — widocznej szczególnie w kontekście `portfolio.html#power-of-mind`:
- tytuł „Firma, która działa bez telefonu" był wyrównany do lewej (nie wyśrodkowany),
- wokół sekcji pojawiała się „karta" (tło/border/shadow), teksty były pogrubione,
- ghost CTA „Zobacz na żywo" miał brandowe indygo `#4f46e5`, niespójne z niebieskim standardem CTA w reszcie projektu.

## Przyczyna

W portfolio ładowany jest `portfolio.css`, który definiuje **inny komponent** o tej samej nazwie klasy `.kwcs-result` (`display:flex; border; backdrop-filter`) oraz `.kwcs-result p { font-weight:600 }` i `.kwcs-card { border; backdrop-filter }`. To shrink-wrapowało tytuł do lewej i dawało efekt karty. Power of Mind nie miał scoped neutralizacji, którą ma już Karoma.

## Zmiana (`assets/css/projects.css`, scope `#case-power-of-mind-pelne`)

- `.kwcs-result` → `display:block` + zdjęcie `background/border/border-radius/box-shadow/max-width/margin/padding` → sekcja centruje treść w tej samej kolumnie `.wrap` co reszta, w obu kontekstach.
- `.kwcs-result p` → `font-weight:400` (reset pogrubienia z portfolio.css).
- `.kwcs-card` → `border:none; backdrop-filter:none` (neutralizacja portfolio.css).
- `.kwcs-cta--ghost` → kolor `#0284c7` zamiast `#4f46e5` (spójność z razdwa/karoma i z primary CTA).
- Wzorzec spójny z `#case-karoma-pelne`.

## Weryfikacja
- Standalone i portfolio: `.kwcs-result` = `display:block`, `text-align:center`, brak bordera/radiusa/tła.
- Tytuł i teksty wyśrodkowane, przyciski spójne (primary cyan gradient + ghost niebieski).
- `docOverflow=0` na 1200 i 390, oba konteksty; 0 broken images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HabjQagBt7sSddtctHxYbB)_