### PR TITLE
Przestaw portfolio na narrację prowadzenia projektów i delivery

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -206,7 +206,7 @@
     <section id="experience-section" class="experience-section">
         <div class="container">
             <h2 class="section-title">Doświadczenie</h2>
-            <p class="section-subtitle">8 lat pracy zawodowej — od grafiki i druku, przez projektowanie stron, po automatyzacje procesów biznesowych</p>
+            <p class="section-subtitle">8 lat pracy zawodowej — od grafiki i druku, przez projektowanie stron i UX/UI, po automatyzacje procesów biznesowych</p>
 
             <div class="exp-stats-grid">
                 <div class="adg-item">

--- a/portfolio.html
+++ b/portfolio.html
@@ -101,9 +101,9 @@
         <div class="container about-me-grid">
             <!-- TEXT -->
             <div class="about-me-text">
-                <p class="about-me-eyebrow">Portfolio / Case studies</p>
+                <p class="about-me-eyebrow">Portfolio / Realizacje</p>
                 <h1>Wybrane realizacje</h1>
-                <p class="subtitle">Projektuję strony, produkty cyfrowe i automatyzacje, które porządkują proces, upraszczają decyzje i pomagają szybciej dowozić efekt.</p>
+                <p class="subtitle">Prowadzę projekty end-to-end — od diagnozy procesu, przez decyzje i wdrożenie, po przekazanie i mierzalny efekt. Poniżej realizacje, które to pokazują.</p>
             </div>
 
             <!-- VISUALS -->
@@ -160,35 +160,35 @@
                     </div>
                 </article>
 
-                <article class="portfolio-new-card" data-project="power-of-mind" role="button" tabindex="0" aria-label="Power of Mind — Serwis i branding">
+                <article class="portfolio-new-card" data-project="power-of-mind" role="button" tabindex="0" aria-label="Power of Mind — Platforma zapisów i wdrożenie">
                     <div class="card-image-wrapper">
                         <img src="assets/images/power-of-mind/POWEROFMIND_HERO_1.webp" alt="Power of Mind — hero strony marki trenerki odporności psychicznej" loading="eager" decoding="async">
                     </div>
                     <div class="card-content">
-                        <span class="card-category">WordPress · Branding</span>
+                        <span class="card-category">Platforma · Wdrożenie</span>
                         <h3 class="card-title">Power of Mind</h3>
-                        <p class="card-description">Kompleksowa strona marki dla trenerki odporności psychicznej — od logo po sklep. Projekt zrealizowany; dziś dostępny jako wersja archiwalna.</p>
+                        <p class="card-description">Zapisy i płatności online zamiast obsługi telefonicznej. Wybór platformy poparty testem trzech i wdrożenie z automatyzacjami. Projekt zrealizowany; dziś wersja archiwalna.</p>
                         <div class="card-features">
                             <span class="feature-item">WordPress</span>
-                            <span class="feature-item">Logo</span>
-                            <span class="feature-item">UX/UI</span>
+                            <span class="feature-item">Automatyzacje</span>
+                            <span class="feature-item">Wdrożenie</span>
                         </div>
                         <span class="card-cta">Zobacz projekt <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></span>
                     </div>
                 </article>
 
-                 <article class="portfolio-new-card" data-project="karoma" role="button" tabindex="0" aria-label="Karoma — E-commerce i branding">
+                 <article class="portfolio-new-card" data-project="karoma" role="button" tabindex="0" aria-label="Karoma — Sklep B2B, dostawa end-to-end">
                     <div class="card-image-wrapper">
-                        <img src="assets/images/karoma/KAROMA_FRONT.webp" alt="Karoma — front sklepu WooCommerce z identyfikacją wizualną marki" loading="eager" decoding="async">
+                        <img src="assets/images/karoma/KAROMA_FRONT.webp" alt="Karoma — front sklepu WooCommerce marki narzędzi CNC B2B" loading="eager" decoding="async">
                     </div>
                     <div class="card-content">
-                        <span class="card-category">E-commerce · Branding</span>
+                        <span class="card-category">Sklep B2B · Dostawa end-to-end</span>
                         <h3 class="card-title">Karoma</h3>
-                        <p class="card-description">Sklep WooCommerce z pełną identyfikacją wizualną marki i optymalizacją UX.</p>
+                        <p class="card-description">Nowa marka i sklep B2B dostarczone end-to-end — od decyzji o zakresie, przez wdrożenie i integracje płatności, po przekazanie klientowi.</p>
                         <div class="card-features">
                             <span class="feature-item">WooCommerce</span>
