### PR TITLE
CyfraDruk: przepisanie na spójny format Tier 1 (bez people leadership)

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -4557,3 +4557,177 @@ body { overflow-x: hidden; }
   font-weight: 600;
   color: #334155;
 }
+
+/* ========================================
+   #CASE-CYFRADRUK-PELNE — scoped overrides
+   Wdrożenie wzorca RazDwa/Karoma/Power-of-Mind pod slug cyfradruk.
+   Narzędzie wewnętrzne pre-press (Adobe Illustrator / CEP). Akcent
+   marki: teal #0292AA (spójnie z rodziną). Scope #case-cyfradruk-pelne
+   — nie rusza innych case studies.
+   ======================================== */
+#case-cyfradruk-pelne .section-divider + .kwcs-sec { padding-top: 1.25rem; }
+
+/* Inline <code> z długimi, nierozdzielnymi tokenami (np. CSInterface.evalScript())
+   przepełniał wąski viewport 390px. Pozwalamy łamać w dowolnym miejscu. */
+#case-cyfradruk-pelne code {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+/* Kontener rozciągnięty na pełną szerokość viewportu (standalone + portfolio) */
+#case-cyfradruk-pelne {
+  max-width: none !important;
+  width: auto;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+}
+
+/* Desktop ≥1280px — content odsunięty za fixed rail, full-bleed kolorowych sekcji */
+@media (min-width: 1280px) {
+  #case-cyfradruk-pelne { padding-left: 216px; padding-right: 216px; --wrap-max: 1240px; }
+  #case-cyfradruk-pelne > .razdwa-summary,
+  #case-cyfradruk-pelne > .kwcs-sec--alt {
+    margin-left: -216px;
+    margin-right: -216px;
+    padding-left: calc(216px + 1rem);
+    padding-right: calc(216px + 1rem);
+  }
+}
+/* Laptop 1101–1279px — węższy rail */
+@media (min-width: 1101px) and (max-width: 1279px) {
+  #case-cyfradruk-pelne { padding-left: 184px; padding-right: 184px; --wrap-max: 1120px; }
+  #case-cyfradruk-pelne > .razdwa-summary,
+  #case-cyfradruk-pelne > .kwcs-sec--alt {
+    margin-left: -184px;
+    margin-right: -184px;
+    padding-left: calc(184px + 1rem);
+    padding-right: calc(184px + 1rem);
+  }
+}
+/* Tablet i mobile ≤1100px — rail jako górny pasek */
+@media (max-width: 1100px) {
+  #case-cyfradruk-pelne { padding-left: 0; }
+}
+
+/* Podtytuł H2 — wyśrodkowany pod tytułem (section-divider jest center) */
+#case-cyfradruk-pelne .razdwa-h2-sub {
+  max-width: 760px;
+  margin: -0.25rem auto 1.25rem;
+  text-align: center;
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 1.15rem;
+  line-height: 1.5;
+}
+
+/* Stat-num na teal akcent marki (spójnie z rodziną case studies) */
+#case-cyfradruk-pelne .razdwa-stat-num { color: #0292AA; }
+
+/* Chapter rail — subtelniejszy, nie konkuruje z treścią */
+#cyfra-chapter-rail {
+  box-shadow: 0 2px 12px rgba(15, 23, 42, 0.07);
+  border-color: #edf0f4;
+  background: rgba(255, 255, 255, 0.90);
+}
+#cyfra-chapter-rail .razdwa-chapter-rail-label { color: #94a3b8; }
+
+/* Hero image — realne proporcje 1254x1254 (kwadrat), contain bez letterboxu */
+#case-cyfradruk-pelne .kwcs-hero-body .hero-image {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+#case-cyfradruk-pelne .kwcs-hero-body .hero-image .cover {
+  display: block;
+  width: 100%;
+  max-width: 640px;
+  height: auto;
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
+  border-radius: 14px;
+  box-shadow: 0 24px 60px -28px rgba(15, 23, 42, 0.32);
+}
+
+/* Hero CTA na mobile — border-box, żeby padding nie wychodził poza kontener */
+#case-cyfradruk-pelne .hero-image-cta {
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+/* result-cards 3-kolumnowe (jak power-of-mind) */
+#case-cyfradruk-pelne .result-cards { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 768px) {
+  #case-cyfradruk-pelne .result-cards { grid-template-columns: 1fr; }
+}
+
+/* Rezultat bez pływającej karty — neutralizacja kolizji z portfolio.css */
+#case-cyfradruk-pelne .kwcs-result {
+  display: block;
+  background: none;
+  border: none;
+  backdrop-filter: none;
+  border-radius: 0;
+  box-shadow: none;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+}
+#case-cyfradruk-pelne .kwcs-result p { font-weight: 400; }
+#case-cyfradruk-pelne .kwcs-card { border: none; backdrop-filter: none; }
+
+/* Blok zaproszenia (CTA końcowe) + slot cytatu — odpowiednik karoma/razdwa */
+#case-cyfradruk-pelne .result-invite {
+  margin-top: 2.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.3);
+  text-align: center;
+}
+#case-cyfradruk-pelne .result-invite h3 {
+  font-size: 1.5rem;
+  line-height: 1.3;
+  margin: 0 0 0.75rem;
+  color: #0f172a;
+}
+#case-cyfradruk-pelne .result-invite p {
+  max-width: 640px;
+  margin: 0 auto 0.5rem;
+  color: #475569;
+}
+#case-cyfradruk-pelne .result-invite-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+#case-cyfradruk-pelne .result-invite-actions .kwcs-cta { margin: 0.5rem 0; }
+#case-cyfradruk-pelne .kwcs-cta--ghost {
+  background: transparent;
+  color: #0284c7;
+  box-shadow: none;
+  border: 1px solid #0284c7;
+}
+#case-cyfradruk-pelne .kwcs-cta--ghost:hover {
+  background: rgba(2, 132, 199, 0.08);
+  box-shadow: none;
+}
+
+/* Gotowy styl cytatu — aktywny po odkomentowaniu slotu w HTML */
+#case-cyfradruk-pelne .razdwa-quote {
+  margin: 2.5rem auto 0;
+  max-width: 720px;
+  padding: 1.75rem 2rem;
+  border-left: 4px solid #06b6d4;
+  background: rgba(6, 182, 212, 0.07);
+  border-radius: 0 0.75rem 0.75rem 0;
+}
+#case-cyfradruk-pelne .razdwa-quote blockquote {
+  margin: 0 0 1rem;
+  font-size: 1.2rem;
+  line-height: 1.6;
+  font-style: italic;
+  color: #0f172a;
+}
+#case-cyfradruk-pelne .razdwa-quote figcaption {
+  font-weight: 600;
+  color: #334155;
+}

