### PR TITLE
RazDwa: wzmocnienie narracji Delivery PM w case study

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -202,6 +202,30 @@
   color: #0c6076;
 }
 
+#case-razdwa-pelne .ux-decision-box ul {
+  margin: 0.25rem 0 0;
+  padding-left: 1.15rem;
+}
+#case-razdwa-pelne .ux-decision-box ul li {
+  font-size: 0.875rem;
+  color: #475569;
+  line-height: 1.55;
+  margin-bottom: 0.4rem;
+}
+#case-razdwa-pelne .ux-decision-box ul li:last-child {
+  margin-bottom: 0;
+}
+
+/* Przebieg projektu ma 6 etapów (o jeden więcej niż domyślny flow) —
+   nieco więcej miejsca i węższe kolumny, żeby ostatni etap się nie ucinał. */
+#case-razdwa-pelne .user-flow--6 {
+  max-width: 1060px;
+}
+#case-razdwa-pelne .user-flow--6 .flow-step {
+  min-width: 104px;
+  padding: 0 0.3rem;
+}
+
 #case-razdwa-pelne .kwcs-hero-body .hero-image {
   width: 100%;
   display: flex;

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -190,6 +190,18 @@
   line-height: 1.5;
 }
 
+#case-razdwa-pelne .razdwa-tradeoff {
+  margin-top: 0.85rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #e2e8f0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #475569;
+}
+#case-razdwa-pelne .razdwa-tradeoff strong {
+  color: #0c6076;
+}
+
 #case-razdwa-pelne .kwcs-hero-body .hero-image {
   width: 100%;
   display: flex;

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -226,6 +226,13 @@
   padding: 0 0.3rem;
 }
 
+#case-razdwa-pelne .razdwa-miro { margin-bottom: 2rem; }
+#case-razdwa-pelne .razdwa-miro img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 12px;
+}
+
 #case-razdwa-pelne .kwcs-hero-body .hero-image {
   width: 100%;
   display: flex;

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -62,6 +62,7 @@
   <li><a class="razdwa-chapter-link" href="#razdwa-kontekst" data-rail-target="razdwa-kontekst" title="Problem: wolna wycena i ryzyko pomyłki" aria-label="Problem: wolna wycena i ryzyko pomyłki">Problem</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-rola" data-rail-target="razdwa-rola" title="Moja rola" aria-label="Moja rola">Moja rola</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-przebieg" data-rail-target="razdwa-przebieg" title="Od diagnozy do przekazania — etapy projektu" aria-label="Od diagnozy do przekazania — etapy projektu">Przebieg projektu</a></li>
+  <li><a class="razdwa-chapter-link" href="#razdwa-zakres" data-rail-target="razdwa-zakres" title="Zakres, ryzyka i gotowość do startu" aria-label="Zakres, ryzyka i gotowość do startu">Zakres i ryzyka</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-decyzje" data-rail-target="razdwa-decyzje" title="Trzy decyzje: tanie utrzymanie i prosta obsługa" aria-label="Trzy decyzje: tanie utrzymanie i prosta obsługa">Kluczowe decyzje</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-ux" data-rail-target="razdwa-ux" title="Wycena w kilku krokach" aria-label="Wycena w kilku krokach">Szybka wycena</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-logika" data-rail-target="razdwa-logika" title="Najtrudniejsze wyceny liczą się same" aria-label="Najtrudniejsze wyceny liczą się same">Automatyzacja CAD</a></li>
@@ -81,7 +82,9 @@
           Zastąpiłem ręczne liczenie i papierowy cennik- aplikacją, która uprościła wycenę, ograniczyła błędy i uporządkowała obsługę zamówień w drukarni.
         </p>
        <div class="pm-hero-meta">
-  <span><strong>Rola</strong> Samodzielne prowadzenie projektu end-to-end (projekt solo)</span>
+  <span><strong>Rola</strong> End-to-end owner (analiza → logika → testy → dostarczenie), projekt solo</span>
+  <span class="pm-meta-sep">·</span>
+  <span><strong>Model</strong> Freelance, równolegle do etatu</span>
   <span class="pm-meta-sep">·</span>
   <span><strong>Czas</strong> ok. 6 miesięcy</span>
   <span class="pm-meta-sep">·</span>
@@ -202,7 +205,7 @@
     <div class="razdwa-stats">
       <div class="razdwa-stat">
         <div class="razdwa-stat-num">~5 min</div>
-        <div class="razdwa-stat-label">tyle trwa dziś typowa wycena — wcześniej nawet godzina</div>
+        <div class="razdwa-stat-label">tyle trwa typowa wycena w narzędziu — wcześniej nawet godzina</div>
       </div>
       <div class="razdwa-stat">
         <div class="razdwa-stat-num">−90%</div>
@@ -232,10 +235,17 @@
       Projekt prowadziłem etapami: najpierw diagnoza realnej pracy, potem decyzje o zakresie pierwszej wersji, budowa z testami, uruchomienie — a po starcie iteracje na podstawie tego, jak narzędzie faktycznie pracuje.
     </p>
 
-    <!-- DO UZUPEŁNIENIA (dane od właściciela portfolio): przybliżone ramy czasowe
-         poszczególnych etapów (np. ile trwała diagnoza, kiedy ruszyła pierwsza wersja,
-         ile tygodni po starcie weszły iteracje). Bez tych danych etapy celowo
+    <!-- DO UZUPEŁNIENIA (dane od kandydata): przybliżone ramy czasowe poszczególnych
+         etapów (np. diagnoza DD.MM.2025 → pierwsza działająca wersja DD.MM.2026 →
+         iteracje od DD.MM.2026 → przekazanie DD.MM.2026). Bez tych danych etapy celowo
          pozostają bez dat, żeby niczego nie zmyślać. -->
+    <!-- ARTEFAKT PM DO WKLEJENIA (asset od kandydata): zrzut z Miro / diagram procesu
+         AS-IS → TO-BE (bloki decyzyjne, etapy). Gdy będzie gotowy, wstaw jako:
+         <div class="kwcs-gallery-grid kwcs-gallery-grid--single"><div class="gallery-item">
+         <img class="lightbox-trigger" src="/KWdesignnew/assets/images/razdwa/PLIK.webp"
+         width="W" height="H" alt="Proces wyceny AS-IS → TO-BE" loading="lazy"
+         data-caption="Mapa procesu przed i po wdrożeniu narzędzia"></div></div>.
+         Bez realnego pliku nie tworzę makiety, żeby nie zmyślać artefaktu. -->
     <div class="user-flow">
       <div class="flow-step">
         <div class="flow-step-icon">01</div>
@@ -257,27 +267,107 @@
       <div class="flow-arrow">→</div>
       <div class="flow-step">
         <div class="flow-step-icon">04</div>
