### PR TITLE
feat: Google Analytics 4 z banerem zgody (Consent Mode v2)

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
+  <script src="/assets/js/analytics.js"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>404 – Strona nie znaleziona | Karol Wyszyński</title>

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -1,0 +1,124 @@
+/*
+ * Google Analytics 4 + baner zgody (Consent Mode v2)
+ * ---------------------------------------------------
+ * Jeden wspólny plik dla całej strony. Ładowany na każdej podstronie linijką:
+ *   <script src="/assets/js/analytics.js"></script>
+ *
+ * >>> JEDYNE, CO MUSISZ ZROBIĆ: wklej swój Measurement ID poniżej. <<<
+ * Znajdziesz go w GA4 → Administracja → Strumienie danych → (Twój strumień web)
+ * Wygląda tak: G-XXXXXXXXXX
+ *
+ * Dopóki ID = "G-XXXXXXXXXX", analityka jest wyłączona i nic się nie ładuje.
+ */
+
+(function () {
+  "use strict";
+
+  // ─────────────────────────────────────────────────────────────
+  var MEASUREMENT_ID = "G-XXXXXXXXXX"; // ← WKLEJ TUTAJ SWÓJ ID
+  // ─────────────────────────────────────────────────────────────
+
+  var STORAGE_KEY = "kw_consent_analytics"; // "granted" | "denied"
+
+  // Brak prawdziwego ID → nic nie robimy (kod gotowy, czeka na ID).
+  if (!MEASUREMENT_ID || MEASUREMENT_ID === "G-XXXXXXXXXX") {
+    console.info(
+      "[analytics] Wklej swój Measurement ID w assets/js/analytics.js, aby włączyć Google Analytics."
+    );
+    return;
+  }
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  window.gtag = gtag;
+
+  var stored = null;
+  try {
+    stored = localStorage.getItem(STORAGE_KEY);
+  } catch (e) {
+    /* localStorage niedostępny (tryb prywatny) — traktujemy jak brak zgody */
+  }
+
+  // Consent Mode v2 — domyślnie wszystko odrzucone (wymóg RODO).
+  gtag("consent", "default", {
+    ad_storage: "denied",
+    ad_user_data: "denied",
+    ad_personalization: "denied",
+    analytics_storage: stored === "granted" ? "granted" : "denied",
+    wait_for_update: 500,
+  });
+
+  // Załaduj oficjalny skrypt gtag.js.
+  var s = document.createElement("script");
+  s.async = true;
+  s.src = "https://www.googletagmanager.com/gtag/js?id=" + encodeURIComponent(MEASUREMENT_ID);
+  document.head.appendChild(s);
+
+  gtag("js", new Date());
+  gtag("config", MEASUREMENT_ID, { anonymize_ip: true });
+
+  // Wybór już zapisany — nie pokazuj banera ponownie.
+  if (stored === "granted" || stored === "denied") return;
+
+  function setConsent(value) {
+    try {
+      localStorage.setItem(STORAGE_KEY, value);
+    } catch (e) {
+      /* ignoruj */
+    }
+    gtag("consent", "update", { analytics_storage: value });
+    var b = document.getElementById("kw-consent");
+    if (b && b.parentNode) b.parentNode.removeChild(b);
+  }
+
+  function buildBanner() {
+    var css =
+      "#kw-consent{position:fixed;left:16px;right:16px;bottom:16px;z-index:2147483000;" +
+      "max-width:560px;margin:0 auto;background:#0f0f12;color:#f5f5f7;" +
+      "border:1px solid rgba(255,255,255,.12);border-radius:14px;padding:16px 18px;" +
+      "box-shadow:0 12px 40px rgba(0,0,0,.35);font-family:inherit;" +
+      "display:flex;flex-direction:column;gap:12px}" +
+      "#kw-consent .kw-consent__text{margin:0;font-size:.9rem;line-height:1.5}" +
+      "#kw-consent a{color:#fff;text-decoration:underline}" +
+      "#kw-consent .kw-consent__actions{display:flex;gap:10px;justify-content:flex-end}" +
+      "#kw-consent .kw-consent__btn{cursor:pointer;border-radius:9px;padding:9px 16px;" +
+      "font-size:.85rem;font-weight:600;border:1px solid transparent;font-family:inherit;line-height:1}" +
+      "#kw-consent .kw-consent__btn--ghost{background:transparent;color:#f5f5f7;border-color:rgba(255,255,255,.28)}" +
+      "#kw-consent .kw-consent__btn--solid{background:var(--primary,#6c5ce7);color:#fff}" +
+      "@media(min-width:560px){#kw-consent{flex-direction:row;align-items:center;justify-content:space-between}" +
+      "#kw-consent .kw-consent__actions{flex-shrink:0}}";
+    var style = document.createElement("style");
+    style.textContent = css;
+    document.head.appendChild(style);
+
+    var wrap = document.createElement("div");
+    wrap.id = "kw-consent";
+    wrap.setAttribute("role", "dialog");
+    wrap.setAttribute("aria-live", "polite");
+    wrap.setAttribute("aria-label", "Zgoda na analityczne pliki cookie");
+    wrap.innerHTML =
+      '<p class="kw-consent__text">Używam Google Analytics, żeby zobaczyć, które strony są odwiedzane. ' +
+      'Zgadzasz się na analityczne pliki cookie? ' +
+      '<a href="/polityka-prywatnosci">Polityka prywatności</a>.</p>' +
+      '<div class="kw-consent__actions">' +
+      '<button type="button" class="kw-consent__btn kw-consent__btn--ghost" id="kw-consent-deny">Odrzuć</button>' +
+      '<button type="button" class="kw-consent__btn kw-consent__btn--solid" id="kw-consent-accept">Akceptuję</button>' +
+      "</div>";
+    document.body.appendChild(wrap);
+
+    document.getElementById("kw-consent-accept").addEventListener("click", function () {
+      setConsent("granted");
+    });
+    document.getElementById("kw-consent-deny").addEventListener("click", function () {
+      setConsent("denied");
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", buildBanner);
+  } else {
+    buildBanner();
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
+  <script src="/assets/js/analytics.js"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Karol Wyszyński – Digital Product Designer | Aplikacje, automatyzacje i strony dla firm</title>

--- a/kontakt.html
+++ b/kontakt.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
+  <script src="/assets/js/analytics.js"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kontakt – Karol Wyszyński | Digital Product Designer</title>

--- a/narzedzie.html
+++ b/narzedzie.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
+  <script src="/assets/js/analytics.js"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>7 sygnałów, że Twój proces nadaje się do automatyzacji – Karol Wyszyński</title>
@@ -20,8 +21,6 @@
     <!-- CSS -->
     <link rel="stylesheet" href="assets/css/index-styles.css" />
 
-    <!-- Cloudflare Web Analytics -->
-    <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "TWOJ_TOKEN"}'></script>
 </head>
 <body>
 

--- a/polityka-prywatnosci.html
+++ b/polityka-prywatnosci.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
+  <script src="/assets/js/analytics.js"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Polityka prywatności – Karol Wyszyński</title>
@@ -22,8 +23,6 @@
     <!-- CSS -->
     <link rel="stylesheet" href="assets/css/index-styles.css" />
 
-    <!-- Cloudflare Web Analytics -->
-    <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "TWOJ_TOKEN"}'></script>
 
     <style>
         .pp-section {
@@ -120,7 +119,7 @@
                     <li><strong>Formularz kontaktowy:</strong> imię, adres e-mail, numer telefonu (opcjonalnie), rodzaj zapytania, opis problemu lub procesu.</li>
                     <li><strong>Lead magnet (checklista PDF):</strong> adres e-mail.</li>
                 </ul>
-                <p>Serwis nie instaluje własnych plików cookie ani nie prowadzi własnego systemu analityki. Pliki cookie mogą być ustawiane przez zewnętrzne usługi wskazane w pkt 4.</p>
+                <p>Serwis korzysta z <strong>Google Analytics 4</strong> (usługa Google LLC) do analizy ruchu. Narzędzie zapisuje pliki cookie i zbiera zanonimizowane dane o odwiedzinach (m.in. odwiedzane podstrony, źródło wejścia, przybliżona lokalizacja, typ urządzenia). Adres IP jest anonimizowany. Analityka uruchamia się <strong>wyłącznie po wyrażeniu zgody</strong> w banerze cookie — do tego czasu żadne analityczne pliki cookie nie są ustawiane. Zgodę możesz w każdej chwili wycofać, czyszcząc pliki cookie w przeglądarce. Pozostałe pliki cookie mogą być ustawiane przez zewnętrzne usługi wskazane w pkt 4.</p>
 
                 <h2>3. W jakim celu dane są przetwarzane</h2>
                 <ul>
@@ -130,6 +129,8 @@
 
                 <h2>4. Gdzie trafiają dane</h2>
                 <p>Dane przesyłane przez formularze trafiają do <strong>Google Apps Script</strong> (usługa Google LLC) i są zapisywane w <strong>Google Sheets</strong>. Google LLC przetwarza dane zgodnie z własną polityką prywatności dostępną na stronie Google. Dane nie są przekazywane innym podmiotom trzecim ani wykorzystywane do celów marketingowych.</p>
+
+                <p>Zanonimizowane dane o ruchu przetwarza <strong>Google Analytics 4</strong> (Google LLC) zgodnie z polityką prywatności Google. Służą wyłącznie do analizy ruchu w serwisie — nie są wykorzystywane do celów marketingowych ani łączone z danymi z formularzy.</p>
 
                 <h2>5. Jak długo dane są przechowywane</h2>
                 <p>Dane kontaktowe są przechowywane przez czas niezbędny do obsłużenia zapytania, nie dłużej niż 12 miesięcy od ostatniego kontaktu. Po tym czasie są usuwane.</p>

--- a/portfolio.html
+++ b/portfolio.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
+  <script src="/assets/js/analytics.js"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portfolio – Karol Wyszyński | Produkty cyfrowe, aplikacje, automatyzacje</title>

--- a/projects/KW-Design.html
+++ b/projects/KW-Design.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
+  <script src="/assets/js/analytics.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/projects/cyfradruk.html
+++ b/projects/cyfradruk.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
+  <script src="/assets/js/analytics.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/projects/karoma.html
+++ b/projects/karoma.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
+  <script src="/assets/js/analytics.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/projects/power-of-mind.html
+++ b/projects/power-of-mind.html
@@ -2,6 +2,7 @@
 <html lang="pl">
 
 <head>
+  <script src="/assets/js/analytics.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -1,6 +1,7 @@
 ﻿<!DOCTYPE html>
 <html lang="pl">
 <head>
+  <script src="/assets/js/analytics.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/projects/sir-roger.html
+++ b/projects/sir-roger.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
+  <script src="/assets/js/analytics.js"></script>
   <!-- Essential Meta Tags -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/projects/voucher-salon-magdy.html
+++ b/projects/voucher-salon-magdy.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
+  <script src="/assets/js/analytics.js"></script>
   <!-- Essential Meta Tags -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/projects/wizualizacje.html
+++ b/projects/wizualizacje.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
+  <script src="/assets/js/analytics.js"></script>
   <!-- Essential Meta Tags -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/uslugi.html
+++ b/uslugi.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
+  <script src="/assets/js/analytics.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Usługi Karola Wyszyńskiego — Digital Product Designer. Projektowanie i wdrażanie produktów cyfrowych, automatyzacje procesów biznesowych, analiza procesów. Każdy projekt wyceniam indywidualnie.">
@@ -62,8 +63,6 @@
   <link rel="stylesheet" href="assets/css/index-styles.css" />
   <link rel="stylesheet" href="assets/css/services-page.css" />
 
-  <!-- Cloudflare Web Analytics -->
-  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "TWOJ_TOKEN"}'></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Co to robi

Dodaje Google Analytics 4 na całej stronie, w sposób zgodny z RODO (baner zgody + Consent Mode v2).

## Zmiany

- **`assets/js/analytics.js`** (nowy) — jeden wspólny plik dla całej strony:
  - GA4 z **Consent Mode v2** (domyślnie wszystko odrzucone),
  - lekki **baner zgody cookie** (bez zewnętrznych bibliotek, styl wstrzykiwany),
  - anonimizacja IP, zapamiętywanie wyboru w `localStorage`,
  - **Measurement ID w jednym miejscu** — przyszłe zmiany = edycja jednego pliku.
- **15 podstron** (root + `projects/`) — dodana jedna linijka `<script src="/assets/js/analytics.js"></script>` w `<head>`.
- **Usunięto martwe wstawki Cloudflare Web Analytics** z 3 podstron (`polityka`, `narzedzie`, `uslugi`) — token był placeholderem `TWOJ_TOKEN`, więc nic nie zbierały. Można wrócić do Cloudflare osobno, jeśli będzie potrzeba.
- **`polityka-prywatnosci.html`** — zaktualizowane pkt 2 i 4: opis użycia GA4, cookies, zgody i anonimizacji (poprzednio polityka mówiła „brak analityki i cookies").

## Wymagane działanie przed wdrożeniem

Analityka jest **wyłączona**, dopóki w `assets/js/analytics.js` (linia z `MEASUREMENT_ID`) nie zostanie wklejony prawdziwy identyfikator z GA4 (`G-XXXXXXXXXX`). Do tego czasu strona działa normalnie, nic się nie ładuje, żaden cookie nie jest ustawiany.

## Uwagi

Do samego oglądania danych wystarczy panel analytics.google.com — API nie jest potrzebne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQbocyHd1t39D6a24zNvUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQbocyHd1t39D6a24zNvUJ)_