### PR TITLE
Portfolio hero: hover swap zdjęcia na wersję z uśmiechem

### DIFF
--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -380,6 +380,24 @@ body.portfolio-page .hero-section{background-image:url('../images/ja-biznesowy-v
     drop-shadow(0 9px 12px rgba(15,23,42,0.40));
 }
 
+/* Hover: zdjęcie z uśmiechem nakłada się na wersję bazową i płynnie pojawia
+   przy najechaniu. Dziedziczy efekt sylwetki z reguły .about-me-image img. */
+.about-me-image .ami-hover{
+  position:absolute;
+  inset:0;
+  z-index:1;
+  opacity:0;
+  transition:opacity .35s ease;
+}
+.about-me-image:hover .ami-hover,
+.about-me-image:focus-within .ami-hover{
+  opacity:1;
+}
+@media (hover:none){
+  /* Na dotyku brak hovera — nie rezerwujemy zachowania, zostaje wersja bazowa. */
+  .about-me-image .ami-hover{display:none;}
+}
+
 /* === PREMIUM CTA BUTTON === */
 .cta-portfolio{
   grid-area:cta;

--- a/portfolio.html
+++ b/portfolio.html
@@ -111,7 +111,8 @@
             <!-- VISUALS -->
             <div class="about-me-visuals">
                 <div class="about-me-image">
-                    <img src="assets/images/ja biznesowyv2 30.07.2026_bez tła.png" alt="Karol Wyszyński - Digital Product Designer">  
+                    <img class="ami-base" src="assets/images/ja biznesowyv2 30.07.2026_bez tła.png" alt="Karol Wyszyński - Digital Product Designer">
+                    <img class="ami-hover" src="assets/images/ja biznesowyv2 30.07.2026_bez tła_smile.webp" alt="" aria-hidden="true" loading="lazy" decoding="async">
                 </div>
             </div>
 


### PR DESCRIPTION
Na życzenie właściciela: po najechaniu na zdjęcie hero w portfolio pojawia się wersja z uśmiechem.

## Zmiana
- `portfolio.html` — w `.about-me-image` drugie `<img class="ami-hover">` (przezroczysty webp bez tła, uśmiech), obok bazowego.
- `assets/css/portfolio.css` — hover: `.ami-hover` nałożony na bazę (`position:absolute; inset:0`), `opacity 0 → 1` z płynnym crossfade przy `:hover`/`:focus-within`; na `hover:none` (dotyk) ukryty. Dziedziczy istniejący efekt sylwetki (biały obrys + cień) z reguły `.about-me-image img`.

Pliki `..._smile.png/.webp` wgrał właściciel; użyty lżejszy `.webp` (alpha).

## Weryfikacja
Render stanu normalnego i hover (1440px) — oba pokrywają się kadrem, ten sam efekt sylwetki, płynne przejście.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPHRU1bNyh8bnjkyXQn89H

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPHRU1bNyh8bnjkyXQn89H)_