### PR TITLE
Karoma: reframe case study jako Delivery PM / launch delivery

### DIFF
--- a/projects/karoma.html
+++ b/projects/karoma.html
@@ -64,6 +64,7 @@
         <li><a class="razdwa-chapter-link" href="#karoma-problem" data-rail-target="karoma-problem" title="Problem: nowa branża bez tożsamości" aria-label="Problem: nowa branża bez tożsamości">Problem</a></li>
         <li><a class="razdwa-chapter-link" href="#karoma-rola" data-rail-target="karoma-rola" title="Moja rola" aria-label="Moja rola">Moja rola</a></li>
         <li><a class="razdwa-chapter-link" href="#karoma-decyzje" data-rail-target="karoma-decyzje" title="Kluczowe decyzje projektowe" aria-label="Kluczowe decyzje projektowe">Kluczowe decyzje</a></li>
+        <li><a class="razdwa-chapter-link" href="#karoma-launch" data-rail-target="karoma-launch" title="Przebieg launchu" aria-label="Przebieg launchu">Przebieg launchu</a></li>
         <li><a class="razdwa-chapter-link" href="#karoma-branding" data-rail-target="karoma-branding" title="Branding i system identyfikacji" aria-label="Branding i system identyfikacji">Branding</a></li>
         <li><a class="razdwa-chapter-link" href="#karoma-strona" data-rail-target="karoma-strona" title="Realizacja strony internetowej" aria-label="Realizacja strony internetowej">Realizacja strony</a></li>
         <li><a class="razdwa-chapter-link" href="#karoma-wnioski" data-rail-target="karoma-wnioski" title="Wnioski z projektu" aria-label="Wnioski z projektu">Wnioski</a></li>
@@ -73,17 +74,19 @@
 
     <div class="kwcs-hero-head">
       <div class="wrap">
-        <p class="eyebrow">Prezentacja procesu budowy i integracji sklepu B2B</p>
-        <h1>Karoma<br>od projektu logo do pełnego sklepu z asortymentem CNC</h1>
-        <p class="sub">Nowa marka + sklep WooCommerce + dedykowane skrypty pod proces B2B. Od analizy do wdrożenia.</p>
+        <p class="eyebrow">Launch delivery: nowa marka i sklep B2B end-to-end</p>
+        <h1>Karoma<br>nowa marka i sklep B2B dostarczone end-to-end w 2 miesiące</h1>
+        <p class="sub">Nowa marka + sklep WooCommerce + dedykowane skrypty pod proces B2B. Od analizy do wdrożenia i przekazania klientowi.</p>
         <div class="pm-hero-meta">
-          <span><strong>Rola</strong> Digital Product Designer</span>
+          <span><strong>Rola</strong> Delivery / end-to-end owner (brand → sklep → integracje → szkolenie)</span>
           <span class="pm-meta-sep">·</span>
-          <span><strong>Czas</strong> ~2 miesiące</span>
+          <span><strong>Model</strong> Freelance, równolegle do etatu</span>
           <span class="pm-meta-sep">·</span>
-          <span><strong>Zakres</strong> Branding · Sklep · Wdrożenie</span>
+          <span><strong>Czas</strong> 2 miesiące</span>
           <span class="pm-meta-sep">·</span>
-          <span><strong>Efekt</strong> Spójna marka + działający sklep B2B</span>
+          <span><strong>Zakres</strong> Brand · Sklep · Integracje · Szkolenie</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Efekt</strong> Marka na 7 nośnikach + produkcyjny sklep B2B, przekazany klientowi</span>
         </div>
       </div>
     </div>
@@ -122,7 +125,7 @@
           </div>
           <div class="razdwa-summary-cell">
             <div class="label">Moja rola</div>
-            <div class="value">Brand design, UX/UI, wdrożenie sklepu, integracje płatności, dedykowane skrypty JS i szkolenie klienta.</div>
+            <div class="value">End-to-end owner dostawy — freelance, równolegle do etatu: od wywiadu i strategii marki, przez sklep i integracje płatności, po launch i szkolenie klienta.</div>
           </div>
           <div class="razdwa-summary-cell">
             <div class="label">Rozwiązanie</div>
@@ -141,7 +144,7 @@
 
     <div class="kwcs-sec">
       <div class="wrap">
-        <p class="razdwa-h2-sub">Marka, sklep i prezentacja produktów — wszystko naraz, w 4miesiące.</p>
+        <p class="razdwa-h2-sub">Marka, sklep i prezentacja produktów — wszystko naraz, w 2 miesiące.</p>
         <p class="kwcs-section-lead">
           Firma zmieniła profil działalności —   z produkcji kół gumowych na frezy i narzędzia CNC dla klientów B2B. W nowej branży zaczynała bez rozpoznawalnej marki i bez kanału sprzedaży online.
         </p>