-        <div class="flow-step-label">Uruchomienie</div>
-        <div class="flow-step-sub">Pierwsza wersja w codziennej pracy drukarni</div>
+        <div class="flow-step-label">Działająca wersja</div>
+        <div class="flow-step-sub">Pierwsza działająca wersja gotowa do pracy przy ladzie</div>
       </div>
       <div class="flow-arrow">→</div>
       <div class="flow-step">
         <div class="flow-step-icon">05</div>
-        <div class="flow-step-label">Iteracje po starcie</div>
+        <div class="flow-step-label">Iteracje na działającej wersji</div>
         <div class="flow-step-sub">Tryb EXPRESS, warianty produktów, eksport PDF</div>
       </div>
       <div class="flow-arrow">→</div>
       <div class="flow-step">
         <div class="flow-step-icon">06</div>
-        <div class="flow-step-label">Przekazanie</div>
-        <div class="flow-step-sub">Właściciel samodzielnie prowadzi cennik</div>
+        <div class="flow-step-label">Przekazanie i gotowość</div>
+        <div class="flow-step-sub">Szkolenie właściciela z panelu cen, gotowość do startu produkcyjnego</div>
       </div>
     </div>
 
     <div class="kwcs-callout">
       <p>
-        <strong>Zakres nie był zamrożony:</strong> potrzeby, które ujawniły się dopiero po uruchomieniu (tryb EXPRESS, warianty produktów, eksport PDF), trafiały do narzędzia jako kolejne iteracje — bez zatrzymywania codziennej pracy drukarni. <strong>Największe ryzyko</strong> — błąd w logice cenowej, który kosztuje realne pieniądze — zabezpieczył pakiet testów automatycznych, uruchamiany przy każdej zmianie cennika.
+        <strong>Zakres nie był zamrożony:</strong> potrzeby, które ujawniły się dopiero na działającej wersji (tryb EXPRESS, warianty produktów, eksport PDF), obsłużyłem jako kolejne iteracje jeszcze przed startem produkcyjnym. <strong>Największe ryzyko</strong> — błąd w logice cenowej, który kosztuje realne pieniądze — zabezpieczył pakiet testów automatycznych, uruchamiany przy każdej zmianie cennika.
       </p>
+    </div>
+  </div>
+</div>
+
+<h2 class="section-divider" id="razdwa-zakres">Zakres, ryzyka i gotowość do startu</h2>
+
+<div class="kwcs-sec">
+  <div class="wrap">
+    <p class="razdwa-h2-sub">Co weszło do pierwszej wersji, co świadomie zostało poza nią i jak zabezpieczyłem najważniejsze ryzyka.</p>
+
+    <div class="ux-decision-grid">
+      <div class="ux-decision-box">
+        <div class="ux-label">W zakresie</div>
+        <h4>Co objęła pierwsza wersja</h4>
+        <ul>
+          <li>Kalkulator wyceny usług z parametrami i wyceną na żywo</li>
+          <li>Wycena plików CAD (rozpoznanie formatu, stawka per plik / per mb)</li>
+          <li>Koszyk, tryb EXPRESS i finalizacja zamówienia</li>
+          <li>Formularz danych klienta B2B i eksport dokumentu PDF</li>
+          <li>Panel administracyjny cen (edycja stawek, dodawanie wariantów)</li>
+          <li>Zapis danych i historii zamówień w Google Sheets</li>
+        </ul>
+      </div>
+      <div class="ux-decision-box">
+        <div class="ux-label">Poza zakresem</div>
+        <h4>Co świadomie zostało poza pierwszą wersją</h4>
+        <ul>
+          <li>Klasyczny backend i dedykowany serwer (świadomie odrzucone — patrz Decyzja 2)</li>
+          <li>Gotowy system e-commerce / sklep online (świadomie odrzucone — patrz Decyzja 1)</li>
+          <li>Rozbudowana skalowalność ponad potrzeby jednej drukarni</li>
+          <!-- DO UZUPEŁNIENIA (dane od kandydata): jeśli świadomie odłożono też inne
+               obszary (np. płatności online, konta klientów, integracja z księgowością),
+               dopisz je tutaj jednym punktem każdy. Bez potwierdzenia nie dodaję,
+               żeby nie zmyślać granic zakresu. -->
+        </ul>
+      </div>
+    </div>
+
+    <h3 class="kwcs-h3-center">Ryzyka i jak je zabezpieczyłem</h3>
+    <div class="ux-decision-grid ux-decision-grid--trio">
+      <div class="ux-decision-box">
+        <div class="ux-label">Ryzyko 1</div>
+        <h4>Błąd w logice cenowej</h4>
+        <p><strong>Wpływ:</strong> zła cena to realny koszt finansowy i utrata zaufania klienta. <strong>Mitygacja:</strong> pakiet testów automatycznych logiki cenowej, uruchamiany przy każdej zmianie cennika.</p>
+      </div>
+      <div class="ux-decision-box">
+        <div class="ux-label">Ryzyko 2</div>
+        <h4>Jakość wycen CAD</h4>
+        <p><strong>Wpływ:</strong> wiele parametrów i wyjątków formatowych przy ręcznym liczeniu dawało największe ryzyko pomyłki wymiarowej. <strong>Mitygacja:</strong> automatyczne rozpoznawanie parametrów pliku i obsługa wyjątków formatowych.</p>
+      </div>
+      <div class="ux-decision-box">
+        <div class="ux-label">Ryzyko 3</div>
+        <h4>Adopcja przy ladzie</h4>
+        <p><strong>Wpływ:</strong> narzędzie na starszym sprzęcie, pod presją czasu, mogło spowalniać zamiast pomagać. <strong>Mitygacja:</strong> prosty, jednoekranowy interfejs odporny na błędy, dopasowany do starszego sprzętu.</p>
+      </div>
+    </div>
+
+    <h3 class="kwcs-h3-center">Checklista gotowości (Go-Live)</h3>
+    <div class="ux-decision-grid">
+      <div class="ux-decision-box">
+        <div class="ux-label">Zrobione przed startem</div>
+        <h4>Gotowe do Go-Live</h4>
+        <ul>
+          <li>Logika wyceny (usługi + CAD) zaimplementowana i pokryta testami automatycznymi</li>
+          <li>Panel administracyjny cen gotowy (edycja stawek, warianty)</li>
+          <li>Eksport dokumentów PDF i zapis zamówień do Google Sheets</li>
+          <li>Szkolenie właściciela z obsługi panelu cen</li>
+        </ul>
+      </div>
+      <div class="ux-decision-box">
+        <div class="ux-label">Pozostaje do startu</div>
+        <h4>Przed / na starcie produkcyjnym</h4>
+        <ul>
+          <li>Start produkcyjny przy ladzie — planowany na <strong>01.08.2026</strong></li>
+          <li>Przekazanie panelu cen właścicielowi do samodzielnej obsługi</li>
+          <!-- [CZEKA NA DANE] Po starcie produkcyjnym dopisz punkt potwierdzający odbiór:
+               np. "Potwierdzenie poprawnej pracy przy ladzie po pierwszym tygodniu (DD.MM.2026)".
+               Bez realnego potwierdzenia nie publikujemy tego jako faktu. -->
+        </ul>
+      </div>
     </div>
   </div>
 </div>
