### PR TITLE
Fix: mobilny poziomy overflow na wszystkich case studies

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -436,6 +436,7 @@
 .kwcs-cta {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
   padding: 1rem 2rem;
   background: linear-gradient(135deg, #06b6d4 0%, #0284c7 100%);
@@ -449,6 +450,13 @@
   margin: 1.5rem 0;
   border: none;
   cursor: pointer;
+  /* Nie może przekroczyć szerokości kontenera — inaczej długi label (np.
+     "Karoma — identyfikacja wizualna i sklep B2B") rozpycha stronę na mobile.
+     min-width:0 pozwala tekstowi zawinąć się zamiast wypychać poza ekran. */
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  text-align: center;
 }
 
 .kwcs-cta:hover {
@@ -1730,6 +1738,9 @@ body.lightbox-open {
   align-items: center;
   gap: 0.5rem;
   width: fit-content;
+  /* fit-content nie może przekroczyć szerokości kontenera na mobile */
+  max-width: 100%;
+  box-sizing: border-box;
   margin: 2rem auto 0;
   padding: 0.85rem 2rem;
   background: linear-gradient(135deg, #06b6d4 0%, #0284c7 100%);
@@ -1743,6 +1754,28 @@ body.lightbox-open {
   border: none;
   cursor: pointer;
   text-align: center;
+}
+
+/* Responsywne obrazy hero w starszej strukturze case studies
+   (sir-roger, voucher, cyfradruk mają <img class="cover" width="1200">).
+   Scoped reguły #case-*-pelne .cover są bardziej specyficzne i wygrywają. */
+.hero-image .cover,
+.hero-image img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* CTA case studies są też .kw-btn, który wymusza white-space:nowrap
+   (kw-buttons.css) — długi label (np. "Karoma — identyfikacja wizualna i
+   sklep B2B") zostawał w jednej linii i był ucinany przez overflow:hidden.
+   Podnosimy specyficzność (.kwcs-cta.kw-btn = 0,2,0 > .kw-btn = 0,1,0),
+   pozwalamy zawijać i rosnąć w pionie. overflow:hidden zostaje (przycina
+   poświatę hover do zaokrąglenia). */
+.kwcs-cta.kw-btn,
+.hero-image-cta.kw-btn {
+  white-space: normal;
+  line-height: 1.25;
+  height: auto;
 }
 
 .hero-image-cta:hover {


### PR DESCRIPTION
## Cel
Naprawa poziomego przewijania strony w bok na telefonie (390 px) na **każdej** podstronie projektu. Follow-up po zmergowanym #91 (narracja Delivery PM dla RazDwa) — ta gałąź została zrestartowana od świeżego `main`.

## Problem
Na mobile stronę dało się przeciągnąć palcem ~44–173 px w bok mimo braku treści (efekt „rozjechanej" strony). Bug był **pre-existing** (obecny na `main`, nie wprowadzony przez #91) i dotyczył wszystkich case studies.

## Trzy współdzielone przyczyny (wszystkie w `assets/css/projects.css`)
1. **`.kwcs-cta`** — `inline-flex` bez `max-width`; długi label CTA (np. „Karoma — identyfikacja wizualna i sklep B2B" = 499 px) rozpychał stronę. → `max-width:100%` + `box-sizing:border-box`.
2. **`.hero-image-cta`** — `width:fit-content` bez `max-width`; to samo w hero (cyfradruk). → `max-width:100%` + `box-sizing`.
3. **`.hero-image .cover` / `img`** — starsza struktura hero z `<img width="1200">` bez responsywnego capa (sir-roger, voucher). → `max-width:100%; height:auto`.

Dodatkowo: `.kwcs-cta` / `.hero-image-cta` są też `.kw-btn`, który wymusza `white-space:nowrap` + `overflow:hidden` (z `kw-buttons.css`) — przez co długi tekst był **ucinany** zamiast zawijać. Override o wyższej specyficzności (`.kwcs-cta.kw-btn` = 0,2,0 > `.kw-btn` = 0,1,0) pozwala tekstowi zawijać i rosnąć w pionie; `overflow:hidden` zostaje (przycina poświatę hover do zaokrąglenia).

## Weryfikacja (Playwright, Chromium)
- 8 case studies (KW-Design, cyfradruk, karoma, power-of-mind, razdwa, sir-roger, voucher, wizualizacje) + `portfolio.html`.
- 390 px i 1440 px: `docOverflow=0` wszędzie (wcześniej 44–173 px na mobile).
- Desktop bez zmian wizualnych (`white-space:normal` zawija tylko gdy trzeba).
- Wizualnie potwierdzone: długie CTA zawijają się na kilka wyśrodkowanych linii, bez ucięcia tekstu.

## Zakres
Tylko `assets/css/projects.css`. `projects.css` ładuje się wyłącznie na `portfolio.html` i podstronach `projects/*` — strony `index/uslugi/kontakt` nietknięte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtX1616iPv3UCMcgR8qGvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtX1616iPv3UCMcgR8qGvr)_