@@ -165,8 +168,19 @@
       <div class="wrap">
         <p class="razdwa-h2-sub">Jeden wykonawca odpowiedzialny za całość — od wywiadu z klientem po działający sklep.</p>
         <p class="kwcs-section-lead">
-          Projekt prowadziłem od początku do końca: od wywiadu z klientem i analizy branży, przez brand design i budowę sklepu, po wdrożenie produkcyjne i szkolenie klienta z obsługi systemu.
+          Projekt prowadziłem od początku do końca: od wywiadu z klientem i analizy branży, przez brand design i budowę sklepu, po wdrożenie produkcyjne i szkolenie klienta z obsługi systemu. Współpraca w modelu freelance, równolegle do etatu — z jednym punktem kontaktu po stronie wykonawcy.
         </p>
+
+        <div class="ux-decision-grid">
+          <div class="ux-decision-box">
+            <h4>Stakeholder: decydent B2B</h4>
+            <p>Właściciel firmy jako decydent — zatwierdzał kierunek marki, zakres wdrożenia i priorytety. Główny odbiorca decyzji strategicznych i akceptacji kolejnych rund logo.</p>
+          </div>
+          <div class="ux-decision-box">
+            <h4>Stakeholder: obsługa zamówień</h4>
+            <p>Osoba obsługująca zamówienia jako docelowy użytkownik panelu sklepu. Pod nią projektowałem prostotę obsługi i do niej kierowałem szkolenie z systemu po odbiorze.</p>
+          </div>
+        </div>
 
         <div class="ux-decision-box">
           <h4>Dwie strefy pracy w jednym projekcie</h4>
@@ -234,6 +248,90 @@
             <p>Klient B2B decyduje na podstawie danych, nie wrażeń wizualnych. Layout kart produktów priorytetyzuje wymiary, kod katalogowy i materiał — nie minimalistyczny design typowy dla sklepów konsumenckich.</p>
           </div>
         </div>