@@ -560,7 +650,7 @@
       <div class="ux-decision-box">
         <div class="ux-label">Wniosek 3</div>
         <h4>Kluczowe funkcje po uruchomieniu</h4>
-        <p>Tryb EXPRESS, zarządzanie wariantami produktów i automatyczny eksport PDF nie były w pierwotnym zakresie. Pojawiły się po uruchomieniu — jako odpowiedź na rzeczywisty przepływ pracy, którego nie było widać przed wdrożeniem.</p>
+        <p>Tryb EXPRESS, zarządzanie wariantami produktów i automatyczny eksport PDF nie były w pierwotnym zakresie. Pojawiły się na działającej wersji — jako odpowiedź na rzeczywisty przepływ pracy, którego nie było widać przed zbudowaniem narzędzia.</p>
       </div>
     </div>
   </div>
@@ -575,7 +665,13 @@
 
       <div class="result-lead">
         <p>
-          Drukarnia dostała narzędzie, które skróciło wycenę <strong>z godziny do około 5 minut</strong> i uporządkowało obsługę zamówień. Mniej <strong>błędów rachunkowych</strong>, a właściciel sam panuje nad cennikiem.
+          Drukarnia dostała gotowe narzędzie, które skraca wycenę <strong>z godziny do około 5 minut</strong> i porządkuje obsługę zamówień. Mniej <strong>błędów rachunkowych</strong>, a właściciel — po przeszkoleniu — samodzielnie panuje nad cennikiem.
+        </p>
+      </div>
+
+      <div class="kwcs-callout">
+        <p>
+          <strong>Status:</strong> narzędzie dostarczone i gotowe do startu produkcyjnego. Start produkcyjny planowany na <strong>01.08.2026</strong>. Wartości czasowe (ok. 5 min, −90% przy CAD) pochodzą z porównania obsługi tego samego typu zamówienia przed i po zbudowaniu narzędzia — nie z długiego okresu użycia produkcyjnego.
         </p>
       </div>
 
@@ -590,7 +686,7 @@
         </div>
         <div class="result-card">
           <h4>Samodzielność po przekazaniu</h4>
-          <p>Po wdrożeniu właściciel prowadzi cennik i rozbudowuje ofertę sam — bez rozbudowanej infrastruktury i bez powrotu do wykonawcy przy każdej zmianie.</p>
+          <p>Właściciel został przeszkolony z obsługi panelu cen i po starcie produkcyjnym prowadzi cennik oraz rozbudowuje ofertę samodzielnie — bez rozbudowanej infrastruktury i bez powrotu do wykonawcy przy każdej zmianie.</p>
         </div>
       </div>
 

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -235,16 +235,18 @@
       Projekt prowadziłem etapami: od diagnozy realnej pracy (03.03.2026), przez decyzje o zakresie i architekturze, budowę z testami i pierwszą działającą wersję (02.04.2026), aż po iteracje i przekazanie narzędzia (04.06.2026).
     </p>
 
-    <!-- ARTEFAKT PM DO WKLEJENIA (asset od kandydata): zrzut z Miro / diagram procesu
-         AS-IS → TO-BE. Plik dostarczony przez kandydata: "Miro_RAZ DWA.webp".
-         KROK 1: wgraj plik do repo jako assets/images/razdwa/Miro_RAZDWA.webp
-                 (bez spacji w nazwie — spacje psują ścieżki na GitHub Pages).
-         KROK 2: sprawdź realne wymiary webp i wstaw poniższy snippet zamiast tego komentarza:
-         <div class="kwcs-gallery-grid kwcs-gallery-grid--single"><div class="gallery-item">
-         <img class="lightbox-trigger" src="/KWdesignnew/assets/images/razdwa/Miro_RAZDWA.webp"
-         width="W" height="H" alt="Mapa procesu wyceny AS-IS → TO-BE (Miro)" loading="lazy"
-         data-caption="Proces wyceny przed i po wdrożeniu narzędzia — bloki decyzyjne"></div></div>.
-         Nie wstawiam <img> teraz, bo pliku nie ma jeszcze w repo (byłby zepsuty link). -->
+    <!-- ARTEFAKT PM: mapa procesu AS-IS → TO-BE (tablica Miro).
+         UWAGA: plik binarny musi trafić do repo pod ścieżką w src poniżej,
+         inaczej obraz będzie zepsutym linkiem. Nazwa musi zgadzać się 1:1
+         (obecnie ze spacją, jak dostarczono). Po dodaniu pliku warto uzupełnić
+         width/height realnymi wymiarami (teraz responsywny bez sztywnych wymiarów). -->
+    <div class="kwcs-gallery-grid kwcs-gallery-grid--single razdwa-miro">
+      <div class="gallery-item">
+        <img class="lightbox-trigger" src="/KWdesignnew/assets/images/razdwa/Miro_RAZ DWA.webp" alt="Mapa procesu wyceny AS-IS → TO-BE zbudowana w Miro" loading="lazy" data-caption="Proces wyceny przed i po wdrożeniu narzędzia — bloki decyzyjne w Miro">
+        <p class="img-desc"><strong>Mapa procesu (Miro):</strong> etapy i bloki decyzyjne, na których oparłem zakres pierwszej wersji — od diagnozy pracy przy ladzie po docelowy przepływ wyceny.</p>
+      </div>
+    </div>
+
     <div class="user-flow user-flow--6">
       <div class="flow-step">
         <div class="flow-step-icon">01</div>

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -61,6 +61,7 @@
   <li><a class="razdwa-chapter-link" href="#razdwa-summary" data-rail-target="razdwa-summary" title="W skrócie" aria-label="W skrócie">W skrócie</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-kontekst" data-rail-target="razdwa-kontekst" title="Problem: wolna wycena i ryzyko pomyłki" aria-label="Problem: wolna wycena i ryzyko pomyłki">Problem</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-rola" data-rail-target="razdwa-rola" title="Moja rola" aria-label="Moja rola">Moja rola</a></li>
