### PR TITLE
Portfolio hero: delikatniejszy cień zdjęcia (rogi bez zmian)

### DIFF
--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -350,10 +350,8 @@ body.portfolio-page .hero-section{background-image:url('../images/ja-biznesowy-v
   border-radius:28px;
   overflow:hidden;
   position:relative;
-  filter:
-    drop-shadow(0 20px 45px rgba(0,0,0,0.15))
-    drop-shadow(0 12px 28px rgba(0,0,0,0.1))
-    drop-shadow(0 6px 12px rgba(0,0,0,0.08));
+  /* Delikatny, miękki cień (wariant 3) zamiast poprzedniego mocnego potrójnego. */
+  filter:drop-shadow(0 14px 28px rgba(30,41,59,0.14));
   transition:none;
 }
 


### PR DESCRIPTION
Na życzenie właściciela: zostają duże zaokrąglone rogi (28px), a mocny potrójny drop-shadow zdjęcia hero zamieniony na jeden **miękki, delikatny cień** (`0 14px 28px rgba(30,41,59,.14)`). Jedna zmiana w `.about-me-image` (`assets/css/portfolio.css`).

Zweryfikowane renderem (1440px): cień subtelny, ramka nadal zaokrąglona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPHRU1bNyh8bnjkyXQn89H

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPHRU1bNyh8bnjkyXQn89H)_