### PR TITLE
Portfolio hero: granatowy backdrop pod przezroczystą wycinką zdjęcia

### DIFF
--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -350,6 +350,9 @@ body.portfolio-page .hero-section{background-image:url('../images/ja-biznesowy-v
   border-radius:28px;
   overflow:hidden;
   position:relative;
+  /* Granatowy backdrop pod przezroczystą wycinką postaci (zdjęcie hero jest PNG
+     bez tła) — spójny ze studyjnym podglądem i ciemnym headerem strony. */
+  background:radial-gradient(75% 65% at 50% 32%,#43617e 0%,#33495f 55%,#253749 100%);
   filter:
     drop-shadow(0 20px 45px rgba(0,0,0,0.15))
     drop-shadow(0 12px 28px rgba(0,0,0,0.1))


### PR DESCRIPTION
## Problem
Zdjęcie hero w portfolio to PNG **bez tła** (przezroczysta wycinka). Renderowało się na jasnym tle sekcji, przez co wyglądało „jak stare zdjęcie” i nie zgadzało się z granatowym podglądem właściciela.

## Zmiana
Dodany radialny granatowy (slate-blue) backdrop w regule `.about-me-image` (`assets/css/portfolio.css`) — postać ląduje na studyjnym granatowym tle, spójnie z ciemnym headerem strony. Jedna reguła CSS, +3 linie, bez zmian w layoucie/HTML.

## Weryfikacja
Wyrenderowane headless Chromium (1440px): zdjęcie na granatowym tle w ramce hero, zgodne z podglądem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPHRU1bNyh8bnjkyXQn89H

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPHRU1bNyh8bnjkyXQn89H)_