+  <li><a class="razdwa-chapter-link" href="#razdwa-przebieg" data-rail-target="razdwa-przebieg" title="Od diagnozy do przekazania — etapy projektu" aria-label="Od diagnozy do przekazania — etapy projektu">Przebieg projektu</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-decyzje" data-rail-target="razdwa-decyzje" title="Trzy decyzje: tanie utrzymanie i prosta obsługa" aria-label="Trzy decyzje: tanie utrzymanie i prosta obsługa">Kluczowe decyzje</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-ux" data-rail-target="razdwa-ux" title="Wycena w kilku krokach" aria-label="Wycena w kilku krokach">Szybka wycena</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-logika" data-rail-target="razdwa-logika" title="Najtrudniejsze wyceny liczą się same" aria-label="Najtrudniejsze wyceny liczą się same">Automatyzacja CAD</a></li>
@@ -80,11 +81,11 @@
           Zastąpiłem ręczne liczenie i papierowy cennik- aplikacją, która uprościła wycenę, ograniczyła błędy i uporządkowała obsługę zamówień w drukarni.
         </p>
        <div class="pm-hero-meta">
-  <span><strong>Rola</strong> Product Design, UX/UI, wdrożenie</span>
+  <span><strong>Rola</strong> Samodzielne prowadzenie projektu end-to-end (projekt solo)</span>
   <span class="pm-meta-sep">·</span>
   <span><strong>Czas</strong> ok. 6 miesięcy</span>
   <span class="pm-meta-sep">·</span>
-  <span><strong>Zakres</strong> analiza procesu, UX/UI, logika systemu</span>
+  <span><strong>Zakres</strong> analiza procesu, decyzje o zakresie, UX/UI, logika systemu, wdrożenie i przekazanie</span>
 <span class="pm-meta-sep">·</span>
 <span><strong>Efekt</strong>  Wycena z godziny do ok. 5 minut, przy dużych zleceniach druku CAD nawet o 90% krócej</span>
 </div>
@@ -135,7 +136,7 @@
   </div>
   <div class="razdwa-summary-cell">
     <div class="label">Moja rola</div>
-    <div class="value">Prowadziłem projekt od analizy procesu po wdrożenie działającego narzędzia.</div>
+    <div class="value">Poprowadziłem projekt end-to-end: od analizy procesu, przez decyzje o zakresie i architekturze, po wdrożenie i przekazanie narzędzia klientowi.</div>
   </div>
   <div class="razdwa-summary-cell">
     <div class="label">Rozwiązanie</div>
@@ -167,8 +168,8 @@
         <p>Najtrudniejsze były zlecenia CAD: wiele parametrów, presja czasu i wysoki koszt pomyłki przy obsłudze klienta na miejscu. Ręczna wycena potrafiła zajmować nawet godzinę.</p>
       </div>
       <div class="ux-decision-box">
-        <h4>Dwie osoby, dwie różne potrzeby</h4>
-        <p><strong>Operator:</strong> potrzebował prostego, szybkiego interfejsu odpornego na błędy. <strong>Właściciel:</strong> potrzebował kontroli nad cennikiem i możliwości samodzielnej edycji stawek.</p>
+        <h4>Dwóch interesariuszy, dwie różne potrzeby</h4>
+        <p><strong>Operator (codzienny użytkownik):</strong> potrzebował prostego, szybkiego interfejsu odpornego na błędy. <strong>Właściciel (decyzje o cenach i budżecie):</strong> potrzebował kontroli nad cennikiem i możliwości samodzielnej edycji stawek. Pogodzenie tych dwóch perspektyw wyznaczyło zakres projektu.</p>
       </div>
     </div>
   </div>
@@ -180,17 +181,20 @@
   <div class="wrap">
     <p class="razdwa-h2-sub">Jeden wykonawca odpowiedzialny za całość — od rozpoznania procesu po działające narzędzie.</p>
     <p class="kwcs-section-lead">
-      Sam odpowiadałem za każdy etap — od rozmów w drukarni, przez projekt i logikę systemu, po testy i uruchomienie.
+      Sam odpowiadałem za każdy etap — od rozmów w drukarni, przez decyzje o zakresie i architekturze, po testy, uruchomienie i przekazanie narzędzia klientowi.
     </p>
 
     <div class="contribution-grid--razdwa">
       <div class="contribution-cell contribution-cell--solo">
         <h3><span class="dot"></span>Za co odpowiadałem</h3>
         <ul>
-          <li>Analiza procesu wyceny i identyfikacja problemów operacyjnych</li>
+          <li>Analiza procesu wyceny i identyfikacja problemów operacyjnych (obserwacja pracy przy ladzie)</li>
+          <li>Zebranie wymagań od właściciela i operatora oraz spięcie ich w jeden zakres projektu</li>
+          <li>Decyzje o architekturze i zakresie — trade-off: koszt utrzymania vs rozbudowa funkcji</li>
           <li>Projekt architektury produktu i głównych przepływów użytkownika</li>
           <li>Opracowanie panelu cen i struktury danych</li>
-          <li>Implementacja produkcyjna, testy i wdrożenie</li>
+          <li>Implementacja produkcyjna, testy automatyczne logiki cenowej i wdrożenie</li>
+          <li>Przekazanie narzędzia i wdrożenie właściciela w samodzielną obsługę panelu cen</li>
         </ul>
       </div>
     </div>
@@ -219,6 +223,65 @@
 
 
     
+<h2 class="section-divider" id="razdwa-przebieg">Od diagnozy do przekazania</h2>
+
+<div class="kwcs-sec">
+  <div class="wrap">
+    <p class="razdwa-h2-sub">Jak w ok. 6 miesięcy proces przy ladzie zmienił się w działające narzędzie.</p>
+    <p class="kwcs-section-lead">
+      Projekt prowadziłem etapami: najpierw diagnoza realnej pracy, potem decyzje o zakresie pierwszej wersji, budowa z testami, uruchomienie — a po starcie iteracje na podstawie tego, jak narzędzie faktycznie pracuje.
+    </p>
+
+    <!-- DO UZUPEŁNIENIA (dane od właściciela portfolio): przybliżone ramy czasowe
+         poszczególnych etapów (np. ile trwała diagnoza, kiedy ruszyła pierwsza wersja,
+         ile tygodni po starcie weszły iteracje). Bez tych danych etapy celowo
+         pozostają bez dat, żeby niczego nie zmyślać. -->
+    <div class="user-flow">
+      <div class="flow-step">
+        <div class="flow-step-icon">01</div>
+        <div class="flow-step-label">Diagnoza</div>
+        <div class="flow-step-sub">Obserwacja pracy przy ladzie, rozmowy z właścicielem i operatorem</div>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-step">
+        <div class="flow-step-icon">02</div>
+        <div class="flow-step-label">Zakres i decyzje</div>
+        <div class="flow-step-sub">Wybór architektury i zakres pierwszej wersji</div>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-step">
+        <div class="flow-step-icon">03</div>
+        <div class="flow-step-label">Budowa i testy</div>
+        <div class="flow-step-sub">Implementacja + testy automatyczne logiki cenowej</div>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-step">
+        <div class="flow-step-icon">04</div>
+        <div class="flow-step-label">Uruchomienie</div>
+        <div class="flow-step-sub">Pierwsza wersja w codziennej pracy drukarni</div>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-step">
+        <div class="flow-step-icon">05</div>
+        <div class="flow-step-label">Iteracje po starcie</div>
+        <div class="flow-step-sub">Tryb EXPRESS, warianty produktów, eksport PDF</div>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-step">
+        <div class="flow-step-icon">06</div>
+        <div class="flow-step-label">Przekazanie</div>
+        <div class="flow-step-sub">Właściciel samodzielnie prowadzi cennik</div>
+      </div>
+    </div>
+
+    <div class="kwcs-callout">
+      <p>
+        <strong>Zakres nie był zamrożony:</strong> potrzeby, które ujawniły się dopiero po uruchomieniu (tryb EXPRESS, warianty produktów, eksport PDF), trafiały do narzędzia jako kolejne iteracje — bez zatrzymywania codziennej pracy drukarni. <strong>Największe ryzyko</strong> — błąd w logice cenowej, który kosztuje realne pieniądze — zabezpieczył pakiet testów automatycznych, uruchamiany przy każdej zmianie cennika.
+      </p>
+    </div>
+  </div>
+</div>
+
 <h2 class="section-divider" id="razdwa-decyzje">Trzy decyzje, które się opłaciły</h2>
 
 <div class="kwcs-sec">