-                            <span class="feature-item">Logo</span>
-                            <span class="feature-item">UX/UI</span>
+                            <span class="feature-item">Integracje</span>
+                            <span class="feature-item">Przekazanie</span>
                         </div>
                         <span class="card-cta">Zobacz projekt <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></span>
                     </div>
@@ -199,11 +199,38 @@
 
     </section>
 
+    <!-- Inline Case Study Viewer -->
+    <div id="case-viewer" class="project-viewer hidden" aria-live="polite"></div>
+
+    <!-- Experience Section -->
+    <section id="experience-section" class="experience-section">
+        <div class="container">
+            <h2 class="section-title">Doświadczenie</h2>
+            <p class="section-subtitle">8 lat pracy zawodowej — od grafiki i druku, przez UX i web, po automatyzacje procesów biznesowych</p>
+
+            <div class="exp-stats-grid">
+                <div class="adg-item">
+                    <span class="adg-label">Branże</span>
+                    <p>Poligrafia · E-commerce · Automatyzacje</p>
+                </div>
+                <div class="adg-item">
+                    <span class="adg-label">Staż</span>
+                    <p>8 lat pracy zawodowej · 8 lat w designie · od 2 lat projektuję produkty cyfrowe</p>
+                </div>
+                <div class="adg-item">
+                    <span class="adg-label">Zrealizowane</span>
+                    <p>5 stron · 1 aplikacja biznesowa · 10+ automatyzacji</p>
+                </div>
+            </div>
+
+        </div>
+    </section>
+
     <!-- Design Archive -->
     <section id="design-archive" class="archive-section">
         <div class="container">
-            <h2 class="section-title archive-title">Design archive</h2>
-            <p class="section-subtitle archive-note">Dodatkowe projekty graficzne i brandingowe — poza głównym kierunkiem portfolio.</p>
+            <h2 class="section-title archive-title">Wcześniejsze prace projektowe</h2>
+            <p class="section-subtitle archive-note">Starsze realizacje projektowe i graficzne — pokazuję je dla pełnego obrazu doświadczenia. Główny nurt portfolio to prowadzenie projektów i wdrożenia (wyżej).</p>
             <div class="archive-grid">
 
                 <article class="portfolio-new-card" data-project="KW-Design" role="button" tabindex="0" aria-label="kwyszynski — Logo i identyfikacja">
@@ -243,38 +270,11 @@
         </div>
     </section>
 
-    <!-- Inline Case Study Viewer -->
-    <div id="case-viewer" class="project-viewer hidden" aria-live="polite"></div>
-
-    <!-- Experience Section -->
-    <section id="experience-section" class="experience-section">
-        <div class="container">
-            <h2 class="section-title">Doświadczenie</h2>
-            <p class="section-subtitle">8 lat pracy zawodowej — od grafiki i druku, przez UX i web, po automatyzacje procesów biznesowych</p>
-
-            <div class="exp-stats-grid">
-                <div class="adg-item">
-                    <span class="adg-label">Branże</span>
-                    <p>Poligrafia · E-commerce · Automatyzacje</p>
-                </div>
-                <div class="adg-item">
-                    <span class="adg-label">Staż</span>
-                    <p>8 lat pracy zawodowej · 8 lat w designie · od 2 lat projektuję produkty cyfrowe</p>
-                </div>
-                <div class="adg-item">
-                    <span class="adg-label">Zrealizowane</span>
-                    <p>5 stron · 1 aplikacja biznesowa · 10+ automatyzacji</p>
-                </div>
-            </div>
-
-        </div>
-    </section>
-
     <!-- CTA Section -->
     <section class="cta-section">
         <div class="container cta-inner">
-            <h2>Masz projekt do uporządkowania albo wdrożenia?</h2>
-            <p>Napisz, z czym wchodzisz. Odpowiem, czy pomogę jako projektant, wdrożeniowiec czy partner od automatyzacji.</p>
+            <h2>Masz projekt do poprowadzenia albo wdrożenia?</h2>
+            <p>Napisz, z czym wchodzisz. Podpowiem, jak poprowadzić projekt — od zakresu, przez wdrożenie, po przekazanie i efekt.</p>
             <a href="mailto:wyszynski.k@onet.pl" class="btn-cta">Napisz wiadomość</a>
         </div>
     </section>

--- a/portfolio.html
+++ b/portfolio.html
@@ -103,7 +103,7 @@
             <div class="about-me-text">
                 <p class="about-me-eyebrow">Portfolio / Realizacje</p>
                 <h1>Wybrane realizacje</h1>