--- a/projects/cyfradruk.html
+++ b/projects/cyfradruk.html
@@ -5,26 +5,26 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <title>Case Study: CyfraDruk – Wtyczka automatyzująca pre-press | Karol Wyszyński</title>
-  <meta name="description" content="Panel CEP dla Adobe Illustrator eliminujący błędy grubości linii i obiektów przed drukiem. Redukcja czasu sprawdzania pliku z 15 minut do 1 sekundy.">
-  <meta name="keywords" content="case study, Adobe Illustrator, CEP panel, ExtendScript, automatyzacja DTP, pre-press, grubość linii, CMYK, Pantone, wtyczka druk">
+  <title>CyfraDruk — automatyzacja kontroli pliku przed drukiem | Karol Wyszyński</title>
+  <meta name="description" content="Wewnętrzna wtyczka do Adobe Illustrator w PolonisDruk: ręczna inspekcja pliku 5–20 min zastąpiona skanem w ~1 s i pełną kontrolą w ~1 min. Onboarding operatora ≤ 30 min. Case study end-to-end.">
+  <meta name="keywords" content="case study, automatyzacja DTP, pre-press, Adobe Illustrator, CEP panel, ExtendScript, kontrola pliku, grubość linii, CMYK, Pantone, narzędzie wewnętrzne">
   <meta name="author" content="Karol Wyszyński">
   <meta name="robots" content="index, follow">
 
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://kwyszynski.pl/projects/cyfradruk.html">
-  <meta property="og:title" content="Case Study: CyfraDruk | Karol Wyszyński">
-  <meta property="og:description" content="Wtyczka CEP dla Adobe Illustrator – automatyczny skaner błędów DTP przed drukiem. 15x szybciej, 100% dokładności.">
-  <meta property="og:image" content="https://kwyszynski.pl/assets/images/cyfradruk-mockup1.webp">
-  <meta property="og:image:width" content="1200">
-  <meta property="og:image:height" content="630">
+  <meta property="og:title" content="CyfraDruk — automatyzacja kontroli pliku przed drukiem">
+  <meta property="og:description" content="Wewnętrzna wtyczka do Adobe Illustrator w PolonisDruk. Ręczna inspekcja 5–20 min → ~1 s skanu + ~1 min pełnej kontroli. Zaprojektowana i wdrożona end-to-end.">
+  <meta property="og:image" content="https://kwyszynski.pl/assets/images/Automatyzacja_liniekolory.webp">
+  <meta property="og:image:width" content="1254">
+  <meta property="og:image:height" content="1254">
   <meta property="og:locale" content="pl_PL">
   <meta property="og:site_name" content="Karol Wyszyński Portfolio">
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Case Study: CyfraDruk | Karol Wyszyński">
-  <meta name="twitter:description" content="Wtyczka CEP dla Adobe Illustrator – automatyczny skaner błędów DTP.">
-  <meta name="twitter:image" content="https://kwyszynski.pl/assets/images/cyfradruk-mockup1.webp">
+  <meta name="twitter:title" content="CyfraDruk — automatyzacja kontroli pliku przed drukiem">
+  <meta name="twitter:description" content="Wewnętrzna wtyczka do Adobe Illustrator — skan pliku przed drukiem jednym kliknięciem.">
+  <meta name="twitter:image" content="https://kwyszynski.pl/assets/images/Automatyzacja_liniekolory.webp">
 
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicon-16x16.png">
@@ -37,9 +37,9 @@
   {
     "@context": "https://schema.org",
     "@type": "CreativeWork",
-    "name": "CyfraDruk — wtyczka automatyzująca pre-press",
-    "description": "Panel CEP dla Adobe Illustrator eliminujący błędy grubości linii i obiektów przed drukiem. Redukcja czasu sprawdzania pliku z 15 minut do 1 sekundy.",
-    "image": "https://kwyszynski.pl/assets/images/cyfradruk-mockup1.webp",
+    "name": "CyfraDruk — automatyzacja kontroli pliku przed drukiem",
+    "description": "Wewnętrzna wtyczka do Adobe Illustrator w PolonisDruk, która zastąpiła ręczną inspekcję pliku przed drukiem skanem jednym kliknięciem. Inspekcja z 5–20 minut do ~1 s skanu i ~1 min pełnej kontroli. Onboarding operatora poniżej 30 minut.",
+    "image": "https://kwyszynski.pl/assets/images/Automatyzacja_liniekolory.webp",
     "url": "https://kwyszynski.pl/projects/cyfradruk.html",
     "author": {
       "@type": "Person",
@@ -65,344 +65,397 @@
         Portfolio
       </a>
       <span class="kwcs-breadcrumb-sep">/</span>
-      <span class="kwcs-breadcrumb-current">CyfraDruk — Wtyczka pre-press</span>
+      <span class="kwcs-breadcrumb-current">CyfraDruk — Automatyzacja kontroli pliku</span>
     </div>
   </nav>
 
   <!-- ================================================================
-       CASE STUDY: CyfraDruk – Wtyczka automatyzująca pre-press
+       CASE STUDY: CyfraDruk — automatyzacja kontroli pliku przed drukiem
+       Narzędzie wewnętrzne (PolonisDruk). Bez people leadership.
   ================================================================ -->
 
-  <section class="kwcs" id="cyfradruk" data-project="cyfradruk" aria-label="Case Study: CyfraDruk – Wtyczka automatyzująca pre-press">
+  <section class="kwcs" id="case-cyfradruk-pelne" aria-label="Pełne Case Study: CyfraDruk — automatyzacja kontroli pliku przed drukiem">
 
     <!-- ============================================================
-         1. HERO HEAD — eyebrow, h1, sub, meta
+         Chapter rail — sticky TOC (klasa razdwa-chapter-rail wymagana
+         przez obserwator widoczności w portfolio.js)
+    ============================================================ -->
+    <nav class="razdwa-chapter-rail" id="cyfra-chapter-rail" aria-label="Spis treści case study">
+      <div class="razdwa-chapter-rail-label">Rozdziały</div>
+      <ul class="razdwa-chapter-rail-list">
+        <li><a class="razdwa-chapter-link" href="#cyfra-summary" data-rail-target="cyfra-summary" title="W skrócie" aria-label="W skrócie">W skrócie</a></li>
+        <li><a class="razdwa-chapter-link" href="#cyfra-kontekst" data-rail-target="cyfra-kontekst" title="Problem: ręczna inspekcja i ryzyko przedruku" aria-label="Problem: ręczna inspekcja i ryzyko przedruku">Problem</a></li>
+        <li><a class="razdwa-chapter-link" href="#cyfra-cel" data-rail-target="cyfra-cel" title="Cel i kryteria sukcesu" aria-label="Cel i kryteria sukcesu">Cel</a></li>
+        <li><a class="razdwa-chapter-link" href="#cyfra-przebieg" data-rail-target="cyfra-przebieg" title="Przebieg projektu — od wywiadu do adopcji" aria-label="Przebieg projektu — od wywiadu do adopcji">Przebieg</a></li>
+        <li><a class="razdwa-chapter-link" href="#cyfra-decyzje" data-rail-target="cyfra-decyzje" title="Trzy kluczowe decyzje" aria-label="Trzy kluczowe decyzje">Decyzje</a></li>
+        <li><a class="razdwa-chapter-link" href="#cyfra-ryzyka" data-rail-target="cyfra-ryzyka" title="Ryzyka i mitigacje" aria-label="Ryzyka i mitigacje">Ryzyka</a></li>
+        <li><a class="razdwa-chapter-link" href="#cyfra-dzialanie" data-rail-target="cyfra-dzialanie" title="Jak działa narzędzie" aria-label="Jak działa narzędzie">Jak działa</a></li>
+        <li><a class="razdwa-chapter-link" href="#cyfra-wdrozenie" data-rail-target="cyfra-wdrozenie" title="Wdrożenie, przekazanie i artefakty" aria-label="Wdrożenie, przekazanie i artefakty">Wdrożenie</a></li>
+        <li><a class="razdwa-chapter-link" href="#cyfra-rezultat" data-rail-target="cyfra-rezultat" title="Metryki, STAR i rezultat" aria-label="Metryki, STAR i rezultat">Rezultat</a></li>
+      </ul>
+    </nav>
+
+    <!-- ============================================================
+         Hero Head
     ============================================================ -->
     <div class="kwcs-hero-head">
       <div class="wrap">
-        <p class="eyebrow">Case Study · Automatyzacja Adobe Illustrator</p>
-        <h1>CyfraDruk<br>wtyczka, która wykrywa błędy pre-press przed drukiem</h1>
+        <p class="eyebrow">Case Study · Automatyzacja pre-press (narzędzie wewnętrzne)</p>
+        <h1>CyfraDruk<br>automatyzacja kontroli pliku przed drukiem</h1>
         <p class="sub">
-          Panel CEP dla Adobe Illustrator, który eliminuje niewidzialne błędy grubości linii i mikro-obiektów — jedno kliknięcie zamiast tysięcy ręcznych sprawdzeń.
+          Wewnętrzna wtyczka do Adobe Illustrator, która zastąpiła ręczną inspekcję grubości linii i kolorów jednym skanem. Zaprojektowana, zbudowana i wdrożona end-to-end w PolonisDruk.
         </p>
         <div class="pm-hero-meta">
-          <span><strong>Rola</strong> Digital Product Designer</span>
+          <span><strong>Rola</strong> Operator DTP / grafik · end-to-end owner</span>
           <span class="pm-meta-sep">·</span>
-          <span><strong>Typ</strong> Automatyzacja DTP · Narzędzie wewnętrzne</span>
+          <span><strong>Kontekst</strong> Wewnętrzne usprawnienie procesu w PolonisDruk</span>
           <span class="pm-meta-sep">·</span>
-          <span><strong>Technologia</strong> Adobe CEP · ExtendScript</span>
+          <span><strong>Zespół</strong> 2 operatorów DTP + sponsor wewnętrzny</span>
           <span class="pm-meta-sep">·</span>
-          <span><strong>Wynik</strong> Inspekcja z 15 minut do 1 sekundy</span>
+          <span><strong>Technologia</strong> Adobe CEP · ExtendScript (.jsx) · HTML/CSS/JS</span>
+          <span class="pm-meta-sep">·</span>
+          <span><strong>Wynik</strong> Inspekcja 5–20 min → ~1 s skanu + ~1 min pełnej kontroli</span>
         </div>
       </div>
     </div>
 
     <!-- ============================================================
-         2. HERO BODY — chipsy po lewej, zdjęcie po prawej
+         Hero Body — chipsy po lewej, obraz po prawej
     ============================================================ -->
     <div class="kwcs-hero-body">
       <div class="wrap inner">
-
         <div class="hero-content-grid">
 
-          <!-- LEWA STRONA: chipsy z metadanymi projektu -->
           <div class="hero-buttons-vertical">
             <div class="kwcs-chip chip-zakres">
               <strong>Zakres</strong><br>
-              UX/UI Design, ExtendScript (.jsx), HTML/CSS/JS, CEP Panel
+              Analiza procesu · projekt panelu · implementacja · testy · wdrożenie
             </div>
-
             <div class="kwcs-chip chip-stack">
               <strong>Technologie</strong><br>
               Adobe Illustrator · CEP Framework · ExtendScript · Adobe CC SDK
             </div>
-
             <div class="kwcs-chip chip-automatyzacje">
               <strong>Co robiłem</strong><br>
-              Analiza procesu DTP · Projekt panelu · Implementacja · Testy
+              Sam robiłem inspekcję ręcznie — więc sam ją zautomatyzowałem
             </div>
-
             <div class="kwcs-chip chip-dostarczone">
               <strong>Co dostarczyłem</strong><br>
-              Wtyczka CEP · Skaner kolorów i obiektów · Raport błędów w jednym panelu
+              Panel CEP · skaner obiektów i kolorów · klikalny raport błędów
             </div>
           </div>
 
-          <!-- PRAWA STRONA: zdjęcie hero -->
           <div class="hero-image">
             <img
               class="cover"
-              src="/assets/images/cyfradruk-mockup1.webp"
-              alt="CyfraDruk – panel CEP w Adobe Illustrator z raportem błędów"
+              src="/assets/images/Automatyzacja_liniekolory.webp"
+              alt="CyfraDruk — panel kontroli grubości linii i kolorów w Adobe Illustrator"
               loading="lazy"
               decoding="async"
-              width="1200"
-              height="630"
-              data-caption="CyfraDruk – panel CEP w Adobe Illustrator">
+              width="1254"
+              height="1254"
+              data-caption="CyfraDruk — kontrola grubości linii i kolorów w jednym panelu">
           </div>
 
         </div>
 
-        <!-- CTA pod gridem -->
-        <a class="kw-btn kw-btn--md hero-image-cta" href="/index.html#contact" rel="noopener noreferrer" aria-label="Zapytaj o podobne narzędzie automatyzacyjne">
-          Zapytaj o podobne narzędzie
+        <a class="kw-btn kw-btn--md hero-image-cta" href="/index.html#contact" rel="noopener noreferrer" aria-label="Zapytaj o podobne usprawnienie procesu">
+          Zapytaj o podobne usprawnienie procesu
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <polyline points="9 18 15 12 9 6"></polyline>
           </svg>
         </a>
-
       </div>
     </div>
 
-
     <!-- ============================================================
-         2. KONTEKST PROJEKTU
+         W skrócie (executive summary)
     ============================================================ -->
-    <div class="kwcs-sec kwcs-context-section">
+    <div class="razdwa-summary" id="cyfra-summary">
       <div class="wrap">
-        <h2>Kontekst projektu</h2>
-
-        <div class="context-intro">
-          <p>
-            <strong>CyfraDruk</strong> to panel CEP (<em>Common Extensibility Platform</em>) napisany dla Adobe Illustrator, który eliminuje jeden z najbardziej kosztownych problemów w drukarniach cyfrowych — <strong>niewidzialne błędy grubości linii i mikro-obiektów</strong>, które nie są widoczne na ekranie, ale powodują zlewanie się elementów podczas druku.
-          </p>
-          <p>
-            Operatorzy DTP musieli ręcznie klikać i weryfikować tysiące wektorów w każdym pliku, co prowadziło do <strong>błędów ludzkich i kosztownych przedruków reklamacji</strong>. Celem projektu było zastąpienie tego procesu jednorazowym kliknięciem i automatycznym raportem w czasie poniżej jednej sekundy.
-          </p>
-        </div>
-
-        <h3 class="scope-heading">Zakres projektu</h3>
-        <div class="scope-grid">
-          <div class="scope-item">
-            <div class="scope-icon">🔍</div>
-            <p>Automatyczne wykrywanie <strong>linii poniżej 0.1 mm</strong></p>
+        <h2>W skrócie</h2>
+        <div class="razdwa-summary-grid">
+          <div class="razdwa-summary-cell">
+            <div class="label">Problem</div>
+            <div class="value">Ręczna kontrola pliku przed drukiem zajmowała 5–20 minut i wciąż przepuszczała błędy grubości linii, które groziły przedrukiem.</div>
           </div>
-          <div class="scope-item">
-            <div class="scope-icon">📐</div>
-            <p>Wykrywanie <strong>ukrytych mikro-kształtów</strong> niewidocznych gołym okiem</p>
+          <div class="razdwa-summary-cell">
+            <div class="label">Moja rola</div>
+            <div class="value">Operator DTP, który sam robił tę inspekcję — i przeprowadził usprawnienie end-to-end: analiza → progi → build → testy → wdrożenie.</div>
           </div>
-          <div class="scope-item">
-            <div class="scope-icon">🎨</div>
-            <p>Weryfikacja wartości <strong>CMYK i kolorów Pantone</strong> (Spot Colors)</p>
+          <div class="razdwa-summary-cell">
+            <div class="label">Rozwiązanie</div>
+            <div class="value">Wewnętrzny panel do Illustratora, który skanuje plik jednym kliknięciem i podaje błędy na klikalnej liście.</div>
           </div>
-          <div class="scope-item">
-            <div class="scope-icon">🖨️</div>
-            <p>Generowanie <strong>bezpiecznych spadów</strong> z wykrojnika jednym przyciskiem</p>
-          </div>
-          <div class="scope-item">
-            <div class="scope-icon">📋</div>
-            <p>Eksport <strong>raportu błędów</strong> z listą obiektów do poprawy</p>
-          </div>
-          <div class="scope-item">
-            <div class="scope-icon">🎯</div>
-            <p>Przycisk <strong>"Zaznacz w AI"</strong> – lokalizacja błędnego wektora w pliku</p>
-          </div>
-          <div class="scope-item">
-            <div class="scope-icon">⚡</div>
-            <p><strong>Czas inspekcji: &lt;1 sekunda</strong> niezależnie od rozmiaru pliku</p>
-          </div>
-          <div class="scope-item">
-            <div class="scope-icon">🔧</div>
-            <p>Integracja z <strong>istniejącym workflow</strong> drukarni bez konieczności zmiany procesu</p>
-          </div>
-          <div class="scope-item">
-            <div class="scope-icon">📦</div>
-            <p>Pakiet instalacyjny <strong>CEP</strong> – instalacja bez uprawnień IT</p>
+          <div class="razdwa-summary-cell">
+            <div class="label">Efekt</div>
+            <div class="value">Inspekcja skrócona do ~1 s skanu i ~1 min pełnej kontroli. Onboarding operatora poniżej 30 minut. Adopcja 06.2026.</div>
           </div>
         </div>
+        <p class="kwcs-footnote">„~1 s" to czas samego skanu; pełna kontrola pliku (skan + przejście raportu + naprawa) to około minuty. Dane o błędach i reklamacjach są jakościowe.</p>
       </div>
     </div>
 
-
     <!-- ============================================================
-         3. PROBLEM — ręczna weryfikacja DTP
+         Problem (Situation + Before)
     ============================================================ -->
-    <div class="kwcs-sec kwcs-logo-section">
+    <h2 class="section-divider" id="cyfra-kontekst">Zanim powstało narzędzie</h2>
+
+    <div class="kwcs-sec">
       <div class="wrap">
-        <h2>Ręczne sprawdzanie wektorów to strata czasu i pieniędzy</h2>
-
-        <div class="logo-intro">
-          <p>
-            W drukarniach cyfrowych cienkie linie poniżej 0.1 mm zlewają się w druku — są dosłownie <strong>niewidoczne dla oka operatora</strong> na monitorze, ale powodują defekty na gotowym produkcie. Proces manualnej weryfikacji całego pliku zajmował od <strong>5 do 20 minut</strong> i był podatny na błędy ludzkie.
-          </p>
-        </div>
-
-        <!-- Galeria: screenshoty problemu i narzędzie -->
-        <div class="kwcs-gallery-grid">
-          <div class="gallery-item">
-            <img
-              src="/assets/images/sprawdzanie_kolorow_Automatyzacja.webp"
-              alt="Widok panelu CyfraDruk – zakładka sprawdzania kolorów CMYK i Pantone"
-              loading="lazy"
-              data-caption="Panel CyfraDruk – weryfikacja kolorów CMYK i Pantone (Spot Colors)">
-            <p class="img-desc">Weryfikacja kolorów CMYK i Pantone</p>
-          </div>
-          <div class="gallery-item">
-            <img
-              src="/assets/images/Sprawdzanie_obiektów_Automatyzacja.webp"
-              alt="Widok panelu CyfraDruk – zakładka sprawdzania obiektów i grubości linii"
-              loading="lazy"
-              data-caption="Panel CyfraDruk – skanowanie obiektów i grubości linii">
-            <p class="img-desc">Skanowanie obiektów i grubości linii</p>
-          </div>
-        </div>
-
-        <p>
-          Powyższe widoki panelu pokazują dwa główne moduły wtyczki: <strong>weryfikację kolorów</strong> z podziałem na wypełnienia i obrysy, oraz <strong>skaner obiektów</strong> z listą wykrytych problemów (czerwone wiersze oznaczają błędy wymagające interwencji). Każda pozycja na liście jest klikalna — jedno kliknięcie zaznacza obiekt bezpośrednio w Illustratorze.
+        <p class="razdwa-h2-sub">Ręczna inspekcja pliku zajmowała 5–20 minut i wciąż groziła przedrukiem.</p>
+        <p class="kwcs-section-lead">
+          W dziale DTP w PolonisDruk każdy plik przed drukiem cyfrowym przechodził ręczną kontrolę. Największym problemem były cienkie linie poniżej progu druku — na monitorze wyglądają poprawnie, ale w druku zlewają się lub znikają. Robiłem tę kontrolę sam, jako operator DTP, i z tej perspektywy zaprojektowałem narzędzie.
         </p>
+
+        <div class="ux-decision-grid">
+          <div class="ux-decision-box">
+            <h4>Co spowalniało i kosztowało</h4>
+            <p>Kontrola polegała na ręcznym klikaniu we właściwości kolejnych obiektów i porównywaniu ich z progami grubości. Przy złożonych plikach to była żmudna, powtarzalna praca — 5–20 minut na plik, podatna na zmęczenie. Do tego dochodziły kolory w RGB zamiast CMYK i niezatwierdzone Pantone. Najdroższy scenariusz błędu to przedruk i ryzyko reklamacji.</p>
+          </div>
+          <div class="ux-decision-box">
+            <h4>Kto był zaangażowany</h4>
+            <p><strong>2 operatorów DTP</strong> — użytkownicy końcowi; na ich realnych plikach testowałem narzędzie. <strong>Sponsor wewnętrzny</strong> — zielone światło i priorytet na czas budowy. To wewnętrzne usprawnienie procesu, nie produkt komercyjny — i tyle właśnie obejmuje jego zasięg.</p>
+          </div>
+        </div>
+
+        <ul class="kwcs-section-list">
+          <li><strong>Linie poniżej progu grubości</strong> — niewidoczne na ekranie, wadliwe w druku.</li>
+          <li><strong>Mikro-obiekty</strong> ukryte w grupach, symbolach i maskach.</li>
+          <li><strong>Kolory RGB zamiast CMYK</strong> oraz niezatwierdzone kolory Pantone (Spot).</li>
+          <li><strong>Błąd ludzki</strong> — przy setkach obiektów łatwo coś przeoczyć pod koniec kontroli.</li>
+        </ul>
       </div>
     </div>
 
+    <!-- ============================================================
+         Cel / kryteria sukcesu (Task)
+    ============================================================ -->
+    <h2 class="section-divider" id="cyfra-cel">Cel — szybciej, pewniej, bez długiego wdrożenia</h2>
+
+    <div class="kwcs-sec">
+      <div class="wrap">
+        <p class="razdwa-h2-sub">Trzy mierzalne kryteria, które zdefiniowałem zanim zacząłem budować.</p>
+
+        <div class="ux-decision-grid ux-decision-grid--trio">
+          <div class="ux-decision-box">
+            <div class="ux-label">Kryterium 1</div>
+            <h4>Krótszy czas inspekcji</h4>
+            <p>Z 5–20 minut do kilkudziesięciu sekund pełnej kontroli — mierzone w minutach na plik, przed i po.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">Kryterium 2</div>
+            <h4>Mniej błędów i reklamacji</h4>
+            <p>Zmniejszyć ryzyko wypuszczenia do druku pliku z błędem wykrywalnym przez narzędzie.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">Kryterium 3</div>
+            <h4>Onboarding ≤ 30 minut</h4>
+            <p>Bez tygodniowego wdrażania — jeden przycisk „Skanuj" i czytelny raport.</p>
+          </div>
+        </div>
+      </div>
+    </div>
 
     <!-- ============================================================
-         4. ROZWIĄZANIE — showcase funkcjonalności
+         Przebieg projektu (Action) — timeline etapami
     ============================================================ -->
+    <h2 class="section-divider" id="cyfra-przebieg">Od wywiadu do adopcji</h2>
+
+    <div class="kwcs-sec">
+      <div class="wrap">
+        <p class="razdwa-h2-sub">Jak od analizy realnej pracy (02.2026) proces kontroli zmienił się w działające narzędzie (adopcja 06.2026).</p>
+        <p class="kwcs-section-lead">
+          Projekt prowadziłem etapami: od wywiadu i analizy procesu, przez reguły i progi grubości, budowę panelu ze skanerem, testy na plikach produkcyjnych, aż po szkolenie operatorów i adopcję.
+        </p>
+
+        <div class="user-flow user-flow--6">
+          <div class="flow-step">
+            <div class="flow-step-icon">01</div>
+            <div class="flow-step-label">Wywiad i analiza</div>
+            <div class="flow-step-sub">02.2026 — realny workflow inspekcji, najczęstsze i najtrudniejsze błędy, koszt przedruku vs czas kontroli</div>
+          </div>
+          <div class="flow-arrow">→</div>
+          <div class="flow-step">
+            <div class="flow-step-icon">02</div>
+            <div class="flow-step-label">Reguły i progi</div>
+            <div class="flow-step-sub">03.2026 — progi grubości pod technikę druku, reguła oceny obiektu (OK / ostrzeżenie / błąd)</div>
+          </div>
+          <div class="flow-arrow">→</div>
+          <div class="flow-step">
+            <div class="flow-step-icon">03</div>
+            <div class="flow-step-label">Build</div>
+            <div class="flow-step-sub">03–04.2026 — panel CEP + rekurencyjny skaner ExtendScript, klikalny raport „zaznacz w AI"</div>
+          </div>
+          <div class="flow-arrow">→</div>
+          <div class="flow-step">
+            <div class="flow-step-icon">04</div>
+            <div class="flow-step-label">Testy</div>
+            <div class="flow-step-sub">05.2026 — pliki produkcyjne: etykiety, ulotki, wizytówki, wykrojnik; skrajne przypadki</div>
+          </div>
+          <div class="flow-arrow">→</div>
+          <div class="flow-step">
+            <div class="flow-step-icon">05</div>
+            <div class="flow-step-label">Szkolenie</div>
+            <div class="flow-step-sub">05–06.2026 — pakiet .zxp bez uprawnień IT, sesja ≤ 30 min dla 2 operatorów</div>
+          </div>
+          <div class="flow-arrow">→</div>
+          <div class="flow-step">
+            <div class="flow-step-icon">06</div>
+            <div class="flow-step-label">Adopcja</div>
+            <div class="flow-step-sub">06.2026 — narzędzie w codziennym użyciu obu operatorów</div>
+          </div>
+        </div>
+
+        <div class="kwcs-callout">
+          <p>
+            <strong>Największe ryzyko</strong> — że skaner pominie obiekt lub że operatorzy nie zaufają narzędziu — zdejmowałem na etapie testów: na starcie kontrolowałem plik równolegle ręcznie i narzędziem, aż wyniki się pokrywały. Dopiero to zbudowało zaufanie i pozwoliło porzucić ręczną inspekcję.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================
+         Trzy kluczowe decyzje
+    ============================================================ -->
+    <h2 class="section-divider" id="cyfra-decyzje">Trzy decyzje, które ukształtowały narzędzie</h2>
+
+    <div class="kwcs-sec">
+      <div class="wrap">
+        <p class="razdwa-h2-sub">Każda skracała czas pracy albo obniżała ryzyko błędu w druku.</p>
+
+        <div class="ux-decision-grid ux-decision-grid--trio">
+          <div class="ux-decision-box">
+            <div class="ux-label">Decyzja 1</div>
+            <h4>Panel wewnątrz Illustratora, nie osobna aplikacja</h4>
+            <p>Kontrola dzieje się tam, gdzie jest praca — operator nie zmienia kontekstu ani nie eksportuje pliku.</p>
+            <p class="razdwa-tradeoff"><strong>Kompromis:</strong> zależność od API Illustratora w zamian za zero zależności od internetu i narzędzi zewnętrznych.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">Decyzja 2</div>
+            <h4>Próg grubości konfigurowalny, nie sztywny</h4>
+            <p>Jeden panel obsługuje różne techniki druku i typy prac — bez rekompilacji pod każdą specyfikację.</p>
+            <p class="razdwa-tradeoff"><strong>Kompromis:</strong> nieco więcej ustawień w zamian za elastyczność bez udziału developera.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">Decyzja 3</div>
+            <h4>Klikalny raport, nie sam listing</h4>
+            <p>Kliknięcie wiersza zaznacza błędny obiekt w dokumencie („zaznacz w AI") — skraca czas naprawy, nie tylko wykrycia.</p>
+            <p class="razdwa-tradeoff"><strong>Kompromis:</strong> dodatkowa praca nad mostem JS ↔ ExtendScript w zamian za realne skrócenie naprawy w codziennym użyciu.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================
+         Ryzyka + mitigacje
+    ============================================================ -->
+    <h2 class="section-divider" id="cyfra-ryzyka">Ryzyka i jak je zdjąłem</h2>
+
+    <div class="kwcs-sec">
+      <div class="wrap">
+        <p class="razdwa-h2-sub">Dwa ryzyka, które mogły przekreślić sens narzędzia — i ich mitigacje.</p>
+
+        <div class="ux-decision-grid">
+          <div class="ux-decision-box">
+            <div class="ux-label">Ryzyko 1</div>
+            <h4>Skaner pomija zagnieżdżone obiekty</h4>
+            <p><strong>Wpływ:</strong> obiekt ukryty w grupie, symbolu lub masce mógł „uciec" kontroli i przejść do druku. <strong>Mitigacja:</strong> rekurencyjne przejście całego drzewa dokumentu + testy na plikach o dużej liczbie obiektów, aż skan pokrywał się z kontrolą ręczną.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">Ryzyko 2</div>
+            <h4>Operatorzy nie zaufają narzędziu</h4>
+            <p><strong>Wpływ:</strong> nowe narzędzie łatwo zignorować i wrócić do ręcznego klikania. <strong>Mitigacja:</strong> na starcie równoległa kontrola ręczna i narzędziem; klikalny raport dawał natychmiastową weryfikację („kliknij → zobacz obiekt"). Zaufanie zbudowało się, gdy wyniki się zgadzały.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================
+         Jak działa narzędzie — funkcjonalność + zrzuty
+         UWAGA: poza zdjęciem hero brak realnych zrzutów w repo.
+         Poniższe kontenery .asset-missing = miejsca na zrzuty DO WSTAWIENIA
+         (widoczne, żeby było jasne ile brakuje przed pushem produkcyjnym).
+    ============================================================ -->
+    <h2 class="section-divider" id="cyfra-dzialanie">Jeden skan zamiast tysięcy kliknięć</h2>
+
     <div class="kwcs-sec kwcs-website-showcase">
       <div class="wrap">
-        <h2>Zautomatyzowany skaner jednym kliknięciem</h2>
-        <p>
-          Wtyczka łączy panel HTML/CSS/JS (warstwa UI) z logiką ExtendScript (.jsx), która <strong>rekurencyjnie skanuje cały plik</strong>, wyłapuje błędy i wystawia interaktywny raport. Operator nie musi znać technikalii — widzi wyłącznie kolorową listę problemów gotową do naprawy.
+        <p class="razdwa-h2-sub">Panel łączy warstwę UI (HTML/CSS/JS) z logiką ExtendScript, która rekurencyjnie skanuje cały plik.</p>
+        <p class="kwcs-section-lead">
+          Operator nie musi znać technikaliów — widzi kolorową listę problemów gotową do naprawy. Poniżej trzy główne moduły narzędzia.
         </p>
 
         <div class="showcase-stack">
 
-          <!-- SEKCJA 1: Skaner obiektów -->
           <div class="showcase-section">
             <h3>Skaner obiektów i grubości linii</h3>
-            <p class="tab-description">Rekurencyjne przeszukiwanie wszystkich warstw pliku — grupy, maski, zagnieżdżone symbole. Zero pominięć, wynik w &lt;1 sekundę</p>
-            <div class="showcase-row">
+            <p class="tab-description">Rekurencyjne przeszukiwanie wszystkich warstw — grupy, maski, zagnieżdżone symbole. Czerwone wiersze oznaczają błędy wymagające interwencji.</p>
+            <div class="showcase-row showcase-row--single">
               <div class="showcase-item">
-                <img
-                  class="lightbox-trigger"
-                  src="/assets/images/Sprawdzanie_obiektów_Automatyzacja.webp"
-                  alt="Panel CyfraDruk – lista wykrytych obiektów z błędami grubości"
-                  loading="lazy"
-                  data-caption="Skaner obiektów – lista błędów z wymiarami i warstwą">
-                <p>Lista wykrytych obiektów z błędami</p>
-              </div>
-              <div class="showcase-item showcase-mobile">
-                <img
-                  class="lightbox-trigger"
-                  src="/assets/images/Sprawdzanie_obiektów_Automatyzacja.png"
-                  alt="Panel CyfraDruk – widok szczegółowy obiektu z błędem grubości linii"
-                  loading="lazy"
-                  data-caption="Szczegóły obiektu – min. wymiar, szerokość, warstwa">
-                <p>Szczegóły obiektu – min. wymiar i warstwa</p>
+                <div class="asset-missing" role="img" aria-label="Zrzut do wstawienia: skaner obiektów i grubości linii">
+                  <span class="asset-missing-icon" aria-hidden="true">📁</span>
+                  <span class="asset-missing-label">Zrzut do wstawienia</span>
+                  <code class="asset-missing-filename">cyfradruk-skaner-obiektow.webp</code>
+                  <span>Panel „Obiekty" — lista wykrytych obiektów z błędami grubości (wymiar, warstwa)</span>
+                </div>
               </div>
             </div>
             <div class="features-box">
               <h4>Jak działa skaner obiektów</h4>
               <ul class="features-list">
-                <li>
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                  <strong>Rekurencyjne przeszukiwanie:</strong> skaner wchodzi w grupy, symbole i maski — żaden obiekt nie ucieka
-                </li>
-                <li>
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                  <strong>Próg 0.25 mm:</strong> konfigurowalny próg minimalnej grubości — ustawiany pod specyfikację danej drukarni
-                </li>
-                <li>
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                  <strong>Czerwone wiersze = błędy:</strong> czytelne oznaczenie kolorowe bez konieczności czytania wartości
-                </li>
-                <li>
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                  <strong>Kliknij wiersz → Zaznacz w AI:</strong> jeden klik przenosi kursor Illustratora prosto na błędny obiekt
-                </li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg><strong>Rekurencyjne przeszukiwanie:</strong> skaner wchodzi w grupy, symbole i maski — żaden obiekt nie ucieka.</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg><strong>Konfigurowalny próg:</strong> minimalna grubość ustawiana pod technikę druku danej pracy.</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg><strong>Czerwone wiersze = błędy:</strong> czytelne oznaczenie kolorem, bez czytania wartości.</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg><strong>Klik wiersza → zaznacz w AI:</strong> kursor Illustratora skacze prosto na błędny obiekt.</li>
               </ul>
             </div>
           </div>
 
-          <!-- SEKCJA 2: Weryfikacja kolorów -->
           <div class="showcase-section">
             <h3>Weryfikacja kolorów CMYK i Pantone</h3>
-            <p class="tab-description">Panel sprawdza wypełnienia i obrysy wszystkich obiektów — wykrywa kolory RGB zamiast CMYK oraz niezatwierdzone Spot Colors (Pantone)</p>
-            <div class="showcase-row">
+            <p class="tab-description">Panel sprawdza wypełnienia i obrysy wszystkich obiektów — wykrywa kolory RGB zamiast CMYK oraz niezatwierdzone Spot Colors (Pantone).</p>
+            <div class="showcase-row showcase-row--single">
               <div class="showcase-item">
-                <img
-                  class="lightbox-trigger"
-                  src="/assets/images/sprawdzanie_kolorow_Automatyzacja.webp"
-                  alt="Panel CyfraDruk – zakładka kolorów z listą wypełnień i obrysów"
-                  loading="lazy"
-                  data-caption="Weryfikacja kolorów – wypełnienia i obrysy osobno">
-                <p>Osobny widok wypełnień i obrysów</p>
-              </div>
-              <div class="showcase-item showcase-mobile">
-                <img
-                  class="lightbox-trigger"
-                  src="/assets/images/Sprawdzanie_obiektów_Automatyzacja.png"
-                  alt="Panel CyfraDruk – zakładka obiektów z kolorami Pantone"
-                  loading="lazy"
-                  data-caption="Obiekt z kolorem Pantone – weryfikacja Spot Color">
-                <p>Weryfikacja Spot Colors (Pantone)</p>
+                <div class="asset-missing" role="img" aria-label="Zrzut do wstawienia: weryfikacja kolorów CMYK i Pantone">
+                  <span class="asset-missing-icon" aria-hidden="true">📁</span>
+                  <span class="asset-missing-label">Zrzut do wstawienia</span>
+                  <code class="asset-missing-filename">cyfradruk-kolory-cmyk-pantone.webp</code>
+                  <span>Panel „Kolory" — osobny widok wypełnień i obrysów, alerty RGB i lista Spot Colors</span>
+                </div>
               </div>
             </div>
             <div class="features-box">
               <h4>Co sprawdza moduł kolorów</h4>
               <ul class="features-list">
-                <li>
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                  <strong>Wypełnienia vs obrysy:</strong> dwa osobne widoki — kolory i grubości obrysów zebrane razem
-                </li>
-                <li>
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                  <strong>Wykrywanie RGB:</strong> automatyczny alert gdy obiekt ma kolor w przestrzeni RGB zamiast CMYK
-                </li>
-                <li>
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                  <strong>Spot Colors (Pantone):</strong> lista wszystkich kolorów dodatkowych w pliku z podziałem na obiekty
-                </li>
-                <li>
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                  <strong>Licznik obiektów:</strong> każda pozycja pokazuje ile obiektów używa danego koloru — priorytetyzacja napraw
-                </li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg><strong>Wypełnienia vs obrysy:</strong> dwa osobne widoki — kolory i grubości obrysów razem.</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg><strong>Wykrywanie RGB:</strong> alert, gdy obiekt ma kolor w przestrzeni RGB zamiast CMYK.</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg><strong>Spot Colors (Pantone):</strong> lista kolorów dodatkowych z podziałem na obiekty.</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg><strong>Licznik obiektów:</strong> ile obiektów używa danego koloru — priorytetyzacja napraw.</li>
               </ul>
             </div>
           </div>
 
-          <!-- SEKCJA 3: Interaktywny raport -->
-          <div class="showcase-section floating-cart-section">
+          <div class="showcase-section">
             <h3>Interaktywny raport i nawigacja do błędów</h3>
-            <p class="tab-description">Kliknięcie wiersza w raporcie wykonuje skok do obiektu w Illustratorze — bez scrollowania, bez szukania w warstwach</p>
-            <div class="showcase-row">
+            <p class="tab-description">Kliknięcie wiersza wykonuje skok do obiektu w Illustratorze — bez scrollowania, bez szukania w warstwach.</p>
+            <div class="showcase-row showcase-row--single">
               <div class="showcase-item">
-                <img
-                  class="lightbox-trigger"
-                  src="/assets/images/Sprawdzanie_obiektów_Automatyzacja.webp"
-                  alt="Panel CyfraDruk – interaktywna lista z zaznaczeniem obiektu w AI"
-                  loading="lazy"
-                  data-caption="Interaktywna lista – klik zaznacza obiekt w Illustratorze">
-                <p>Klik w raporcie → zaznaczenie w AI</p>
-              </div>
-              <div class="showcase-item showcase-mobile">
-                <img
-                  class="lightbox-trigger"
-                  src="/assets/images/sprawdzanie_kolorow_Automatyzacja.webp"
-                  alt="Panel CyfraDruk – raport kolorów z przyciskiem zaznaczenia"
-                  loading="lazy"
-                  data-caption="Raport kolorów – przycisk zaznaczenia obiektu w pliku">
-                <p>Raport kolorów z nawigacją</p>
+                <div class="asset-missing" role="img" aria-label="Zrzut do wstawienia: interaktywny raport i zaznaczenie obiektu w Illustratorze">
+                  <span class="asset-missing-icon" aria-hidden="true">📁</span>
+                  <span class="asset-missing-label">Zrzut do wstawienia</span>
+                  <code class="asset-missing-filename">cyfradruk-raport-zaznacz-w-ai.webp</code>
+                  <span>Klik w raporcie → obiekt zaznaczony i wycentrowany w dokumencie Illustratora</span>
+                </div>
               </div>
             </div>
             <div class="features-box">
               <h4>Architektura interaktywnego raportu</h4>
               <ul class="features-list">
-                <li>
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                  <strong>ExtendScript bridge:</strong> panel JS wysyła ID obiektu do warstwy .jsx → Illustrator zaznacza i centruje widok na błędzie
-                </li>
-                <li>
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                  <strong>Sortowanie błędów:</strong> lista sortowana od najpoważniejszych (0 mm) do granicznych — operator zaczyna od najgorszych
-                </li>
-                <li>
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                  <strong>Filtrowanie warstw:</strong> możliwość ograniczenia skanowania do wybranej warstwy — szybsza weryfikacja po poprawkach
-                </li>
-                <li>
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                  <strong>Zaznacz wszystkie:</strong> przycisk "Zaznacz wszystkie błędy" — grupowe zaznaczenie do masowej korekty w jednej operacji
-                </li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg><strong>ExtendScript bridge:</strong> panel wysyła ID obiektu przez <code>CSInterface.evalScript()</code> → Illustrator zaznacza i centruje widok.</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg><strong>Sortowanie błędów:</strong> od najpoważniejszych do granicznych — operator zaczyna od najgorszych.</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg><strong>Filtrowanie warstw:</strong> skan ograniczony do wybranej warstwy — szybsza weryfikacja po poprawkach.</li>
+                <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg><strong>Zaznacz wszystkie:</strong> grupowe zaznaczenie błędów do masowej korekty w jednej operacji.</li>
               </ul>
             </div>
           </div>
@@ -411,227 +464,149 @@
       </div>
     </div>
 
-
     <!-- ============================================================
-         5. ARCHITEKTURA TECHNICZNA
+         Wdrożenie, przekazanie i artefakty
     ============================================================ -->
-    <div class="kwcs-sec kwcs-mockups-section">
+    <h2 class="section-divider" id="cyfra-wdrozenie">Wdrożenie, przekazanie i artefakty</h2>
+
+    <div class="kwcs-sec">
       <div class="wrap">
-        <h2>Architektura techniczna — CEP + ExtendScript</h2>
+        <p class="razdwa-h2-sub">W codziennym użyciu 2 operatorów DTP od 06.2026.</p>
 
-        <div class="mockups-intro">
-          <p>
-            Wtyczka CEP składa się z dwóch warstw: <strong>panelu webowego</strong> (HTML/CSS/JS renderowany w Chromium wbudowanym w Illustratora) oraz <strong>skryptu ExtendScript</strong> (.jsx), który ma bezpośredni dostęp do modelu dokumentu Illustratora (DOM). Komunikacja między nimi odbywa się przez <code>CSInterface.evalScript()</code>.
-          </p>
+        <div class="ux-decision-grid">
+          <div class="ux-decision-box">
+            <div class="ux-label">Adopcja</div>
+            <h4>W użyciu od czerwca 2026</h4>
+            <p>Narzędzie zastąpiło ręczną inspekcję jako standardowy krok kontroli pliku przed drukiem. To wewnętrzne usprawnienie procesu — zasięg dokładnie taki, jak opisano: 2 operatorów, jeden dział DTP.</p>
+          </div>
+          <div class="ux-decision-box">
+            <div class="ux-label">Onboarding / Handover</div>
+            <h4>Wdrożenie poniżej 30 minut</h4>
+            <ul>
+              <li>Instalacja bez IT — pakiet <code>.zxp</code>, bez uprawnień administratora.</li>
+              <li>Szkolenie ≤ 30 min — jeden przycisk „Skanuj", czytelny raport, akcja naprawy.</li>
+              <li>Krótkie przekazanie — jak ustawić próg grubości, jak czytać kolory raportu, jak zaznaczyć błąd.</li>
+            </ul>
+          </div>
         </div>
 
-        <!-- Galeria: kod i architektura -->
-        <div class="kwcs-gallery-grid">
-          <div class="gallery-item">
-            <img
-              src="/assets/images/Sprawdzanie_obiektów_Automatyzacja.webp"
-              alt="Panel CyfraDruk – widok zakładki Obiekty z danymi skanowania"
-              loading="lazy">
-            <p class="img-desc">Moduł skanowania obiektów – wyniki</p>
+        <h3 class="kwcs-h3-center">Artefakty</h3>
+        <div class="ux-decision-grid">
+          <div class="ux-decision-box">
+            <div class="ux-label">Co powstało</div>
+            <h4>Dostarczone elementy</h4>
+            <ul>
+              <li>Panel CEP z dwoma modułami: skaner obiektów/grubości i weryfikacja kolorów.</li>
+              <li>Rekurencyjny skrypt skanujący w ExtendScript (.jsx).</li>
+              <li>Klikalny raport błędów z akcją „zaznacz w AI".</li>
+              <li>Pakiet instalacyjny <code>.zxp</code>.</li>
+            </ul>
           </div>
-          <div class="gallery-item">
-            <img
-              src="/assets/images/sprawdzanie_kolorow_Automatyzacja.webp"
-              alt="Panel CyfraDruk – widok zakładki Kolory z listą CMYK i Pantone"
-              loading="lazy">
-            <p class="img-desc">Moduł weryfikacji kolorów – wyniki</p>
-          </div>
-          <div class="gallery-item">
-            <img
-              src="/assets/images/Sprawdzanie_obiektów_Automatyzacja.png"
-              alt="Panel CyfraDruk – zaznaczony obiekt w Illustratorze"
-              loading="lazy">
-            <p class="img-desc">Nawigacja do obiektu – zaznaczenie w AI</p>
+          <div class="ux-decision-box">
+            <div class="ux-label">Materiał wizualny</div>
+            <h4>Zrzuty panelu</h4>
+            <p>Do przygotowania: co najmniej 2–3 zrzuty modułów panelu (skaner obiektów, kolory, interaktywny raport) — miejsca oznaczone wyżej jako „Zrzut do wstawienia". Zdjęcie przeglądowe panelu jest już w hero.</p>
           </div>
         </div>
       </div>
     </div>
 
-
     <!-- ============================================================
-         6. TRZY KARTY: Statystyki i wyniki
+         Rezultat + metryki + STAR
     ============================================================ -->
-    <div class="kwcs-sec" id="zakres">
-      <div class="wrap kwcs-trio">
+    <h2 class="section-divider" id="cyfra-rezultat">Efekt: minuty zamiast kwadransów</h2>
 
-        <article class="kwcs-card">
-          <h3>15x szybciej</h3>
-          <ul>
-            <li>Zmniejszenie czasu inspekcji z <strong>15 minut do 1 sekundy</strong></li>
-            <li>Operator skanuje plik jednym kliknięciem przycisku "Skanuj plik"</li>
-            <li>Wynik dostępny natychmiast — bez oczekiwania niezależnie od liczby obiektów</li>
-            <li>Czas zaoszczędzony przy 20 plikach dziennie: <strong>ponad 4 godziny</strong> pracy operatora</li>
-          </ul>
-        </article>
-
-        <article class="kwcs-card">
-          <h3>100% dokładności</h3>
-          <ul>
-            <li>Algorytm rekurencyjny <strong>nie przeoczy mikroskopijnego punktu</strong> ukrytego w grupie lub masce</li>
-            <li>Zero błędów ludzkich — komputer nie ulega zmęczeniu po 200. obiekcie</li>
-            <li>Weryfikacja zarówno <strong>fill</strong> jak i <strong>stroke</strong> każdego obiektu osobno</li>
-            <li>Obsługa zagnieżdżonych grup, symboli i obiektów złożonych</li>
-          </ul>
-        </article>
-
-        <article class="kwcs-card">
-          <h3>Interaktywny UI</h3>
-          <ul>
-            <li>Przycisk <strong>"Zaznacz w AI"</strong> automatycznie lokalizuje błędny wektor w dokumencie</li>
-            <li>Skrócenie czasu naprawy — operator nie musi szukać obiektu w warstwach</li>
-            <li>Kolorowe oznaczenia: czerwony = błąd krytyczny, zielony = prawidłowy</li>
-            <li>Sortowanie i filtrowanie listy błędów według warstwy lub rodzaju problemu</li>
-          </ul>
-        </article>
-
-      </div>
-    </div>
-
-
-    <!-- ============================================================
-         7. ACCORDION — proces projektowy
-    ============================================================ -->
-    <div class="kwcs-sec" id="dostarczone">
+    <div class="kwcs-sec">
       <div class="wrap">
-        <h2>Proces projektowy</h2>
-        <div class="kwcs-accordion">
-
-          <div class="kwcs-item">
-            <button class="kwcs-header" aria-expanded="false" aria-controls="content-cyfra-1" id="header-cyfra-1" type="button">
-              <span class="num">1</span> Analiza — mapowanie procesu DTP w drukarni
-              <span class="icon" aria-hidden="true">+</span>
-            </button>
-            <div class="kwcs-content" id="content-cyfra-1" role="region" aria-labelledby="header-cyfra-1">
-              <p><strong>Obserwacja pracy operatora:</strong> Spędziłem czas przy stanowisku DTP obserwując realny workflow. Zobaczyłem, że inspekcja pliku to seria ręcznych kliknięć — otwieranie właściwości każdego obiektu, sprawdzanie zakładki "Obrys", porównywanie z cennikiem grubości linii.</p>
-              <ul>
-                <li>Wywiad z operatorami — jakie rodzaje błędów zdarzają się najczęściej, które są najtrudniejsze do wykrycia</li>
-                <li>Analiza kosztów reklamacji — policzenie ile kosztuje jeden przedruk vs. czas poświęcony na inspekcję</li>
-                <li>Ustalenie specyfikacji — progi grubości linii dla różnych technik druku (offset, cyfrowy, UV)</li>
-                <li>Constraint: wtyczka musi działać bez dostępu do internetu, bez zewnętrznych zależności — tylko Adobe SDK</li>
-              </ul>
-            </div>
-          </div>
-
-          <div class="kwcs-item">
-            <button class="kwcs-header" aria-expanded="false" aria-controls="content-cyfra-2" id="header-cyfra-2" type="button">
-              <span class="num">2</span> Projekt UI panelu CEP — architektura informacji
-              <span class="icon" aria-hidden="true">+</span>
-            </button>
-            <div class="kwcs-content" id="content-cyfra-2" role="region" aria-labelledby="header-cyfra-2">
-              <p><strong>Kluczowa decyzja projektowa:</strong> Panel musi być czytelny w wąskim pasku bocznym Illustratora (domyślna szerokość panelu to ok. 250–300 px). Hierarchia informacji musiała działać w jednej kolumnie.</p>
-              <ul>
-                <li>Wireframe w Figmie — układ zakładek: "Obiekty" / "Kolory" / "Ustawienia"</li>
-                <li>System kolorów błędów: czerwony (krytyczny, &lt; progu), żółty (ostrzeżenie, blisko progu), zielony (OK)</li>
-                <li>Tabela wyników z kolumnami: Min. wymiar, Szerokość × Wysokość, Warstwa</li>
-                <li>Przycisk „Skanuj plik" jako jedyna akcja główna — bez progu wejścia dla operatora</li>
-                <li>Stan „Brak właściwości kształtu" dla zaznaczenia wielu obiektów — obsługa skrajnego przypadku</li>
-              </ul>
-            </div>
-          </div>
-
-          <div class="kwcs-item">
-            <button class="kwcs-header" aria-expanded="false" aria-controls="content-cyfra-3" id="header-cyfra-3" type="button">
-              <span class="num">3</span> Implementacja ExtendScript — algorytm rekurencyjny
-              <span class="icon" aria-hidden="true">+</span>
-            </button>
-            <div class="kwcs-content" id="content-cyfra-3" role="region" aria-labelledby="header-cyfra-3">
-              <p><strong>Kluczowy algorytm:</strong> Skanowanie dokumentu Illustratora wymaga rekurencyjnego przechodzenia przez drzewo obiektów — grupy mogą zawierać grupy, symbole mogą zawierać inne symbole zagnieżdżone 5 poziomów w głąb.</p>
-              <ul>
-                <li><strong>Funkcja <code>scanPageItems()</code>:</strong> rekurencja przez <code>pageItems</code>, <code>groupItems</code>, <code>symbolItems</code></li>
-                <li><strong>Pomiar obiektu:</strong> <code>geometricBounds</code> vs <code>visibleBounds</code> — różnica ma znaczenie przy obiektach z obrysem</li>
-                <li><strong>Wykrywanie grubości:</strong> <code>pathItem.strokeWidth</code> — konwersja z punktów do mm (1 pt = 0.3528 mm)</li>
-                <li><strong>Kolory:</strong> <code>fillColor instanceof SpotColor</code> — identyfikacja Pantone, <code>colorType</code> dla RGB vs CMYK</li>
-                <li><strong>Zaznaczenie z panelu:</strong> <code>app.selection = [targetObject]</code> + <code>app.activeDocument.activeView.centerSelection()</code></li>
-              </ul>
-            </div>
-          </div>
-
-          <div class="kwcs-item">
-            <button class="kwcs-header" aria-expanded="false" aria-controls="content-cyfra-4" id="header-cyfra-4" type="button">
-              <span class="num">4</span> Komunikacja JS ↔ ExtendScript — CSInterface bridge
-              <span class="icon" aria-hidden="true">+</span>
-            </button>
-            <div class="kwcs-content" id="content-cyfra-4" role="region" aria-labelledby="header-cyfra-4">
-              <p><strong>Architektura komunikacji:</strong> Panel CEP (Chromium) nie ma bezpośredniego dostępu do API Illustratora. Wszystkie wywołania przechodzą przez <code>CSInterface.evalScript()</code> — asynchroniczny most między JS a ExtendScript.</p>
-              <ul>
-                <li><strong>Wywołanie skanowania:</strong> <code>csInterface.evalScript('scanAllObjects(' + threshold + ')', callback)</code></li>
-                <li><strong>Serializacja wyników:</strong> ExtendScript zwraca JSON jako string — panel parsuje i renderuje tabelę</li>
-                <li><strong>Zaznaczenie obiektu:</strong> <code>csInterface.evalScript('selectObjectById("' + objectId + '")')</code> — każdy obiekt ma unikalne ID generowane przy skanowaniu</li>
-                <li><strong>Wydajność:</strong> batch processing — jeden eval zamiast pętli eval'ów (10x szybciej na dużych plikach)</li>
-              </ul>
-            </div>
-          </div>
-
-          <div class="kwcs-item">
-            <button class="kwcs-header" aria-expanded="false" aria-controls="content-cyfra-5" id="header-cyfra-5" type="button">
-              <span class="num">5</span> Testy i wdrożenie w środowisku drukarni
-              <span class="icon" aria-hidden="true">+</span>
-            </button>
-            <div class="kwcs-content" id="content-cyfra-5" role="region" aria-labelledby="header-cyfra-5">
-              <p><strong>Testowanie na realnych plikach:</strong> Wtyczka była testowana na plikach produkcyjnych drukarni — etykiety, ulotki, wizytówki, projekty z wykrojnikiem. Każdy typ pliku wymagał obsłużenia innego skrajnego przypadku w algorytmie.</p>
-              <ul>
-                <li>Testy na plikach z &gt;5000 obiektów — weryfikacja czasu skanowania i stabilności</li>
-                <li>Skrajne przypadki: obiekty z <code>strokeWidth = 0</code> (brak obrysu), obiekty ukryte, obiekty na zablokowanych warstwach</li>
-                <li>Szkolenie operatorów — 30-minutowa sesja zamiast tygodniowego onboardingu</li>
-                <li>Zbieranie feedbacku po 2 tygodniach użytkowania — dodanie filtru warstw i sortowania na życzenie zespołu</li>
-                <li>Pakiet instalacyjny — folder <code>.zxp</code> instalowany przez Adobe Extension Manager bez uprawnień administratora</li>
-              </ul>
-            </div>
-          </div>
-
-        </div>
-
-
-        <!-- ============================================================
-             8. REZULTAT
-        ============================================================ -->
         <div class="kwcs-result">
-          <h2>Rezultat</h2>
+          <h3 class="kwcs-result-title">Co się zmieniło w kontroli pliku</h3>
 
           <div class="result-lead">
             <p>
-              Wtyczka CyfraDruk została wdrożona w środowisku produkcyjnym drukarni i <strong>wyeliminowała ręczną inspekcję plików</strong>. Czas sprawdzenia jednego pliku skrócił się z 15 minut do mniej niż sekundy. Operatorzy zgłaszają zero reklamacji związanych z grubością linii po wdrożeniu.
+              Ręczna inspekcja 5–20 minut ustąpiła miejsca skanowi jednym kliknięciem. Pełna kontrola pliku — skan, przejście raportu i naprawa — zamyka się dziś w około minucie, a nowy operator uczy się narzędzia w mniej niż 30 minut.
             </p>
           </div>
 
-          <div class="result-cards">
-            <div class="result-card">
-              <div class="result-icon">⚡</div>
-              <h3>&lt;1 sekunda na plik</h3>
-              <p>Czas inspekcji skrócony z 15 minut — niezależnie od liczby obiektów w dokumencie</p>
+          <div class="razdwa-stats">
+            <div class="razdwa-stat">
+              <div class="razdwa-stat-num">~1 min</div>
+              <div class="razdwa-stat-label">pełna kontrola pliku (skan + raport + naprawa) — wcześniej 5–20 min</div>
             </div>
-            <div class="result-card">
-              <div class="result-icon">✅</div>
-              <h3>Zero reklamacji</h3>
-              <p>Po wdrożeniu żaden plik nie przeszedł do druku z błędem grubości linii wykrywalnym przez wtyczkę</p>
+            <div class="razdwa-stat">
+              <div class="razdwa-stat-num">~1 s</div>
+              <div class="razdwa-stat-label">sam skan pliku jednym kliknięciem, niezależnie od liczby obiektów</div>
             </div>
-            <div class="result-card">
-              <div class="result-icon">🎯</div>
-              <h3>Bez szkolenia</h3>
-              <p>Operatorzy opanowali narzędzie w 30 minut — jeden przycisk, czytelny raport, akcja naprawy</p>
+            <div class="razdwa-stat">
+              <div class="razdwa-stat-num">≤ 30 min</div>
+              <div class="razdwa-stat-label">onboarding operatora zamiast długiego wdrożenia</div>
+            </div>
+            <div class="razdwa-stat">
+              <div class="razdwa-stat-num">brak</div>
+              <div class="razdwa-stat-label">reklamacji związanych z tym typem błędu odnotowanych po wdrożeniu</div>
             </div>
           </div>
 
-          <a class="kw-btn kw-btn--lg kwcs-cta" href="/index.html#contact" aria-label="Zapytaj o podobną wtyczkę lub automatyzację DTP">
-            Zapytaj o podobne narzędzie
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <polyline points="9 18 15 12 9 6"></polyline>
-            </svg>
-          </a>
+          <div class="kwcs-callout">
+            <p>
+              <strong>Uczciwie o liczbach:</strong> „~1 s" to czas samego skanu — pełna kontrola pliku to około minuty. Dane o błędach i reklamacjach są jakościowe: <strong>po wdrożeniu nie odnotowaliśmy reklamacji związanych z tym typem błędu</strong>. Celem było zmniejszenie ryzyka wypuszczenia do druku pliku z błędem wykrywalnym przez narzędzie — nie absolutna gwarancja.
+            </p>
+          </div>
+
+          <h3 class="kwcs-h3-center">Skrót w formacie STAR</h3>
+          <div class="razdwa-summary-grid">
+            <div class="razdwa-summary-cell">
+              <div class="label">Sytuacja</div>
+              <div class="value">Ręczna inspekcja pliku 5–20 min, niewidoczne błędy grubości linii, ryzyko przedruków w PolonisDruk.</div>
+            </div>
+            <div class="razdwa-summary-cell">
+              <div class="label">Zadanie</div>
+              <div class="value">Skrócić czas kontroli, ograniczyć błędy i reklamacje, onboarding operatora ≤ 30 min.</div>
+            </div>
+            <div class="razdwa-summary-cell">
+              <div class="label">Działanie</div>
+              <div class="value">Zaprojektowałem i zbudowałem panel CEP end-to-end (analiza → progi → build → testy → szkolenie), wdrożyłem u 2 operatorów.</div>
+            </div>
+            <div class="razdwa-summary-cell">
+              <div class="label">Rezultat</div>
+              <div class="value">~1 s skanu + ~1 min pełnej kontroli, brak reklamacji tego typu po wdrożeniu, onboarding ≤ 30 min, adopcja 06.2026.</div>
+            </div>
+          </div>
+
+          <!-- ============================================================
+               SLOT NA CYTAT (proof) — celowo NIEWIDOCZNY do czasu
+               uzyskania prawdziwej opinii sponsora / operatora.
+               Zero fikcyjnych nazwisk. Style .razdwa-quote gotowe w
+               projects.css (scope #case-cyfradruk-pelne).
+          ============================================================
+          <figure class="razdwa-quote">
+            <blockquote>„TU PRAWDZIWY CYTAT — np. o skróconym czasie kontroli lub mniejszej liczbie błędów w druku."</blockquote>
+            <figcaption>Imię Nazwisko — rola, PolonisDruk</figcaption>
+          </figure>
+          -->
+
+          <div class="result-invite">
+            <h3>Podsumowanie</h3>
+            <p>CyfraDruk pokazuje, jak powtarzalną, ręczną kontrolę da się zamknąć w jeden przycisk wewnątrz narzędzia, którego zespół już używa — z uczciwie zmierzonym efektem i realnym wdrożeniem, bez rozdmuchiwania skali.</p>
+            <div class="result-invite-actions">
+              <a class="kw-btn kw-btn--lg kwcs-cta" href="mailto:wyszynski.k@onet.pl?subject=Automatyzacja%20procesu%20w%20mojej%20firmie" aria-label="Napisz do mnie w sprawie podobnego usprawnienia">
+                Napisz do mnie
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <polyline points="9 18 15 12 9 6"></polyline>
+                </svg>
+              </a>
+            </div>
+          </div>
 
           <div class="result-next">
-            <h3>Co dalej?</h3>
-            <p>
-              Planowane rozszerzenia: <strong>moduł spadów</strong> — automatyczne generowanie bezpiecznych spadów z wykrojnika jednym przyciskiem, <strong>weryfikacja fontów</strong> (wykrywanie fontów niekonwertowanych na krzywe), <strong>eksport raportu do PDF</strong> dla klienta jako protokół weryfikacji pliku przed drukiem.
-            </p>
+            <h3>Następny projekt</h3>
+            <a class="kw-btn kw-btn--lg kwcs-cta" href="/portfolio.html#karoma" aria-label="Przejdź do projektu Karoma">
+              Karoma — identyfikacja wizualna i sklep B2B
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="9 18 15 12 9 6"></polyline>
+              </svg>
+            </a>
           </div>
         </div>
-
       </div>
     </div>
 


### PR DESCRIPTION
## Cel

Przepisanie case study **CyfraDruk** na spójny, nowoczesny format Tier 1 (wzorzec Raz Dwa Druk / Karoma) — jako **narzędzie wewnętrzne pre-press w PolonisDruk**, z uczciwą skalą i realnym dowozem, **bez people leadership** i bez udawania dużego produktu.

## Zmiany treści (uczciwość zamiast hype)

- **Rola:** Operator DTP / grafik · end-to-end owner (usunięte „Digital Product Designer").
- **Metryki:** `5–20 min → ~1 s skanu + ~1 min pełnej kontroli` — usunięte niepoparte „15 min → 1 sekunda", „100% dokładności", „zero reklamacji".
- **Reklamacje:** jakościowo — „po wdrożeniu nie odnotowaliśmy reklamacji związanych z tym typem błędu".
- **Kontekst:** PolonisDruk, 2 operatorów DTP + sponsor wewnętrzny.
- **Timeline etapami** z orientacyjnymi miesiącami: wywiad 02.2026 → reguły 03.2026 → build 03–04.2026 → testy 05.2026 → szkolenie 05–06.2026 → **adopcja 06.2026**.
- Dodane: 3 kluczowe decyzje, 2 ryzyka + mitigacje, metryki przed/po, adopcja z datą, onboarding/handover, artefakty, one-liner biznesowy, blok **STAR**, uproszczone CTA końcowe (domknięcie zamiast sprzedaży).

## Zmiany struktury / formatu

- `id="case-cyfradruk-pelne"` + chapter rail (konwencja z playbooka).
- Scoped blok CSS `#case-cyfradruk-pelne` w `assets/css/projects.css` (padding pod fixed rail, full-bleed tła, wyśrodkowany `.razdwa-h2-sub`, hero image 1254×1254, hero CTA border-box, blok CTA + gotowy slot cytatu). Mirror karoma / power-of-mind — **nie rusza innych case studies**.
- Niewidoczny slot cytatu klienta (bez zmyślania nazwisk).

## Zrzuty

Jedyny realny asset w repo (`Automatyzacja_liniekolory.webp`) użyty w hero. Pozostałe zrzuty modułów panelu wstawione jako **widoczne kontenery `.asset-missing`** („Zrzut do wstawienia" + docelowa nazwa pliku), żeby było jasne, ile brakuje przed pushem produkcyjnym:

- `cyfradruk-skaner-obiektow.webp`
- `cyfradruk-kolory-cmyk-pantone.webp`
- `cyfradruk-raport-zaznacz-w-ai.webp`

## Weryfikacja renderu

- `docOverflow = 0` na 1440 px i 390 px.
- Standalone (`projects/cyfradruk.html`) oraz kontekst `portfolio.html#cyfradruk` (inline viewer) — sekcja wstrzykiwana, chapter rail widoczny, brak zepsutych obrazów.

## Do domknięcia przed publikacją produkcyjną

- Dodać ≥2–3 realne zrzuty w miejsce kontenerów `.asset-missing`.
- Opcjonalnie: prawdziwy cytat sponsora/operatora → odkomentować gotowy slot.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EEYZP4QJDBgH7z3tfYw6pX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEYZP4QJDBgH7z3tfYw6pX)_