@@ -233,16 +296,19 @@
         <div class="ux-label">Decyzja 1</div>
         <h4>Dedykowana aplikacja zamiast gotowego sklepu</h4>
         <p>Zamiast skomplikowanego systemu zaprojektowałem prostą aplikację, dopasowaną do szybkiej obsługi pracy na starszym sprzęcie. Dzięki temu operator nie walczy z narzędziem, tylko szybko obsługuje klienta.</p>
+        <p class="razdwa-tradeoff"><strong>Kompromis:</strong> mniej gotowych funkcji „z pudełka" w zamian za interfejs skrojony pod jeden, konkretny proces.</p>
       </div>
       <div class="ux-decision-box">
         <div class="ux-label">Decyzja 2</div>
         <h4>Znane zaplecze zamiast ciężkiej infrastruktury</h4>
         <p>Google Sheets i Apps Script pozwoliły oprzeć system na narzędziach, które klient już znał. Dzięki temu wdrożenie było tańsze, a firma nie płaci co miesiąc za serwer ani za specjalistyczne utrzymanie.</p>
+        <p class="razdwa-tradeoff"><strong>Kompromis:</strong> świadoma rezygnacja z klasycznego backendu i skalowalności na rzecz zerowego kosztu utrzymania i braku uzależnienia od dostawcy.</p>
       </div>
       <div class="ux-decision-box">
         <div class="ux-label">Decyzja 3</div>
         <h4>Panel cen zamiast zależności od programisty</h4>
         <p>Właściciel potrzebował samodzielnie aktualizować stawki, dlatego stworzyłem panel administracyjny do zmiany cennika. Dzięki temu firma nie czeka na developera i nie płaci za każdą korektę ceny.</p>
+        <p class="razdwa-tradeoff"><strong>Kompromis:</strong> dodatkowa praca nad panelem administracyjnym w zamian za samodzielność klienta po przekazaniu narzędzia.</p>
       </div>
     </div>
   </div>
@@ -523,10 +589,16 @@
           <p>Automatyczne przeliczenia i panel administracyjny ograniczyły ryzyko pomyłek oraz uprościły zarządzanie stawkami.</p>
         </div>
         <div class="result-card">
-          <h4>Lekkie utrzymanie</h4>
-          <p>Rozwiązanie działa bez rozbudowanej infrastruktury, a klient może samodzielnie obsługiwać kluczowe zmiany operacyjne.</p>
+          <h4>Samodzielność po przekazaniu</h4>
+          <p>Po wdrożeniu właściciel prowadzi cennik i rozbudowuje ofertę sam — bez rozbudowanej infrastruktury i bez powrotu do wykonawcy przy każdej zmianie.</p>
         </div>
       </div>
+
+      <!-- DO UZUPEŁNIENIA (dane od właściciela portfolio): twarde dane potwierdzające
+           adopcję po przekazaniu — np. jak długo narzędzie jest w codziennym użyciu,
+           ile zamówień/wycen przechodzi przez aplikację miesięcznie, ile zmian cennika
+           właściciel wprowadził samodzielnie. Dopóki brak realnych liczb, celowo nie
+           podajemy tu żadnych metryk adopcji, żeby nie zmyślać. -->
 
       <!-- ============================================================
            SLOT NA CYTAT KLIENTA (proof)

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -66,7 +66,7 @@
   <li><a class="razdwa-chapter-link" href="#razdwa-decyzje" data-rail-target="razdwa-decyzje" title="Trzy decyzje: tanie utrzymanie i prosta obsługa" aria-label="Trzy decyzje: tanie utrzymanie i prosta obsługa">Kluczowe decyzje</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-ux" data-rail-target="razdwa-ux" title="Wycena w kilku krokach" aria-label="Wycena w kilku krokach">Szybka wycena</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-logika" data-rail-target="razdwa-logika" title="Najtrudniejsze wyceny liczą się same" aria-label="Najtrudniejsze wyceny liczą się same">Automatyzacja CAD</a></li>
-  <li><a class="razdwa-chapter-link" href="#razdwa-cennik" data-rail-target="razdwa-cennik" title="Właściciel zmienia ceny sam" aria-label="Właściciel zmienia ceny sam">Samodzielny cennik</a></li>
+  <li><a class="razdwa-chapter-link" href="#razdwa-cennik" data-rail-target="razdwa-cennik" title="Właścicielka zmienia ceny sama" aria-label="Właścicielka zmienia ceny sama">Samodzielny cennik</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-architektura" data-rail-target="razdwa-architektura" title="Bez serwera i stałych opłat" aria-label="Bez serwera i stałych opłat">Lekka architektura</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-lessons" data-rail-target="razdwa-lessons" title="Czego nauczyło mnie to wdrożenie" aria-label="Czego nauczyło mnie to wdrożenie">Wnioski</a></li>
   <li><a class="razdwa-chapter-link" href="#razdwa-rezultat" data-rail-target="razdwa-rezultat" title="Co zmieniło się w drukarni" aria-label="Co zmieniło się w drukarni">Rezultat</a></li>
@@ -172,7 +172,7 @@
       </div>
       <div class="ux-decision-box">
         <h4>Dwóch interesariuszy, dwie różne potrzeby</h4>
-        <p><strong>Operator (codzienny użytkownik):</strong> potrzebował prostego, szybkiego interfejsu odpornego na błędy. <strong>Właściciel (decyzje o cenach i budżecie):</strong> potrzebował kontroli nad cennikiem i możliwości samodzielnej edycji stawek. Pogodzenie tych dwóch perspektyw wyznaczyło zakres projektu.</p>
+        <p><strong>Operator (codzienny użytkownik):</strong> potrzebował prostego, szybkiego interfejsu odpornego na błędy. <strong>Właścicielka (decyzje o cenach i budżecie):</strong> potrzebowała kontroli nad cennikiem i możliwości samodzielnej edycji stawek. Pogodzenie tych dwóch perspektyw wyznaczyło zakres projektu.</p>
       </div>
     </div>
   </div>