-                <p class="subtitle">Prowadzę projekty end-to-end — od diagnozy procesu, przez decyzje i wdrożenie, po przekazanie i mierzalny efekt. Poniżej realizacje, które to pokazują.</p>
+                <p class="subtitle">Prowadzę projekty od początku do końca — od diagnozy procesu, przez decyzje i wdrożenie, po przekazanie i mierzalny efekt. Poniżej realizacje, które to pokazują.</p>
             </div>
 
             <!-- VISUALS -->
@@ -122,7 +122,7 @@
     <section id="portfolio-section" class="portfolio-section">
         <div class="container">
             <h2 class="section-title">Wybrane projekty</h2>
-            <p class="section-subtitle">Do drobnego usprawnienia wystarcza automatyzacja, do większego — strona albo wdrożenie web, do złożonego procesu — dedykowany produkt cyfrowy. Poniższe realizacje pokazują te trzy poziomy w praktyce.</p>
+            <p class="section-subtitle">Do drobnego usprawnienia wystarcza automatyzacja, do większego — strona albo wdrożenie internetowe, do złożonego procesu — dedykowany produkt cyfrowy. Poniższe realizacje pokazują te trzy poziomy w praktyce.</p>
 
             <div class="portfolio-new-grid">
 
@@ -143,18 +143,18 @@
                     </div>
                 </article>
 
-                <article class="portfolio-new-card" data-project="cyfradruk" role="button" tabindex="0" aria-label="CyfraDruk — Automatyzacja pre-press">
+                <article class="portfolio-new-card" data-project="cyfradruk" role="button" tabindex="0" aria-label="CyfraDruk — Automatyzacja przygotowania plików do druku">
                     <div class="card-image-wrapper">
                         <img src="assets/images/Automatyzacja_liniekolory.webp" alt="CyfraDruk — automatyczne wykrywanie błędów kolorów i cienkich linii przed drukiem" loading="eager" decoding="async">
                     </div>
                     <div class="card-content">
-                        <span class="card-category">Automatyzacja · Pre-press</span>
+                        <span class="card-category">Automatyzacja · Przygotowanie do druku</span>
                         <h3 class="card-title">CyfraDruk</h3>
                         <p class="card-description">Kontrola pliku przed drukiem skrócona z ~15 min do ~1 s skanu — mniej przedruków, wdrożenie operatora ≤ 30 min.</p>
                         <div class="card-features">
                             <span class="feature-item">ExtendScript</span>
                             <span class="feature-item">Illustrator</span>
-                            <span class="feature-item">Pre-press</span>
+                            <span class="feature-item">Przygotowanie do druku</span>
                         </div>
                         <span class="card-cta">Zobacz projekt <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></span>
                     </div>
@@ -177,14 +177,14 @@
                     </div>
                 </article>
 
-                 <article class="portfolio-new-card" data-project="karoma" role="button" tabindex="0" aria-label="Karoma — Sklep B2B, dostawa end-to-end">
+                 <article class="portfolio-new-card" data-project="karoma" role="button" tabindex="0" aria-label="Karoma — Sklep B2B, prowadzenie od początku do końca">
                     <div class="card-image-wrapper">
                         <img src="assets/images/karoma/KAROMA_FRONT.webp" alt="Karoma — front sklepu WooCommerce marki narzędzi CNC B2B" loading="eager" decoding="async">
                     </div>
                     <div class="card-content">
-                        <span class="card-category">Sklep B2B · Dostawa end-to-end</span>
+                        <span class="card-category">Sklep B2B · Od analizy po wdrożenie</span>
                         <h3 class="card-title">Karoma</h3>
-                        <p class="card-description">Nowa marka i sklep B2B dostarczone end-to-end — od decyzji o zakresie, przez wdrożenie i integracje płatności, po przekazanie klientowi.</p>
+                        <p class="card-description">Nowa marka i sklep B2B poprowadzone od początku do końca — od decyzji o zakresie, przez wdrożenie i integracje płatności, po przekazanie klientowi.</p>
                         <div class="card-features">
                             <span class="feature-item">WooCommerce</span>
                             <span class="feature-item">Integracje</span>
@@ -206,7 +206,7 @@
     <section id="experience-section" class="experience-section">
         <div class="container">
             <h2 class="section-title">Doświadczenie</h2>
-            <p class="section-subtitle">8 lat pracy zawodowej — od grafiki i druku, przez UX i web, po automatyzacje procesów biznesowych</p>
+            <p class="section-subtitle">8 lat pracy zawodowej — od grafiki i druku, przez projektowanie stron, po automatyzacje procesów biznesowych</p>
 
             <div class="exp-stats-grid">
                 <div class="adg-item">
