### PR TITLE
RazDwa: zmniejszenie podglądu tablicy Miro (~połowa rozmiaru)

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -228,9 +228,19 @@
 
 #case-razdwa-pelne .razdwa-miro { margin-bottom: 2rem; }
 #case-razdwa-pelne .razdwa-miro img {
-  max-width: 100%;
+  /* Miro to dowód, że było planowanie — wystarczy podgląd ~połowy rozmiaru,
+     pełny widok dostępny po kliknięciu (lightbox). width:100% + max-width
+     trzyma responsywność na mobile (nie przekroczy szerokości ekranu). */
+  display: block;
+  width: 100%;
+  max-width: 380px;
   height: auto;
+  margin: 0 auto;
   border-radius: 12px;
+  cursor: zoom-in;
+}
+#case-razdwa-pelne .razdwa-miro .img-desc {
+  text-align: center;
 }
 
 #case-razdwa-pelne .kwcs-hero-body .hero-image {


### PR DESCRIPTION
## Cel
Podgląd tablicy Miro (mapa procesu AS-IS → TO-BE) w sekcji „Przebieg projektu" był zbyt duży. Zmniejszam go do ~połowy rozmiaru.

## Zmiana
`assets/css/projects.css` — `#case-razdwa-pelne .razdwa-miro img`:
- `max-width: 380px` (wcześniej pełna szerokość ~760 px) + wyśrodkowanie
- `width: 100%` + `max-width` → responsywność na mobile (nie przekracza ekranu)
- `cursor: zoom-in` — pełny widok nadal dostępny po kliknięciu (lightbox)

## Uzasadnienie
Podgląd wystarcza jako dowód, że etap planowania w Miro faktycznie miał miejsce; szczegóły dostępne po powiększeniu.

## Weryfikacja (Playwright)
- 1440 px: obraz 380 px, `docOverflow=0`
- 390 px: obraz 326 px (responsywny), `docOverflow=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtX1616iPv3UCMcgR8qGvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtX1616iPv3UCMcgR8qGvr)_