@@ -192,12 +192,12 @@
         <h3><span class="dot"></span>Za co odpowiadałem</h3>
         <ul>
           <li>Analiza procesu wyceny i identyfikacja problemów operacyjnych (obserwacja pracy przy ladzie)</li>
-          <li>Zebranie wymagań od właściciela i operatora oraz spięcie ich w jeden zakres projektu</li>
+          <li>Zebranie wymagań od właścicielki i operatora oraz spięcie ich w jeden zakres projektu</li>
           <li>Decyzje o architekturze i zakresie — trade-off: koszt utrzymania vs rozbudowa funkcji</li>
           <li>Projekt architektury produktu i głównych przepływów użytkownika</li>
           <li>Opracowanie panelu cen i struktury danych</li>
           <li>Implementacja produkcyjna, testy automatyczne logiki cenowej i wdrożenie</li>
-          <li>Przekazanie narzędzia i wdrożenie właściciela w samodzielną obsługę panelu cen</li>
+          <li>Przekazanie narzędzia i wdrożenie właścicielki w samodzielną obsługę panelu cen (instrukcja wideo mp4)</li>
         </ul>
       </div>
     </div>
@@ -217,7 +217,7 @@
       </div>
       <div class="razdwa-stat">
         <div class="razdwa-stat-num">2 role</div>
-        <div class="razdwa-stat-label">operator i właściciel obsłużeni jednym systemem</div>
+        <div class="razdwa-stat-label">operator i właścicielka obsłużeni jednym systemem</div>
       </div>
     </div>
   </div>
@@ -232,25 +232,24 @@
   <div class="wrap">
     <p class="razdwa-h2-sub">Jak w ok. 6 miesięcy proces przy ladzie zmienił się w działające narzędzie.</p>
     <p class="kwcs-section-lead">
-      Projekt prowadziłem etapami: najpierw diagnoza realnej pracy, potem decyzje o zakresie pierwszej wersji, budowa z testami, uruchomienie — a po starcie iteracje na podstawie tego, jak narzędzie faktycznie pracuje.
+      Projekt prowadziłem etapami: od diagnozy realnej pracy (03.03.2026), przez decyzje o zakresie i architekturze, budowę z testami i pierwszą działającą wersję (02.04.2026), aż po iteracje i przekazanie narzędzia (04.06.2026).
     </p>
 
-    <!-- DO UZUPEŁNIENIA (dane od kandydata): przybliżone ramy czasowe poszczególnych
-         etapów (np. diagnoza DD.MM.2025 → pierwsza działająca wersja DD.MM.2026 →
-         iteracje od DD.MM.2026 → przekazanie DD.MM.2026). Bez tych danych etapy celowo
-         pozostają bez dat, żeby niczego nie zmyślać. -->
     <!-- ARTEFAKT PM DO WKLEJENIA (asset od kandydata): zrzut z Miro / diagram procesu
-         AS-IS → TO-BE (bloki decyzyjne, etapy). Gdy będzie gotowy, wstaw jako:
+         AS-IS → TO-BE. Plik dostarczony przez kandydata: "Miro_RAZ DWA.webp".
+         KROK 1: wgraj plik do repo jako assets/images/razdwa/Miro_RAZDWA.webp
+                 (bez spacji w nazwie — spacje psują ścieżki na GitHub Pages).
+         KROK 2: sprawdź realne wymiary webp i wstaw poniższy snippet zamiast tego komentarza:
          <div class="kwcs-gallery-grid kwcs-gallery-grid--single"><div class="gallery-item">
-         <img class="lightbox-trigger" src="/KWdesignnew/assets/images/razdwa/PLIK.webp"
-         width="W" height="H" alt="Proces wyceny AS-IS → TO-BE" loading="lazy"
-         data-caption="Mapa procesu przed i po wdrożeniu narzędzia"></div></div>.
-         Bez realnego pliku nie tworzę makiety, żeby nie zmyślać artefaktu. -->
-    <div class="user-flow">
+         <img class="lightbox-trigger" src="/KWdesignnew/assets/images/razdwa/Miro_RAZDWA.webp"
+         width="W" height="H" alt="Mapa procesu wyceny AS-IS → TO-BE (Miro)" loading="lazy"
+         data-caption="Proces wyceny przed i po wdrożeniu narzędzia — bloki decyzyjne"></div></div>.
+         Nie wstawiam <img> teraz, bo pliku nie ma jeszcze w repo (byłby zepsuty link). -->
+    <div class="user-flow user-flow--6">
       <div class="flow-step">
         <div class="flow-step-icon">01</div>
         <div class="flow-step-label">Diagnoza</div>
-        <div class="flow-step-sub">Obserwacja pracy przy ladzie, rozmowy z właścicielem i operatorem</div>
+        <div class="flow-step-sub">03.03.2026 — obserwacja pracy przy ladzie, rozmowy z właścicielką i operatorem</div>
       </div>
       <div class="flow-arrow">→</div>
       <div class="flow-step">
@@ -268,25 +267,25 @@
       <div class="flow-step">
         <div class="flow-step-icon">04</div>
         <div class="flow-step-label">Działająca wersja</div>
-        <div class="flow-step-sub">Pierwsza działająca wersja gotowa do pracy przy ladzie</div>
+        <div class="flow-step-sub">02.04.2026 — pierwsza działająca wersja gotowa do pracy przy ladzie</div>
       </div>
       <div class="flow-arrow">→</div>
       <div class="flow-step">
         <div class="flow-step-icon">05</div>
-        <div class="flow-step-label">Iteracje na działającej wersji</div>
-        <div class="flow-step-sub">Tryb EXPRESS, warianty produktów, eksport PDF</div>
+        <div class="flow-step-label">Iteracje</div>
+        <div class="flow-step-sub">od 02.04.2026 — tryb EXPRESS, warianty produktów, eksport PDF</div>
       </div>
       <div class="flow-arrow">→</div>
       <div class="flow-step">
         <div class="flow-step-icon">06</div>
-        <div class="flow-step-label">Przekazanie i gotowość</div>
-        <div class="flow-step-sub">Szkolenie właściciela z panelu cen, gotowość do startu produkcyjnego</div>
+        <div class="flow-step-label">Przekazanie</div>
+        <div class="flow-step-sub">04.06.2026 — instrukcja wideo (mp4) dla obsługi i właścicielki</div>
       </div>
     </div>
 
     <div class="kwcs-callout">
       <p>
