### PR TITLE
Revert granatowego backdropu w hero portfolio (wycinka na jasnym tle)

### DIFF
--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -350,9 +350,6 @@ body.portfolio-page .hero-section{background-image:url('../images/ja-biznesowy-v
   border-radius:28px;
   overflow:hidden;
   position:relative;
-  /* Granatowy backdrop pod przezroczystą wycinką postaci (zdjęcie hero jest PNG
-     bez tła) — spójny ze studyjnym podglądem i ciemnym headerem strony. */
-  background:radial-gradient(75% 65% at 50% 32%,#43617e 0%,#33495f 55%,#253749 100%);
   filter:
     drop-shadow(0 20px 45px rgba(0,0,0,0.15))
     drop-shadow(0 12px 28px rgba(0,0,0,0.1))


### PR DESCRIPTION
Na życzenie właściciela: zostaje przezroczysta wycinka zdjęcia hero, ale **bez** dodanego wcześniej granatowego tła — powrót do stanu sprzed poprzedniej zmiany (wycinka na jasnym tle sekcji).

Usunięta jedna reguła `background` z `.about-me-image` w `assets/css/portfolio.css`. Plik zdjęcia bez zmian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPHRU1bNyh8bnjkyXQn89H

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPHRU1bNyh8bnjkyXQn89H)_