### PR TITLE
Hero: eyebrow pod H1 + powiększony H1 (54px) + odstępy

### DIFF
--- a/assets/css/index-styles.css
+++ b/assets/css/index-styles.css
@@ -3881,7 +3881,7 @@ header * {
 .hero-text {
     max-width: none;
     padding-top: 0;
-    gap: var(--space-3);
+    gap: 10px; /* bazowy odstep; H1 → eyebrow = 10px */
     text-align: left;
     align-items: flex-start;
 }
@@ -3906,7 +3906,7 @@ header * {
 
 .hero-title .ht-line1,
 .hero-title .ht-line2 {
-    font-size: clamp(2rem, 3.5vw, 2.75rem);
+    font-size: clamp(2rem, 3.8vw, 3.375rem); /* powiekszony H1 (~54px na 1440), 2 linie */
     line-height: 1.1;
     white-space: nowrap;
 }
@@ -4420,8 +4420,11 @@ ul.hero-info-icons {
     padding: 0;
 }
 .hero-text .hero-info-icons {
-    margin-top: var(--space-6);
+    margin-top: 2.875rem; /* subtitle → lista: 10 gap + 46 = 56px */
     gap: 0.9rem;
+}
+.hero-text .hero-subtitle {
+    margin-top: 12px; /* eyebrow → subtitle: 10 gap + 12 = 22px */
 }
 .info-icon {
     align-items: flex-start;
@@ -4476,7 +4479,7 @@ ul.hero-info-icons {
     align-items: center;
     gap: var(--space-5);
     flex-wrap: wrap;
-    margin-top: var(--space-7);
+    margin-top: 34px; /* lista → CTA: 10 gap + 34 = 44px (fix niezdefiniowanej --space-7) */
 }
 .btn.btn-hero-cta {
     padding: var(--space-4) var(--space-8);
@@ -4509,8 +4512,8 @@ ul.hero-info-icons {
     .hero-main-content {
         align-items: stretch !important;
     }
-    .hero-text .hero-eyebrow { order: 1 !important; }
-    .hero-text .hero-title   { order: 2 !important; }
+    .hero-text .hero-title   { order: 1 !important; }
+    .hero-text .hero-eyebrow { order: 2 !important; }
     .hero-text .hero-subtitle {
         order: 3 !important;
         text-align: left !important;
@@ -4553,8 +4556,8 @@ ul.hero-info-icons {
         gap: 0 !important;
     }
     .hero-text { display: contents !important; }
-    .hero-text .hero-eyebrow  { order: 1 !important; text-align: left !important; white-space: normal !important; }
-    .hero-text .hero-title    { order: 2 !important; text-align: left !important; }
+    .hero-text .hero-title    { order: 1 !important; text-align: left !important; }
+    .hero-text .hero-eyebrow  { order: 2 !important; text-align: left !important; white-space: normal !important; }
     .hero-image {
         order: 3 !important;
         grid-column: auto !important;

--- a/index.html
+++ b/index.html
@@ -113,12 +113,12 @@
         <div class="hero-main-content">
 
             <div class="hero-text">
-                <p class="hero-eyebrow">STRONY · AUTOMATYZACJE · USPRAWNIANIE PROCESÓW</p>
-
                 <h1 class="hero-title">
                     <span class="ht-line1">Uporządkuj procesy, </span>
                     <span class="ht-line2">odzyskaj czas.</span>
                 </h1>
+
+                <p class="hero-eyebrow">STRONY · AUTOMATYZACJE · USPRAWNIANIE PROCESÓW</p>
 
                 <p class="hero-subtitle">
                    Powtarzasz te same czynności, choć dawno mogłyby dziać się same? 


### PR DESCRIPTION
## Zakres

Korekta hierarchii i odstępów w sekcji hero (`index.html` + `assets/css/index-styles.css`). Bez zmian w strukturze 2-kolumnowej, portrecie i liście 3 punktów.

### Zmiany
1. **Eyebrow pod H1** — nowa kolejność: **H1 → eyebrow → subtitle → lista → CTA** (spójnie na desktop, tablet i mobile).
2. **H1 powiększony** — ~44px → ~54px (`clamp(2rem, 3.8vw, 3.375rem)`), pozostaje 2-liniowy.
3. **Odstępy** (zmierzone na 1440px):
   - H1 → eyebrow: 10px
   - eyebrow → subtitle: 22px
   - subtitle → lista: 56px
   - lista → CTA: 44px
4. **Fix** niezdefiniowanej zmiennej `--space-7` (odstęp przed CTA gubił się do wartości domyślnej).

### Weryfikacja
- 1440 / 1024 / mobile 390 — kolejność spójna, H1 2 linie, brak przepełnienia poziomego.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoDK1L6nrk915A6cgPYB6u

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoDK1L6nrk915A6cgPYB6u)_