-        <strong>Zakres nie był zamrożony:</strong> potrzeby, które ujawniły się dopiero na działającej wersji (tryb EXPRESS, warianty produktów, eksport PDF), obsłużyłem jako kolejne iteracje jeszcze przed startem produkcyjnym. <strong>Największe ryzyko</strong> — błąd w logice cenowej, który kosztuje realne pieniądze — zabezpieczył pakiet testów automatycznych, uruchamiany przy każdej zmianie cennika.
+        <strong>Zakres nie był zamrożony:</strong> część potrzeb (jak tryb EXPRESS, warianty produktów czy eksport PDF) zgłaszała właścicielka dopiero na działającej wersji. Przekładałem je na konkretne rozwiązania, proponowałem realizację i wdrażałem jako kolejne iteracje jeszcze przed pełnym startem produkcyjnym. <strong>Największe ryzyko</strong> — błąd w logice cenowej, który kosztuje realne pieniądze — zabezpieczył pakiet testów automatycznych, uruchamiany przy każdej zmianie cennika.
       </p>
     </div>
   </div>
@@ -318,10 +317,9 @@
           <li>Klasyczny backend i dedykowany serwer (świadomie odrzucone — patrz Decyzja 2)</li>
           <li>Gotowy system e-commerce / sklep online (świadomie odrzucone — patrz Decyzja 1)</li>
           <li>Rozbudowana skalowalność ponad potrzeby jednej drukarni</li>
-          <!-- DO UZUPEŁNIENIA (dane od kandydata): jeśli świadomie odłożono też inne
-               obszary (np. płatności online, konta klientów, integracja z księgowością),
-               dopisz je tutaj jednym punktem każdy. Bez potwierdzenia nie dodaję,
-               żeby nie zmyślać granic zakresu. -->
+          <li>Płatności online — poza zakresem obecnej wersji</li>
+          <li>Konta klientów — poza zakresem obecnej wersji</li>
+          <li>Integracja z księgowością — poza zakresem obecnej wersji</li>
         </ul>
       </div>
     </div>
@@ -354,16 +352,17 @@
           <li>Logika wyceny (usługi + CAD) zaimplementowana i pokryta testami automatycznymi</li>
           <li>Panel administracyjny cen gotowy (edycja stawek, warianty)</li>
           <li>Eksport dokumentów PDF i zapis zamówień do Google Sheets</li>
-          <li>Szkolenie właściciela z obsługi panelu cen</li>
+          <li>Szkolenie właścicielki z obsługi panelu cen</li>
+          <li>Instrukcja obsługi nagrana jako wideo (mp4) i przekazana obsłudze oraz właścicielce</li>
         </ul>
       </div>
       <div class="ux-decision-box">
         <div class="ux-label">Pozostaje do startu</div>
         <h4>Przed / na starcie produkcyjnym</h4>
         <ul>
-          <li>Start produkcyjny przy ladzie — planowany na <strong>01.08.2026</strong></li>
-          <li>Przekazanie panelu cen właścicielowi do samodzielnej obsługi</li>
-          <!-- [CZEKA NA DANE] Po starcie produkcyjnym dopisz punkt potwierdzający odbiór:
+          <li>Pełny start produkcyjny przy ladzie — planowany na <strong>01.08.2026</strong></li>
+          <li>Narzędzie jest już częściowo wykorzystywane i realnie przyspiesza pracę</li>
+          <!-- [CZEKA NA DANE] Po pełnym starcie produkcyjnym dopisz punkt z metryką odbioru:
                np. "Potwierdzenie poprawnej pracy przy ladzie po pierwszym tygodniu (DD.MM.2026)".
                Bez realnego potwierdzenia nie publikujemy tego jako faktu. -->
         </ul>
@@ -397,7 +396,7 @@
       <div class="ux-decision-box">
         <div class="ux-label">Decyzja 3</div>
         <h4>Panel cen zamiast zależności od programisty</h4>
-        <p>Właściciel potrzebował samodzielnie aktualizować stawki, dlatego stworzyłem panel administracyjny do zmiany cennika. Dzięki temu firma nie czeka na developera i nie płaci za każdą korektę ceny.</p>
+        <p>Właścicielka potrzebowała samodzielnie aktualizować stawki, dlatego stworzyłem panel administracyjny do zmiany cennika. Dzięki temu firma nie czeka na developera i nie płaci za każdą korektę ceny.</p>
         <p class="razdwa-tradeoff"><strong>Kompromis:</strong> dodatkowa praca nad panelem administracyjnym w zamian za samodzielność klienta po przekazaniu narzędzia.</p>
       </div>
     </div>
@@ -522,19 +521,19 @@
   </div>
 </div>
 
-<h2 class="section-divider" id="razdwa-cennik">Cennik pod kontrolą właściciela</h2>
+<h2 class="section-divider" id="razdwa-cennik">Cennik pod kontrolą właścicielki</h2>
 
 <div class="kwcs-sec">
   <div class="wrap">
-    <p class="razdwa-h2-sub">Zmienia stawki sam, bez dzwonienia do programisty.</p>
+    <p class="razdwa-h2-sub">Zmienia stawki sama, bez dzwonienia do programisty.</p>
     <p class="kwcs-section-lead">
-      Panel administracyjny pozwala właścicielowi <strong>samodzielnie</strong> zmieniać stawki i dodawać warianty — bez psucia struktury danych i bez kosztu za każdą zmianę. Nowe warianty zapisywane są w bazie danych, więc dodane warianty cenowe dostępne są zaraz po dodaniu.
+      Panel administracyjny pozwala właścicielce <strong>samodzielnie</strong> zmieniać stawki i dodawać warianty — bez psucia struktury danych i bez kosztu za każdą zmianę. Nowe warianty zapisywane są w bazie danych, więc dodane warianty cenowe dostępne są zaraz po dodaniu.
     </p>
 
     <div class="kwcs-gallery-grid kwcs-gallery-grid--single" style="margin-bottom:2rem;">
       <div class="gallery-item">
         <img class="lightbox-trigger" src="/KWdesignnew/assets/images/razdwa/ustawienia_cen_RAZDWA.webp" width="676" height="519" alt="Panel administracyjny do zarządzania cenami" loading="lazy" data-caption="Panel cen — widok wszystkich kategorii cennika w panelu administracyjnym">
-        <p class="img-desc"><strong>Panel cen:</strong> Właściciel wybiera kategorię i edytuje stawki bezpośrednio w panelu.</p>
+        <p class="img-desc"><strong>Panel cen:</strong> Właścicielka wybiera kategorię i edytuje stawki bezpośrednio w panelu.</p>
       </div>
     </div>
 
@@ -613,7 +612,7 @@
 
     <div class="kwcs-callout">
       <p>
-        <strong>Efekt dla firmy:</strong> historia zamówień, cennik i codzienna obsługa w jednym miejscu, które właściciel utrzymuje sam — bez programistów i dodatkowych kosztów.
+        <strong>Efekt dla firmy:</strong> historia zamówień, cennik i codzienna obsługa w jednym miejscu, które właścicielka utrzymuje sama — bez programistów i dodatkowych kosztów.
       </p>
     </div>
 
