### PR TITLE
Przygotowanie repo pod Google Analytics 4

### DIFF
--- a/404.html
+++ b/404.html
@@ -80,6 +80,8 @@
             color: #fff;
         }
     </style>
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body>
     <div class="container">

--- a/README.md
+++ b/README.md
@@ -87,6 +87,29 @@ Zobacz pełny audyt: [`audyt-strony-KW.txt`](./audyt-strony-KW.txt)
 
 ---
 
+## 📊 Google Analytics (pomiar ruchu)
+
+Strona jest przygotowana pod **Google Analytics 4 (GA4)**. Kod pomiarowy jest
+scentralizowany w jednym pliku `assets/js/analytics.js`, dołączanym na każdej
+podstronie — identyfikator zmieniasz więc **tylko w jednym miejscu**.
+
+**Jak włączyć:**
+
+1. Załóż usługę GA4 w [analytics.google.com](https://analytics.google.com)
+   (*Administracja → Utwórz usługę*).
+2. Skopiuj **identyfikator pomiaru** w formacie `G-XXXXXXXXXX`.
+3. Wklej go w `assets/js/analytics.js` w zmiennej `MEASUREMENT_ID`.
+4. `git commit` + `git push` na `main` → auto-deploy (GitHub / Cloudflare Pages).
+
+Dopóki `MEASUREMENT_ID` ma wartość-zaślepkę `G-XXXXXXXXXX`, skrypt jest
+nieaktywny (nie wysyła żadnych żądań). Domeny GA są już dopisane do CSP w
+`_headers`, a IP jest maskowane (`anonymize_ip`) zgodnie z dobrą praktyką RODO.
+
+> ⚠️ Po uruchomieniu pomiaru uzupełnij informację o Google Analytics
+> w `polityka-prywatnosci.html`.
+
+---
+
 ## 👤 Autor
 
 **Karol Wyszyński** – Digital Product Designer  

--- a/_headers
+++ b/_headers
@@ -12,7 +12,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   X-XSS-Protection: 1; mode=block
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://script.google.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://kwyszynski.pl https://kwyszynskidesign.github.io; connect-src 'self' https://script.google.com https://script.googleusercontent.com https://cloudflareinsights.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self' https://script.google.com;
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://script.google.com https://static.cloudflareinsights.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://kwyszynski.pl https://kwyszynskidesign.github.io https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com; connect-src 'self' https://script.google.com https://script.googleusercontent.com https://cloudflareinsights.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self' https://script.google.com;
   Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
 
 ###############################################################################

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -1,0 +1,42 @@
+/**
+ * Google Analytics 4 – centralna konfiguracja
+ * ---------------------------------------------------------------------------
+ * Aby URUCHOMIĆ pomiar ruchu:
+ *   1. Załóż usługę GA4 w https://analytics.google.com (Admin → Utwórz usługę).
+ *   2. Skopiuj identyfikator pomiaru (Measurement ID) w formacie G-XXXXXXXXXX.
+ *   3. Wklej go poniżej w zmiennej MEASUREMENT_ID.
+ *   4. Commit + push → GitHub Pages / Cloudflare Pages zdeployuje automatycznie.
+ *
+ * Ten plik jest dołączany na każdej podstronie przez:
+ *   <script defer src="/assets/js/analytics.js"></script>
+ * dzięki czemu ID zmieniasz TYLKO w jednym miejscu.
+ *
+ * Dopóki MEASUREMENT_ID pozostaje wartością-zaślepką ("G-XXXXXXXXXX"),
+ * skrypt nic nie robi (żadne żądania nie są wysyłane).
+ */
+(function () {
+  'use strict';
+
+  var MEASUREMENT_ID = 'G-XXXXXXXXXX'; // ← wklej tutaj swój identyfikator GA4
+
+  // Nie uruchamiaj, dopóki nie wpisano prawdziwego ID.
+  if (!MEASUREMENT_ID || MEASUREMENT_ID === 'G-XXXXXXXXXX') {
+    return;
+  }
+
+  // Wczytaj bibliotekę gtag.js.
+  var s = document.createElement('script');
+  s.async = true;
+  s.src = 'https://www.googletagmanager.com/gtag/js?id=' + encodeURIComponent(MEASUREMENT_ID);
+  document.head.appendChild(s);
+
+  // Inicjalizacja gtag.
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { window.dataLayer.push(arguments); }
+  window.gtag = gtag;
+
+  gtag('js', new Date());
+  gtag('config', MEASUREMENT_ID, {
+    anonymize_ip: true // maskowanie adresu IP (dobra praktyka RODO)
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -75,6 +75,8 @@
     <link rel="stylesheet" href="assets/css/kw-buttons.css" />
 
 
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 
 <body>

--- a/kontakt.html
+++ b/kontakt.html
@@ -43,6 +43,8 @@
 
     <!-- Main CSS -->
     <link rel="stylesheet" href="assets/css/style.css" />
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body>
     <header>

--- a/narzedzie.html
+++ b/narzedzie.html
@@ -22,6 +22,8 @@
 
     <!-- Cloudflare Web Analytics -->
     <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "TWOJ_TOKEN"}'></script>
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body>
 

--- a/polityka-prywatnosci.html
+++ b/polityka-prywatnosci.html
@@ -79,6 +79,8 @@
             margin: 0;
         }
     </style>
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body>
 

--- a/portfolio.html
+++ b/portfolio.html
@@ -63,6 +63,8 @@
          żeby aliasy .kw-btn wygrywały w kaskadzie. -->
     <link rel="stylesheet" href="assets/css/kw-buttons.css" />
 
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body class="portfolio-page">
 

--- a/projects/KW-Design.html
+++ b/projects/KW-Design.html
@@ -49,6 +49,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body>
 

--- a/projects/cyfradruk.html
+++ b/projects/cyfradruk.html
@@ -54,6 +54,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 
 <body>

--- a/projects/karoma.html
+++ b/projects/karoma.html
@@ -56,6 +56,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 
 <body>

--- a/projects/power-of-mind.html
+++ b/projects/power-of-mind.html
@@ -56,6 +56,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 
 <body>

--- a/projects/razdwa_aplikacja.html
+++ b/projects/razdwa_aplikacja.html
@@ -53,6 +53,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 
 <body>

--- a/projects/sir-roger.html
+++ b/projects/sir-roger.html
@@ -63,6 +63,8 @@
   <!-- Preconnect for Performance -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 
 <body>

--- a/projects/voucher-salon-magdy.html
+++ b/projects/voucher-salon-magdy.html
@@ -65,6 +65,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <!-- Montserrat — realny krój vouchera (koncepcja B), używany w sekcji „System UI” -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600;700&display=swap">
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 
 <body>

--- a/projects/wizualizacje.html
+++ b/projects/wizualizacje.html
@@ -49,6 +49,8 @@
   <link rel="stylesheet" href="/assets/css/kw-buttons.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body>
 

--- a/uslugi.html
+++ b/uslugi.html
@@ -64,6 +64,8 @@
 
   <!-- Cloudflare Web Analytics -->
   <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "TWOJ_TOKEN"}'></script>
+    <!-- Google Analytics 4 (identyfikator w /assets/js/analytics.js) -->
+    <script defer src="/assets/js/analytics.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Co robi ten PR

Przygotowuje statyczną stronę pod pomiar ruchu w **Google Analytics 4 (GA4)**. Pomiar jest gotowy do uruchomienia po wklejeniu jednego identyfikatora — nie ma jeszcze aktywnego trackowania w tym PR (celowo).

## Zmiany

- **`assets/js/analytics.js`** (nowy) — centralny snippet GA4:
  - identyfikator pomiaru trzymany w jednej zmiennej `MEASUREMENT_ID`,
  - ładuje `gtag.js` i inicjalizuje GA4 z `anonymize_ip` (dobra praktyka RODO),
  - dopóki `MEASUREMENT_ID` = zaślepka `G-XXXXXXXXXX`, skrypt jest **nieaktywny** i nie wysyła żadnych żądań.
- **15 podstron HTML** — dołączenie `<script defer src="/assets/js/analytics.js"></script>` przed `</head>` (ścieżka absolutna działa też z `projects/`).
- **`_headers`** — rozszerzenie CSP o domeny `www.googletagmanager.com` oraz `*.google-analytics.com` / `*.analytics.google.com` (`script-src`, `img-src`, `connect-src`), żeby przeglądarka nie blokowała GA.
- **`README.md`** — instrukcja włączenia pomiaru (4 kroki) + przypomnienie o aktualizacji polityki prywatności.

## Jak włączyć pomiar

1. Załóż usługę GA4 → skopiuj identyfikator `G-XXXXXXXXXX`.
2. Wklej go w `assets/js/analytics.js` (zmienna `MEASUREMENT_ID`).
3. Commit + push na `main` → auto-deploy.

> Po uruchomieniu warto uzupełnić informację o Google Analytics w `polityka-prywatnosci.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVVXXZrk2Q2RynMTxVKyeX)_