+      </div>
+    </div>
+
+    <h2 class="section-divider" id="karoma-launch">Jak prowadziłem launch</h2>
+
+    <div class="kwcs-sec">
+      <div class="wrap">
+        <p class="razdwa-h2-sub">Kryteria sukcesu, etapy, ryzyka i przekazanie — czyli za co odpowiadałem jako właściciel dostawy.</p>
+
+        <div class="ux-decision-box">
+          <h4>Definicja sukcesu launchu (ustalona na starcie)</h4>
+          <p>Spójna marka na wszystkich nośnikach handlowych, sklep przyjmujący zamówienia z działającą płatnością online oraz klient zdolny prowadzić sklep samodzielnie po odbiorze — bez dalszych prac deweloperskich po launchu.</p>
+        </div>
+
+        <div class="contribution-grid--razdwa">
+          <div class="contribution-cell contribution-cell--solo">
+            <h3><span class="dot"></span>Przebieg (2 miesiące, etapami)</h3>
+            <ul>
+              <li><strong>Etap 1 — Discovery:</strong> wywiad z klientem i analiza branży CNC (3 liderzy jako punkt odniesienia)</li>
+              <li><strong>Etap 2 — Brand:</strong> logo w 3 rundach iteracji + system identyfikacji, test na 7 nośnikach</li>
+              <li><strong>Etap 3 — Sklep:</strong> budowa WooCommerce i dedykowane skrypty JS (koszyk, kategoryzator)</li>
+              <li><strong>Etap 4 — Integracje i content:</strong> Przelewy24, SEO, SSL, RODO, obróbka zdjęć produktowych</li>
+              <li><strong>Etap 5 — Testy i launch:</strong> testy funkcjonalne → launch produkcyjny</li>
+              <li><strong>Etap 6 — Handover:</strong> szkolenie klienta i przekazanie sklepu</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="ux-decision-grid">
+          <div class="ux-decision-box">
+            <div class="ux-label">Ryzyko 1</div>
+            <h4>Aktualizacje platformy psują customizacje</h4>
+            <p><strong>Mitygacja:</strong> zamiast wtyczek napisałem skrypty <em>nad</em> WooCommerce (pływający koszyk, kategoryzator), odporne na aktualizacje rdzenia platformy.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">Ryzyko 2</div>
+            <h4>Klient zostaje sam z systemem, którego nie zna</h4>
+            <p><strong>Mitygacja:</strong> wdrożenie zamknąłem sesją szkoleniową i przekazaniem, tak by obsługa produktów i zamówień była możliwa bez zewnętrznego wsparcia.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">Ryzyko 3</div>
+            <h4>Content zjada harmonogram</h4>
+            <p><strong>Mitygacja:</strong> dziesiątki zdjęć produktowych wymagały obróbki nieujętej w pierwotnym planie — po tym projekcie content jest osobną pozycją wyceny (patrz „Wnioski").</p>
+          </div>
+        </div>
+
+        <div class="ux-decision-box">
+          <h4>Poza zakresem (out of scope)</h4>
+          <p>Bieżące prowadzenie sprzedaży i marketing po launchu, zarządzanie stanami magazynowymi oraz obsługa klientów końcowych pozostały po stronie klienta. Sklep przekazano jako gotowy do samodzielnego prowadzenia.</p>
+        </div>
+
+        <div class="ux-decision-box">
+          <h4>Flow zamówienia i płatności</h4>
+          <p>Produkt → pływający koszyk (z paskiem progu darmowej dostawy) → checkout → płatność Przelewy24 → potwierdzenie. Koszyk pamięta zawartość po odświeżeniu strony, a pasek postępu wskazuje, ile brakuje do darmowej dostawy.</p>
+        </div>
+
+        <div class="contribution-grid--razdwa">
+          <div class="contribution-cell contribution-cell--solo">
+            <h3><span class="dot"></span>Checklista Go-Live</h3>
+            <ul>
+              <li>Testy funkcjonalne sklepu i procesu zamówienia</li>
+              <li>Płatności Przelewy24 podłączone i sprawdzone</li>
+              <li>Certyfikat SSL aktywny</li>
+              <li>Zgodność RODO (polityka, zgody)</li>
+              <li>Podstawowe SEO wdrożone</li>
+              <li>Dedykowane skrypty JS (koszyk, kategoryzator) działające na produkcji</li>
+              <li>Zdjęcia i opisy produktów opublikowane</li>
+              <li>Szkolenie klienta przeprowadzone, sklep przekazany</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="contribution-grid--razdwa">
+          <div class="contribution-cell contribution-cell--solo">
+            <h3><span class="dot"></span>Handover — zakres szkolenia</h3>
+            <ul>
+              <li>Dodawanie i edycja produktów w panelu</li>
+              <li>Obsługa zamówienia od wpłynięcia do realizacji</li>
+              <li>Podstawy płatności Przelewy24</li>
+              <li>Zarządzanie treścią sklepu</li>
+            </ul>
+          </div>
+        </div>
+
       </div>
     </div>
 
@@ -376,15 +474,15 @@
         <div class="kwcs-trio">
           <article class="kwcs-card">
             <h3>Content to oddzielna pozycja w wycenie</h3>
-            <p>Dziesiątki produktów wymagały profesjonalnej obróbki zdjęć — nie było tego w pierwotnym planie i zjadło znaczną część buforu czasowego. Od tego projektu każda wycena e-commerce ma osobny wiersz na content: zdjęcia, opisy, kategoryzacja.</p>
+            <p><strong>Sytuacja:</strong> dziesiątki produktów wymagały profesjonalnej obróbki zdjęć i opisów. <strong>Zadanie:</strong> zmieścić content w pierwotnym harmonogramie. <strong>Akcja:</strong> obróbka nie była w pierwotnym planie i zjadła znaczną część buforu czasowego. <strong>Rezultat:</strong> launch dowieziony, a od tego projektu content to osobny wiersz w każdej wycenie e-commerce — zdjęcia, opisy, kategoryzacja.</p>
           </article>
           <article class="kwcs-card">
             <h3>Szkolenie klienta jest częścią produktu</h3>
-            <p>Sklep bez szkolenia to sklep, który za miesiąc przestaje działać poprawnie. Wdrożenie Karoma zamknąłem sesją szkoleniową z obsługi systemu — klient zarządza produktami i zamówieniami samodzielnie od pierwszego dnia po odbiorze.</p>
+            <p>Sklep bez szkolenia to sklep, który za miesiąc przestaje działać poprawnie. Wdrożenie Karoma zamknąłem sesją szkoleniową z obsługi systemu i przekazaniem — tak, by klient mógł zarządzać produktami i zamówieniami bez zewnętrznego wsparcia.</p>
           </article>
           <article class="kwcs-card">
             <h3>Brand najpierw, sklep potem</h3>
-            <p>Prowadzenie obu ścieżek równolegle wymusiło cofanie niektórych decyzji projektowych po finalizacji logo. Następnym razem: realizuje identyfikacje jako pierwszą — dopiero potem zaczynam budować sklep.</p>
+            <p><strong>Sytuacja:</strong> marka i sklep były potrzebne jednocześnie w oknie 2 miesięcy. <strong>Zadanie:</strong> zdecydować, co prowadzić najpierw przy równoległej pracy. <strong>Akcja:</strong> prowadziłem obie ścieżki równolegle, co wymusiło cofanie części decyzji sklepowych po finalizacji logo. <strong>Rezultat:</strong> sklep dowieziony na czas; wniosek na przyszłość — najpierw domknąć identyfikację, potem budować sklep.</p>
           </article>
         </div>
       </div>
@@ -394,12 +492,12 @@
 
     <div class="kwcs-sec">
       <div class="wrap">
-        <p class="razdwa-h2-sub">Uruchomione w 2 miesiące — klient obsługuje zamówienia samodzielnie od dnia wdrożenia.</p>
+        <p class="razdwa-h2-sub">Dostarczone w 2 miesiące: marka na 7 nośnikach + produkcyjny sklep B2B z płatnościami online, przekazany klientowi.</p>
         <div class="kwcs-result">
           <h3 class="kwcs-result-title">Co zostało wdrożone</h3>
           <div class="result-lead">
             <p>
-              Karoma uruchomiła sklep gotowy na zamówienia B2B — z własną identyfikacją wizualną, integracją Przelewy24 i dedykowanymi skryptami — w 2 miesiące od pomysłu. Nie dysponuję danymi sprzedażowymi klienta. Mierzę to, co wdrożyłem: działający system, z którego klient obsługuje zamówienia samodzielnie od dnia odbioru.
+              Karoma uruchomiła sklep gotowy na zamówienia B2B — z własną identyfikacją wizualną, integracją Przelewy24 i dedykowanymi skryptami — w 2 miesiące od pomysłu. Nie dysponuję danymi sprzedażowymi klienta. Mierzę to, co dostarczyłem: działający system, przeszkolony klient i przekazanie, po którym sklep może być prowadzony samodzielnie, bez dalszych prac deweloperskich.
             </p>
           </div>
           <div class="result-cards">
@@ -412,8 +510,8 @@
               <p>WooCommerce z Przelewy24, dedykowanym koszykiem i kategoryzatorem — uruchomiony produkcyjnie bez dalszych prac deweloperskich po launchcie.</p>
             </div>
             <div class="result-card">
-              <h4>Klient przejął obsługę</h4>
-              <p>Szkolenie z obsługi po odbiorze. Klient dodaje produkty, obsługuje zamówienia i zarządza treścią bez zewnętrznego wsparcia.</p>
+              <h4>Klient przejął obsługę na odbiorze</h4>
+              <p>Szkolenie z obsługi po odbiorze i przekazanie systemu. Klient został przygotowany do samodzielnego dodawania produktów, obsługi zamówień i zarządzania treścią — bez zewnętrznego wsparcia.</p>
             </div>
           </div>
           <!-- ============================================================


### PR DESCRIPTION
## Cel
Przerobić case Karoma tak, aby był czytany jako **Delivery PM / launch delivery**, a nie brand showcase. Wdrożone tylko bezpieczne zmiany — bez wymyślania faktów, revenue, SKU, adopcji ani people managementu.

## Co dodane / zmienione (`projects/karoma.html`)
- **Model współpracy:** freelance, równolegle do etatu (hero-meta + „Moja rola").
- **Etykieta roli:** „Digital Product Designer" → **Delivery / end-to-end owner** (brand → sklep → integracje → szkolenie).
- **Stakeholderzy:** dwie role rozdzielone — właściciel B2B jako decydent + osoba obsługująca zamówienia.
- **Nowa sekcja „Jak prowadziłem launch"** (+ wpis w chapter rail):
  - definicja sukcesu launchu,
  - timeline w 6 etapach,
  - 3 ryzyka + mitygacje,
  - out of scope,
  - flow zamówienia / płatności,
  - checklista Go-Live,
  - handover / zakres szkolenia.
- **Ostrożny status adopcji:** „przekazanie na odbiorze", klient *przygotowany* do samodzielnego prowadzenia — zamiast twierdzenia o realnej adopcji.
- **One-liner launch delivery** w hero i w rezultacie.
- **2 lekcje w formacie STAR:** priorytetyzacja brand vs sklep oraz scope creep content.
- **Mniej design-showcase** w hero i eyebrow.
- Fix literówki „4miesiące" → „2 miesiące".

## Nie ruszane (świadomie)
Problem biznesowy, 3 decyzje z trade-offami, metryki delivery (0→7 nośników, Woo + Przelewy24), scope creep content jako lekcja, logika launchowa w treści, screeny / dowody wizualne.

## Weryfikacja
Render Playwright 1440px + 390px, `docOverflow=0` na obu; rail targets == section ids; balans tagów `div` OK. Reużyte istniejące klasy CSS (`ux-decision-box`, `contribution-cell--solo`, `razdwa-*`) — zero nowego CSS.

## Wymaga potwierdzenia właściciela
- Model freelance/równolegle do etatu — założony z briefu, potwierdź.
- Dokładny zakres szkolenia (agenda handover) — lista oparta na treści case.
- Czy istnieje realny artefakt checklisty Go-Live do podłączenia (screen/plik).
- Czy adopcja jest dziś potwierdzona obserwacyjnie (wtedy można wzmocnić copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNzgydvGjCEDfB1QxsdrJH)_