@@ -665,13 +664,13 @@
 
       <div class="result-lead">
         <p>
-          Drukarnia dostała gotowe narzędzie, które skraca wycenę <strong>z godziny do około 5 minut</strong> i porządkuje obsługę zamówień. Mniej <strong>błędów rachunkowych</strong>, a właściciel — po przeszkoleniu — samodzielnie panuje nad cennikiem.
+          Drukarnia dostała gotowe narzędzie, które skraca wycenę <strong>z godziny do około 5 minut</strong> i porządkuje obsługę zamówień. Mniej <strong>błędów rachunkowych</strong>, a właścicielka — po przeszkoleniu — samodzielnie panuje nad cennikiem.
         </p>
       </div>
 
       <div class="kwcs-callout">
         <p>
-          <strong>Status:</strong> narzędzie dostarczone i gotowe do startu produkcyjnego. Start produkcyjny planowany na <strong>01.08.2026</strong>. Wartości czasowe (ok. 5 min, −90% przy CAD) pochodzą z porównania obsługi tego samego typu zamówienia przed i po zbudowaniu narzędzia — nie z długiego okresu użycia produkcyjnego.
+          <strong>Status:</strong> narzędzie jest już częściowo wykorzystywane w drukarni i realnie przyspiesza pracę oraz wspiera wyceny. Pełny start produkcyjny planowany na <strong>01.08.2026</strong>. Wartości czasowe (ok. 5 min, −90% przy CAD) pochodzą z porównania obsługi tego samego typu zamówienia przed i po zbudowaniu narzędzia — nie z długiego okresu pełnego użycia produkcyjnego.
         </p>
       </div>
 
@@ -686,20 +685,19 @@
         </div>
         <div class="result-card">
           <h4>Samodzielność po przekazaniu</h4>
-          <p>Właściciel został przeszkolony z obsługi panelu cen i po starcie produkcyjnym prowadzi cennik oraz rozbudowuje ofertę samodzielnie — bez rozbudowanej infrastruktury i bez powrotu do wykonawcy przy każdej zmianie.</p>
+          <p>Właścicielka została przeszkolona z obsługi panelu cen (instrukcja wideo mp4) i prowadzi cennik oraz rozbudowuje ofertę samodzielnie — bez rozbudowanej infrastruktury i bez powrotu do wykonawcy przy każdej zmianie.</p>
         </div>
       </div>
 
-      <!-- DO UZUPEŁNIENIA (dane od właściciela portfolio): twarde dane potwierdzające
-           adopcję po przekazaniu — np. jak długo narzędzie jest w codziennym użyciu,
-           ile zamówień/wycen przechodzi przez aplikację miesięcznie, ile zmian cennika
-           właściciel wprowadził samodzielnie. Dopóki brak realnych liczb, celowo nie
-           podajemy tu żadnych metryk adopcji, żeby nie zmyślać. -->
+      <!-- DO UZUPEŁNIENIA (dane od kandydata): twarde dane potwierdzające adopcję —
+           np. ile zamówień/wycen przechodzi przez aplikację miesięcznie, ile zmian
+           cennika właścicielka wprowadziła samodzielnie, od kiedy trwa częściowe użycie.
+           Dopóki brak realnych liczb, celowo nie podajemy tu żadnych metryk, żeby nie zmyślać. -->
 
       <!-- ============================================================
            SLOT NA CYTAT KLIENTA (proof)
            Celowo NIEWIDOCZNY do czasu uzyskania prawdziwej opinii
-           właściciela drukarni. Zero fikcyjnych nazwisk.
+           właścicielki drukarni. Zero fikcyjnych nazwisk.
            Aby aktywować: usuń znaczniki komentarza i uzupełnij treść
            oraz podpis (imię, rola, firma). Style .razdwa-quote są już
            gotowe w assets/css/projects.css (scope #case-razdwa-pelne).


### PR DESCRIPTION
## Cel
Przegląd case study **Raz Dwa Druk** okiem rekrutera PM i wdrożenie poprawek pod narrację **Junior / Associate Delivery PM** — bez wymyślania faktów, metryk czy zespołów.

## Diagnoza (co było)
Case study był już mocny i biznesowy (problem, liczby przed→po, decyzje, lekka architektura), ale czytany pod PM miał luki:
- rola brzmiała jak „designer" (Product Design, UX/UI), a nie owner delivery,
- brakowało **timeline'u / etapów** i jawnego **zarządzania scope po starcie**,
- **trade-offy** były ukryte w „zamiast X zrobiłem Y", bez nazwania kompromisu,
- **interesariusze** nie byli nazwani jako stakeholderzy z różnymi celami,
- **handover / adopcja** były słabo wyeksponowane w Rezultacie.

## Zmiany w tym PR
- **Rola (hero + summary):** jasny sygnał *solo, end-to-end* (owned / delivered / decided / trained client) — bez overclaimu seniority i people managementu.
- **Nowa sekcja „Przebieg projektu":** timeline 6 etapów (diagnoza → zakres/decyzje → budowa+testy → uruchomienie → iteracje po starcie → przekazanie) + callout o niezamrożonym scope i o ryzyku logiki cenowej zabezpieczonym testami. Dodany wpis w chapter rail.
- **Interesariusze:** operator (codzienny użytkownik) vs właściciel (decyzje o cenach/budżecie) — nazwani jako dwie perspektywy wyznaczające zakres.
- **Decyzje:** przy każdej z trzech kluczowych decyzji dołożony jawny **Kompromis** (co świadomie odpuszczono).
- **Rezultat:** trzecia karta przeformułowana na **samodzielność po przekazaniu** (adopcja).
- **CSS:** scoped `#case-razdwa-pelne .razdwa-tradeoff` w `projects.css` (bez inline styli, zgodnie z konwencją case studies).
- **Luki oznaczone komentarzami `DO UZUPEŁNIENIA`:** ramy czasowe etapów oraz twarde metryki adopcji — czekają na dane od właściciela portfolio, żeby niczego nie zmyślać.

## Czego świadomie nie robiłem
- Nie ruszałem innych case studies ani logiki aplikacji.
- Nie dodałem żadnych nowych liczb, dat, zespołów, budżetów ani cytatów — slot na cytat klienta pozostaje niewidoczny do czasu realnej opinii.
- Bez ogólnego redesignu — zachowane istniejące, działające elementy wizualne.

## Weryfikacja
- Bilans tagów HTML sprawdzony (div/section zbalansowane).
- Nowe style scoped pod `#case-razdwa-pelne`, brak wpływu na inne strony.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtX1616iPv3UCMcgR8qGvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtX1616iPv3UCMcgR8qGvr)_