### PR TITLE
fix: napraw linki do kalkulatora po zmianie nazwy konta GitHub

### DIFF
--- a/projects/power-of-mind.html
+++ b/projects/power-of-mind.html
@@ -129,7 +129,7 @@
           </div>
         </div>
 
-        <a class="kw-btn kw-btn--md hero-image-cta" href="https://kwyszynskidesign.github.io/Powerofmind/" target="_blank" rel="noopener noreferrer" aria-label="Zobacz zarchiwizowaną wersję strony Power of Mind">
+        <a class="kw-btn kw-btn--md hero-image-cta" href="https://wyszynskik.github.io/Powerofmind/" target="_blank" rel="noopener noreferrer" aria-label="Zobacz zarchiwizowaną wersję strony Power of Mind">
           Zobacz wersję archiwalną
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <polyline points="9 18 15 12 9 6"></polyline>
@@ -613,7 +613,7 @@
                   <polyline points="9 18 15 12 9 6"></polyline>
                 </svg>
               </a>
-              <a class="kw-btn kw-btn--lg kwcs-cta kwcs-cta--ghost" href="https://kwyszynskidesign.github.io/Powerofmind/" target="_blank" rel="noopener noreferrer" aria-label="Otwórz zarchiwizowaną wersję strony Power of Mind">
+              <a class="kw-btn kw-btn--lg kwcs-cta kwcs-cta--ghost" href="https://wyszynskik.github.io/Powerofmind/" target="_blank" rel="noopener noreferrer" aria-label="Otwórz zarchiwizowaną wersję strony Power of Mind">
                 Zobacz wersję archiwalną
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <polyline points="9 18 15 12 9 6"></polyline>

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -135,7 +135,7 @@
    
             
 
-        <a class="kw-btn kw-btn--md hero-image-cta" href="https://kwyszynskidesign.github.io/RAZDWA/" target="_blank" rel="noopener noreferrer" aria-label="Zobacz działającą aplikację Raz Dwa Druk">
+        <a class="kw-btn kw-btn--md hero-image-cta" href="https://wyszynskik.github.io/RAZDWA/" target="_blank" rel="noopener noreferrer" aria-label="Zobacz działającą aplikację Raz Dwa Druk">
           Zobacz działającą aplikację
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <polyline points="9 18 15 12 9 6"></polyline>
@@ -732,7 +732,7 @@
               <polyline points="9 18 15 12 9 6"></polyline>
             </svg>
           </a>
-          <a class="kw-btn kw-btn--lg kwcs-cta kwcs-cta--ghost" href="https://kwyszynskidesign.github.io/RAZDWA/" target="_blank" rel="noopener noreferrer" aria-label="Otwórz aplikację Raz Dwa Druk na żywo">
+          <a class="kw-btn kw-btn--lg kwcs-cta kwcs-cta--ghost" href="https://wyszynskik.github.io/RAZDWA/" target="_blank" rel="noopener noreferrer" aria-label="Otwórz aplikację Raz Dwa Druk na żywo">
             Zobacz aplikację na żywo
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <polyline points="9 18 15 12 9 6"></polyline>


### PR DESCRIPTION
## Problem

Po zmianie nazwy konta GitHub z `kwyszynskidesign` na `wyszynskik` linki do aplikacji hostowanych na GitHub Pages przestały działać — subdomena `kwyszynskidesign.github.io` już nie istnieje i zwraca **404 "There isn't a GitHub Pages site here"**.

Dotyczyło to m.in. kalkulatora wycen **Raz Dwa Druk** linkowanego ze strony projektu.

## Zmiana

Zaktualizowano wszystkie 4 linki `kwyszynskidesign.github.io` → `wyszynskik.github.io`:

- `projects/razdwa_aplikacja.html` — 2× link do kalkulatora (`/RAZDWA/`)
- `projects/power-of-mind.html` — 2× link do archiwum (`/Powerofmind/`)

Nowy URL kalkulatora potwierdzony jako działający: https://wyszynskik.github.io/RAZDWA/

## Uwaga

Główna strona (`kwyszynski.pl`) działa przez własną domenę (CNAME), więc jej to nie dotyczyło — problem był tylko w linkach wychodzących na github.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQbocyHd1t39D6a24zNvUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQbocyHd1t39D6a24zNvUJ)_