@@ -238,18 +238,18 @@
                         <img src="assets/images/kwyszynski/KWDESIGN_HERO.png" alt="kwyszynski — aktualna strona główna marki (sekcja hero)" loading="lazy" decoding="async">
                     </div>
                     <div class="card-content">
-                        <span class="card-category">Branding · Identyfikacja</span>
+                        <span class="card-category">Marka · Identyfikacja wizualna</span>
                         <h3 class="card-title">kwyszynski</h3>
                         <span class="card-cta">Zobacz projekt <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></span>
                     </div>
                 </article>
 
-                <article class="portfolio-new-card" data-project="sir-roger" role="button" tabindex="0" aria-label="Sir Roger — Rebranding i opakowania">
+                <article class="portfolio-new-card" data-project="sir-roger" role="button" tabindex="0" aria-label="Sir Roger — Odświeżenie marki i opakowania">
                     <div class="card-image-wrapper">
-                        <img src="assets/images/Roger.png" alt="Sir Roger — rebranding i opakowania marki herbat premium" loading="lazy" decoding="async">
+                        <img src="assets/images/Roger.png" alt="Sir Roger — odświeżenie marki i opakowania marki herbat wysokiej klasy" loading="lazy" decoding="async">
                     </div>
                     <div class="card-content">
-                        <span class="card-category">Branding · Opakowania</span>
+                        <span class="card-category">Marka · Opakowania</span>
                         <h3 class="card-title">Sir Roger</h3>
                         <span class="card-cta">Zobacz projekt <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></span>
                     </div>
@@ -284,7 +284,7 @@
         <div class="container footer-inner">
             <div class="footer-info">
                 <h3>Karol Wyszyński</h3>
-                <p>Delivery · Automatyzacje · Wdrożenia cyfrowe</p>
+                <p>Prowadzenie projektów · Automatyzacje · Wdrożenia cyfrowe</p>
                 <a href="mailto:wyszynski.k@onet.pl" class="footer-email">wyszynski.k@onet.pl</a>
                 <div class="footer-social">
                     <a href="https://www.linkedin.com/in/karol-wyszy%C5%84ski-62a844162/" target="_blank" rel="noopener" aria-label="LinkedIn">


### PR DESCRIPTION
## Cel

Portfolio ma na pierwszy rzut oka pokazywać prowadzenie projektów, dostawę end-to-end, wdrożenia i efekty — a nie głównie branding, logo i identyfikację. Zmiany wyłącznie w `portfolio.html`, bez ruszania innych plików i globalnych stylów, bez usuwania wcześniejszych prac.

## Zmiany

**Kolejność / waga sekcji**
- Sekcja wcześniejszych prac graficznych (dawniej „Design archive”) przeniesiona **niżej** — pod „Doświadczenie”. Nowa kolejność: projekty główne → podgląd case study → Doświadczenie → Wcześniejsze prace projektowe → CTA.
- Główne case studies (Raz Dwa Druk, CyfraDruk, Power of Mind, Karoma) zostają na górze; CyfraDruk pozostaje wysoko (#2).

**Etykiety i opisy kart**
- Power of Mind: „WordPress · Branding” → „Platforma · Wdrożenie”; tagi Logo/UX/UI → Automatyzacje/Wdrożenie; opis o problemie, decyzji i wdrożeniu.
- Karoma: „E-commerce · Branding” → „Sklep B2B · Dostawa end-to-end”; tagi Logo/UX/UI → Integracje/Przekazanie; opis o dostawie end-to-end i przekazaniu klientowi.
- Raz Dwa Druk i CyfraDruk: bez zmian (już mówiły o efekcie i wdrożeniu).

**Nagłówki i sygnały freelancingu**
- Eyebrow „Portfolio / Case studies” → „Portfolio / Realizacje”; podtytuł prowadzony narracją prowadzenia projektów.
- Tytuł archiwum „Design archive” → „Wcześniejsze prace projektowe” + neutralny podtytuł.
- CTA na dole przeformułowane z „pomogę jako projektant…” na prowadzenie projektu (zakres → wdrożenie → przekazanie → efekt).
- Usunięto angielskie zwroty z widocznej treści.

## Uczciwość

Wcześniejsze prace graficzne (kwyszynski, Sir Roger, Voucher) zachowują swoje etykiety w sekcji archiwum — nie są ukrywane, tylko przestawione tak, by nie były pierwszym komunikatem.

## Zakres

- Zmieniony plik: `portfolio.html`
- Bez zmian w innych plikach i globalnych stylach
- Bez nowych danych/liczb i bez usuwania historii

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BehkwDFSgFNMT773bTeeEy

---
_Generated by [Claude Code](https://claude.ai/code/session_01BehkwDFSgFNMT773bTeeEy)_